### PR TITLE
Removing graph log declaration from munin_stats plugin

### DIFF
--- a/plugins/node.d/munin_stats.in
+++ b/plugins/node.d/munin_stats.in
@@ -28,7 +28,7 @@ use warnings;
 
 use Munin::Plugin;
 
-my @logs = qw/update graph html limits/;
+my @logs = qw/update html limits/;
 my $logdir = ($ENV{'logdir'} || $ENV{'MUNIN_LOGDIR'} || '@@LOGDIR@@');
 
 if ($ARGV[0] and $ARGV[0] eq 'autoconf') {


### PR DESCRIPTION
Munin 2.0.0 introduced CGI only graphing, so this log is no longer created / available to parse.
