### PR TITLE
ipmi_: improve autoconf handling, and move to generic node.d directory.

### DIFF
--- a/plugins/node.d/ipmi_.in
+++ b/plugins/node.d/ipmi_.in
@@ -45,10 +45,12 @@ CONFIG=no
 
 case $1 in
     autoconf)
-        ! test -x /usr/bin/ipmitool && 
-	  echo 'no (no /usr/bin/ipmitool)' && exit 0
-	! (/sbin/lsmod | grep -q ipmi) &&
-	  echo 'no (impi module not loaded' && exit 0
+	type -p ipmitool &>/dev/null ||
+	  { echo 'no (missing ipmitool command)' && exit 0; }
+	
+	ipmitool sensor &>/dev/null || 
+	  { echo 'no (unable to access IPMI device)' && exit 0; }
+
 	echo yes
         exit 0
 	;;


### PR DESCRIPTION
First of all the ipmitool command might not be in /usr/bin (in Gentoo
it's in /usr/sbin); second of all instead of checking whether the ipmi
driver is loaded (and then fail if the ipmi device is unavailable to
the munin user), check whether ipmitool is able to fetch the sensors.

The ipmitool command supposedly works with Linux, Solaris 10 and
FreeBSD.
