### PR TITLE
Don't exclude simfs per default.

### DIFF
--- a/plugins/node.d.linux/df.in
+++ b/plugins/node.d.linux/df.in
@@ -14,7 +14,7 @@ Every Linux system with df installed.
 The plugin excludes per default the following special, read-only or
 dynamically allocating file systems from graphing:
 
-  none unknown rootfs iso9660 squashfs udf romfs ramfs debugfs simfs
+  none unknown rootfs iso9660 squashfs udf romfs ramfs debugfs
 
 To change this set the environment variable "exclude" with a list of
 space separated fs types.  The environment variables "warning" and
@@ -24,7 +24,7 @@ the disk usage.
 This configuration snipplet is an example with the defaults:
 
   [df]
-    env.exclude none unknown rootfs iso9660 squashfs udf romfs ramfs debugfs simfs
+    env.exclude none unknown rootfs iso9660 squashfs udf romfs ramfs debugfs
     env.warning 92
     env.critical 98
 
@@ -85,9 +85,9 @@ use strict;
 use Munin::Plugin;
 
 # For these devices use the mount point, the device is useless
-my %usemntpt = ( tmpfs => 1, none => 1, udev => 1 );
+my %usemntpt = ( tmpfs => 1, none => 1, udev => 1, simfs => 1 );
 
-my $exclude = $ENV{'exclude'} || 'none unknown rootfs iso9660 squashfs udf romfs ramfs debugfs simfs cgroup_root';
+my $exclude = $ENV{'exclude'} || 'none unknown rootfs iso9660 squashfs udf romfs ramfs debugfs cgroup_root';
 my $dfopts  = "-P -l ".join(' -x ',('',split('\s+',$exclude)));
 
 my $mode = ($ARGV[0] or "print");

--- a/plugins/node.d.linux/df_inode.in
+++ b/plugins/node.d.linux/df_inode.in
@@ -14,7 +14,7 @@ Every Linux system with df installed.
 The plugin excludes per default the following special, read-only or
 dynamically allocating file systems from graphing:
 
-  none unknown iso9660 squashfs udf romfs ramfs vfat debugfs simfs nilfs2 rootfs
+  none unknown iso9660 squashfs udf romfs ramfs vfat debugfs nilfs2 rootfs
 
 To change this set the environment variable "exclude" with a list of
 space separated fs types.  The environment variables "warning" and
@@ -24,7 +24,7 @@ the disk usage.
 This configuration snipplet is an example with the defaults:
 
   [df_inode]
-    env.exclude none unknown iso9660 squashfs udf romfs ramfs vfat debugfs simfs nilfs2 rootfs
+    env.exclude none unknown iso9660 squashfs udf romfs ramfs vfat debugfs nilfs2 rootfs
     env.warning 92
     env.critical 98
 
@@ -85,9 +85,9 @@ use strict;
 use Munin::Plugin;
 
 # For these devices use the mount point, the device is useless
-my %usemntpt = ( tmpfs => 1, none => 1, udev => 1 );
+my %usemntpt = ( tmpfs => 1, none => 1, udev => 1, simfs => 1 );
 
-my $exclude = $ENV{'exclude'} || 'none unknown iso9660 squashfs udf romfs ramfs vfat debugfs simfs nilfs2 rootfs reiserfs';
+my $exclude = $ENV{'exclude'} || 'none unknown iso9660 squashfs udf romfs ramfs vfat debugfs nilfs2 rootfs reiserfs';
 my $dfopts  = "-P -l -i ".join(' -x ',('',split('\s+',$exclude)));
 
 my $mode = ($ARGV[0] or "print");


### PR DESCRIPTION
This was added in commit e86f958deb without further explanation.  OpenVZ
uses a filesystem type of simfs for all the mounts so this makes munin
more or less useless on OpenVZ guests.  The device name is useless though.

Typical example:

Filesystem         1024-blocks      Used Available Capacity Mounted on
/dev/simfs           398458880  91795132 306663748      24% /
varrun                 2097152        28   2097124       1% /var/run
varlock                2097152         0   2097152       0% /var/lock
/dev/simfs           330279532  15616532 297885784       5% /opt/zimbra/backup
