### PR TITLE
Fix different links in templates (due to sub-groups)

### DIFF
--- a/master/lib/Munin/Master/HTMLConfig.pm
+++ b/master/lib/Munin/Master/HTMLConfig.pm
@@ -320,6 +320,7 @@ sub generate_compare_groups {
         foreach my $tmpserv (@{$tmpcat->{'services'}}) {
           $comparecatshash->{$tmpcat->{'name'}}->{'services'}->{$tmpserv->{'name'}}->{'nodes'}->{$tmpgroup->{'name'}} = $tmpserv;
           $comparecatshash->{$tmpcat->{'name'}}->{'services'}->{$tmpserv->{'name'}}->{'nodes'}->{$tmpgroup->{'name'}}->{'nodename'} = $tmpgroup->{'name'};
+          $comparecatshash->{$tmpcat->{'name'}}->{'services'}->{$tmpserv->{'name'}}->{'nodes'}->{$tmpgroup->{'name'}}->{'nodeurl'} = $tmpgroup->{'url'};
         }
       }
     }

--- a/master/www/munin-comparison-day.tmpl
+++ b/master/www/munin-comparison-day.tmpl
@@ -15,13 +15,13 @@
 		<span class="nodetitle"><a href="<TMPL_VAR ESCAPE="URL" NAME="NODENAME">/index.html">
 			<TMPL_VAR ESCAPE="HTML" NAME="NODENAME"></a> :: <TMPL_IF NAME="URL1">
 				<a <TMPL_IF NAME="STATE_WARNING">class="warn"</TMPL_IF>
-				 <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="URL1">">
+				 <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="R_PATH">/<TMPL_VAR NAME="URL">">
 				</TMPL_IF>
 				<TMPL_VAR ESCAPE="HTML" NAME="LABEL">
 				<TMPL_IF NAME="URL1"></a></TMPL_IF>
 		</span><br />
 		<TMPL_IF NAME="CIMGDAY">
-			<a href="<TMPL_VAR NAME="URL1">">
+			<a href="<TMPL_VAR NAME="R_PATH">/<TMPL_VAR NAME="URL">">
 				<img src="<TMPL_VAR NAME="CIMGDAY">" alt="<TMPL_VAR ESCAPE="HTML" NAME="LABEL">"
 				class="i<TMPL_IF NAME="STATE_WARNING">warn</TMPL_IF><TMPL_IF NAME="STATE_CRITICAL">crit</TMPL_IF>"
 				 <TMPL_IF NAME="IMGDAYWIDTH">width="<TMPL_VAR NAME="IMGDAYWIDTH">" </TMPL_IF> 

--- a/master/www/munin-comparison-month.tmpl
+++ b/master/www/munin-comparison-month.tmpl
@@ -15,13 +15,13 @@
 		<span class="nodetitle"><a href="<TMPL_VAR ESCAPE="URL" NAME="NODENAME">/index.html">
 			<TMPL_VAR ESCAPE="HTML" NAME="NODENAME"></a> :: <TMPL_IF NAME="URL1">
 				<a <TMPL_IF NAME="STATE_WARNING">class="warn"</TMPL_IF>
-				 <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="URL1">">
+				 <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="R_PATH">/<TMPL_VAR NAME="URL">">
 				</TMPL_IF>
 				<TMPL_VAR ESCAPE="HTML" NAME="LABEL">
 				<TMPL_IF NAME="URL1"></a></TMPL_IF>
 		</span><br />
 		<TMPL_IF NAME="CIMGMONTH">
-			<a href="<TMPL_VAR NAME="URL1">">
+			<a href="<TMPL_VAR NAME="R_PATH">/<TMPL_VAR NAME="URL">">
 				<img src="<TMPL_VAR NAME="CIMGMONTH">" alt="<TMPL_VAR ESCAPE="HTML" NAME="LABEL">"
 				 class="i<TMPL_IF NAME="STATE_WARNING">warn</TMPL_IF><TMPL_IF NAME="STATE_CRITICAL">crit</TMPL_IF>"
 				 <TMPL_IF NAME="IMGMONTHWIDTH">width="<TMPL_VAR NAME="IMGMONTHWIDTH">" </TMPL_IF> 

--- a/master/www/munin-comparison-week.tmpl
+++ b/master/www/munin-comparison-week.tmpl
@@ -15,13 +15,13 @@
 		<span class="nodetitle"><a href="<TMPL_VAR ESCAPE="URL" NAME="NODENAME">/index.html">
 			<TMPL_VAR ESCAPE="HTML" NAME="NODENAME"></a> :: <TMPL_IF NAME="URL1">
 				<a <TMPL_IF NAME="STATE_WARNING">class="warn"</TMPL_IF>
-				 <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="URL1">">
+				 <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="R_PATH">/<TMPL_VAR NAME="URL">">
 				</TMPL_IF>
 				<TMPL_VAR ESCAPE="HTML" NAME="LABEL">
 				<TMPL_IF NAME="URL1"></a></TMPL_IF>
 		</span><br />
 		<TMPL_IF NAME="CIMGWEEK">
-			<a href="<TMPL_VAR NAME="URL1">">
+			<a href="<TMPL_VAR NAME="R_PATH">/<TMPL_VAR NAME="URL">">
 				<img src="<TMPL_VAR NAME="CIMGWEEK">" alt="<TMPL_VAR ESCAPE="HTML" NAME="LABEL">" 
 				class="i<TMPL_IF NAME="STATE_WARNING">warn</TMPL_IF><TMPL_IF NAME="STATE_CRITICAL">crit</TMPL_IF>"
 				 <TMPL_IF NAME="IMGDAYWIDTH">width="<TMPL_VAR NAME="IMGWEEKWIDTH">" </TMPL_IF> 

--- a/master/www/munin-comparison-year.tmpl
+++ b/master/www/munin-comparison-year.tmpl
@@ -15,13 +15,13 @@
 		<span class="nodetitle"><a href="<TMPL_VAR ESCAPE="URL" NAME="NODENAME">/index.html">
 			<TMPL_VAR ESCAPE="HTML" NAME="NODENAME"></a> :: <TMPL_IF NAME="URL1">
 				<a <TMPL_IF NAME="STATE_WARNING">class="warn"</TMPL_IF>
-				 <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="URL1">">
+				 <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="R_PATH">/<TMPL_VAR NAME="URL">">
 				</TMPL_IF>
 				<TMPL_VAR ESCAPE="HTML" NAME="LABEL">
 				<TMPL_IF NAME="URL1"></a></TMPL_IF>
 		</span><br />
 		<TMPL_IF NAME="CIMGDAY">
-			<a href="<TMPL_VAR NAME="URL1">">
+			<a href="<TMPL_VAR NAME="R_PATH">/<TMPL_VAR NAME="URL">">
 				<img src="<TMPL_VAR NAME="CIMGYEAR">" alt="<TMPL_VAR ESCAPE="HTML" NAME="LABEL">" 
 				 class="i<TMPL_IF NAME="STATE_WARNING">warn</TMPL_IF><TMPL_IF NAME="STATE_CRITICAL">crit</TMPL_IF>"
 				 <TMPL_IF NAME="IMGYEARWIDTH">width="<TMPL_VAR NAME="IMGYEARWIDTH">" </TMPL_IF> 

--- a/master/www/munin-overview.tmpl
+++ b/master/www/munin-overview.tmpl
@@ -12,10 +12,10 @@
 		<li <TMPL_IF NAME="__LAST__">class="last"</TMPL_IF>>
 		<TMPL_IF NAME="NCATEGORIES"><span class="host"><TMPL_ELSE><span class="domain"></TMPL_IF><a href="<TMPL_VAR NAME="URL">"><TMPL_VAR ESCAPE="HTML" NAME="NAME"></a></span>
 		<TMPL_IF NAME="COMPARE"> :: [ 
-          <a href="<TMPL_VAR NAME="NAME">/comparison-day.html">day</a> 
-          <a href="<TMPL_VAR NAME="NAME">/comparison-week.html">week</a> 
-          <a href="<TMPL_VAR NAME="NAME">/comparison-month.html">month</a> 
-          <a href="<TMPL_VAR NAME="NAME">/comparison-year.html">year</a>&nbsp;]</TMPL_IF>
+          <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-day.html">day</a> 
+          <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-week.html">week</a> 
+          <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-month.html">month</a> 
+          <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-year.html">year</a>&nbsp;]</TMPL_IF>
         <TMPL_IF NAME="NCATEGORIES">[ <TMPL_LOOP NAME="CATEGORIES">
           <a <TMPL_IF NAME="STATE_WARNING">class="warn"</TMPL_IF> <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="URL">"><TMPL_VAR ESCAPE="HTML" NAME="NAME"></a></TMPL_LOOP>&nbsp]</TMPL_IF>
 		<ul>
@@ -23,10 +23,10 @@
 			<li <TMPL_IF NAME="__LAST__">class="last"</TMPL_IF>>
 			<TMPL_IF NAME="NCATEGORIES"><span class="host"><TMPL_ELSE><span class="domain"></TMPL_IF><a href="<TMPL_VAR NAME="URL">"><TMPL_VAR ESCAPE="HTML" NAME="NAME"></a></span>
 			<TMPL_IF NAME="COMPARE"> :: [ 
-	          <a href="<TMPL_VAR NAME="NAME">/comparison-day.html">day</a> 
-        	  <a href="<TMPL_VAR NAME="NAME">/comparison-week.html">week</a> 
-    	      <a href="<TMPL_VAR NAME="NAME">/comparison-month.html">month</a> 
-	          <a href="<TMPL_VAR NAME="NAME">/comparison-year.html">year</a>&nbsp;]</TMPL_IF>
+	          <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-day.html">day</a> 
+        	  <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-week.html">week</a> 
+    	      <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-month.html">month</a> 
+	          <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-year.html">year</a>&nbsp;]</TMPL_IF>
     	    <TMPL_IF NAME="NCATEGORIES">[ <TMPL_LOOP NAME="CATEGORIES">
 	          <a <TMPL_IF NAME="STATE_WARNING">class="warn"</TMPL_IF> <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="URL">"><TMPL_VAR ESCAPE="HTML" NAME="NAME"></a>&nbsp;</TMPL_LOOP>]</TMPL_IF>
 			<ul>
@@ -34,10 +34,10 @@
 				<li <TMPL_IF NAME="__LAST__">class="last"</TMPL_IF>>
 				<TMPL_IF NAME="NCATEGORIES"><span class="host"><TMPL_ELSE><span class="domain"></TMPL_IF><a href="<TMPL_VAR NAME="URL">"><TMPL_VAR ESCAPE="HTML" NAME="NAME"></a></span>
 				<TMPL_IF NAME="COMPARE"> :: [ 
-		          <a href="<TMPL_VAR NAME="NAME">/comparison-day.html">day</a> 
-       			  <a href="<TMPL_VAR NAME="NAME">/comparison-week.html">week</a> 
-	    	      <a href="<TMPL_VAR NAME="NAME">/comparison-month.html">month</a> 
-       			  <a href="<TMPL_VAR NAME="NAME">/comparison-year.html">year</a>&nbsp;]</TMPL_IF>
+		          <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-day.html">day</a> 
+       			  <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-week.html">week</a> 
+	    	      <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-month.html">month</a> 
+       			  <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-year.html">year</a>&nbsp;]</TMPL_IF>
 	        	<TMPL_IF NAME="NCATEGORIES">[ <TMPL_LOOP NAME="CATEGORIES">
   	        	  <a <TMPL_IF NAME="STATE_WARNING">class="warn"</TMPL_IF> <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="URL">"><TMPL_VAR ESCAPE="HTML" NAME="NAME"></a>&nbsp;</TMPL_LOOP>]</TMPL_IF>
 				<ul>
@@ -45,10 +45,10 @@
 					<li <TMPL_IF NAME="__LAST__">class="last"</TMPL_IF>>
 					<TMPL_IF NAME="NCATEGORIES"><span class="host"><TMPL_ELSE><span class="domain"></TMPL_IF><a href="<TMPL_VAR NAME="URL">"><TMPL_VAR ESCAPE="HTML" NAME="NAME"></a></span>
 					<TMPL_IF NAME="COMPARE"> :: [ 
-			          <a href="<TMPL_VAR NAME="NAME">/comparison-day.html">day</a> 
-			          <a href="<TMPL_VAR NAME="NAME">/comparison-week.html">week</a> 
-			          <a href="<TMPL_VAR NAME="NAME">/comparison-month.html">month</a> 
-			          <a href="<TMPL_VAR NAME="NAME">/comparison-year.html">year</a>&nbsp;]</TMPL_IF>
+			          <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-day.html">day</a> 
+			          <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-week.html">week</a> 
+			          <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-month.html">month</a> 
+			          <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-year.html">year</a>&nbsp;]</TMPL_IF>
 			        <TMPL_IF NAME="NCATEGORIES">[ <TMPL_LOOP NAME="CATEGORIES">
 			          <a <TMPL_IF NAME="STATE_WARNING">class="warn"</TMPL_IF> <TMPL_IF NAME="STATE_CRITICAL">class="crit"</TMPL_IF> href="<TMPL_VAR NAME="URL">"><TMPL_VAR ESCAPE="HTML" NAME="NAME"></a></TMPL_LOOP>&nbsp;]</TMPL_IF>
 				</TMPL_UNLESS></TMPL_LOOP>

--- a/master/www/munin-problemview.tmpl
+++ b/master/www/munin-problemview.tmpl
@@ -13,7 +13,7 @@
 		<td>
 		<div class="node">
 		<span class="nodetitle">
-			<a href="<TMPL_VAR ESCAPE="URL" NAME="NODENAME">/index.html">
+			<a href="<TMPL_VAR NAME="NODEURL">">
 			<TMPL_VAR ESCAPE="HTML" NAME="NODENAME"></a> 
 			:: <TMPL_IF NAME="URL"><a href="<TMPL_VAR NAME="URL">"></TMPL_IF>
 				<TMPL_VAR ESCAPE="HTML" NAME="LABEL">
@@ -30,7 +30,7 @@
 		<td>
 		<div class="node">
 		<span class="nodetitle">
-			<a href="<TMPL_VAR ESCAPE="URL" NAME="NODENAME">/index.html">
+			<a href="<TMPL_VAR NAME="NODEURL">">
 			<TMPL_VAR ESCAPE="HTML" NAME="NODENAME"></a> 
 			:: <TMPL_IF NAME="URL"><a href="<TMPL_VAR NAME="URLX">"></TMPL_IF>
 				<TMPL_VAR ESCAPE="HTML" NAME="LABEL">
@@ -56,7 +56,7 @@
 		<td>
 		<div class="node">
 		<span class="nodetitle">
-			<a href="<TMPL_VAR ESCAPE="URL" NAME="NODENAME">/index.html">
+			<a href="<TMPL_VAR NAME="NODEURL">">
 			<TMPL_VAR ESCAPE="HTML" NAME="NODENAME"></a> 
 			:: <TMPL_IF NAME="URL"><a href="<TMPL_VAR NAME="URL">"></TMPL_IF>
 				<TMPL_VAR ESCAPE="HTML" NAME="LABEL">
@@ -73,7 +73,7 @@
 		<td>
 		<div class="node">
 		<span class="nodetitle">
-			<a href="<TMPL_VAR ESCAPE="URL" NAME="NODENAME">/index.html">
+			<a href="<TMPL_VAR NAME="NODEURL">">
 			<TMPL_VAR ESCAPE="HTML" NAME="NODENAME"></a> 
 			:: <TMPL_IF NAME="URL"><a href="<TMPL_VAR NAME="URLX">"></TMPL_IF>
 				<TMPL_VAR ESCAPE="HTML" NAME="LABEL">
@@ -99,7 +99,7 @@
 		<td>
 		<div class="node">
 		<span class="nodetitle">
-			<a href="<TMPL_VAR ESCAPE="URL" NAME="NODENAME">/index.html">
+			<a href="<TMPL_VAR NAME="NODEURL">">
 			<TMPL_VAR ESCAPE="HTML" NAME="NODENAME"></a> 
 			:: <TMPL_IF NAME="URL"><a href="<TMPL_VAR NAME="URL">"></TMPL_IF>
 				<TMPL_VAR ESCAPE="HTML" NAME="LABEL">
@@ -116,7 +116,7 @@
 		<td>
 		<div class="node">
 		<span class="nodetitle">
-			<a href="<TMPL_VAR ESCAPE="URL" NAME="NODENAME">/index.html">
+			<a href="<TMPL_VAR NAME="NODEURL">">
 			<TMPL_VAR ESCAPE="HTML" NAME="NODENAME"></a> 
 			:: <TMPL_IF NAME="URL"><a href="<TMPL_VAR NAME="URLX">"></TMPL_IF>
 				<TMPL_VAR ESCAPE="HTML" NAME="LABEL">

--- a/master/www/munin-serviceview.tmpl
+++ b/master/www/munin-serviceview.tmpl
@@ -73,7 +73,7 @@ This service is in CRITICAL state because one of the values reported is outside 
 <tr>
 	<th class="field">Field</th>
 	<th class="internal"><span title="For use in munin.conf">Internal name</span></th>
-	<th class="type"><a href="../../static/definitions.html#data_types">Type</a></th>
+	<th class="type"><a href="<TMPL_VAR ESCAPE="URL" NAME="R_PATH">/static/definitions.html#data_types">Type</a></th>
 	<th class="warn">Warn</th>
 	<th class="crit">Crit</th>
 	<th class="info">Info</th>

--- a/master/www/partial/bottom_navigation.tmpl
+++ b/master/www/partial/bottom_navigation.tmpl
@@ -28,6 +28,6 @@
       </TMPL_LOOP>
       </select>
       <TMPL_ELSE>
-        :<TMPL_LOOP NAME="PEERS">: <TMPL_IF NAME="LINK"><a href="<TMPL_VAR NAME="LINK">"></TMPL_IF><TMPL_VAR NAME="PATHNAME"><TMPL_IF NAME="LINK"></a></TMPL_IF> </TMPL_LOOP>
+        :<TMPL_LOOP NAME="PEERS">: <TMPL_IF NAME="LINK"><a href="<TMPL_VAR NAME="LINK">"></TMPL_IF><TMPL_VAR NAME="NAME"><TMPL_IF NAME="LINK"></a></TMPL_IF> </TMPL_LOOP>
   </TMPL_IF>
              

--- a/master/www/partial/logo_navigation_comparison.tmpl
+++ b/master/www/partial/logo_navigation_comparison.tmpl
@@ -1,9 +1,9 @@
 <div id="header">
 	<h1><a href="<TMPL_VAR NAME="R_PATH">"><span class="logo"></span></a><span class="currentpage">
 	<TMPL_LOOP NAME="PATH">
-		<TMPL_IF NAME="NAME"> :: 
+		<TMPL_IF NAME="PATHNAME"> :: 
 			<TMPL_IF NAME="PATH"><a href="<TMPL_VAR NAME="PATH">"></TMPL_IF>
-				<TMPL_VAR NAME="NAME">
+				<TMPL_VAR NAME="PATHNAME">
 			<TMPL_IF NAME="PATH"></a></TMPL_IF>
 		<TMPL_ELSE>
 			<TMPL_IF NAME="PATH"><a href="<TMPL_VAR NAME="PATH">"></TMPL_IF>


### PR DESCRIPTION
Subgroups weren't heavily tested in templates. I found different bad links, and fixed them so I don't get much 404 when doing a wget --mirror from a munin directory.

The ones I still get are from a bottom-navigation links in comparaison pages, when peers doesn't have any comparaison available.
