### PR TITLE
Call munin-graph with the --cron option from cron script

### DIFF
--- a/master/_bin/munin-cron.in
+++ b/master/_bin/munin-cron.in
@@ -16,4 +16,4 @@ nice @@LIBDIR@@/munin-html $@ || exit 1
 # Now the result of munin-html is needed for munin-graph.
 # It is always lauched, but will be a noop if 
 # graph_strategy is "cgi" 
-nice @@LIBDIR@@/munin-graph $@ || exit 1
+nice @@LIBDIR@@/munin-graph --cron $@ || exit 1


### PR DESCRIPTION
Otherwise we now generate graphs twice when the graph_strategy is set to
'cgi'. This is a bit of a regression in the provided cron script between
2.0.1 and 2.0.4 due to commit cbecced27.
