### PR TITLE
munin-master: htmlconf.storable is back (fix previous commit)

### DIFF
--- a/master/lib/Munin/Master/HTMLConfig.pm
+++ b/master/lib/Munin/Master/HTMLConfig.pm
@@ -36,8 +36,11 @@ sub generate_config {
     my $use_cache = shift;
     if ($use_cache) {
 	# if there is some cache, use it (for cgi)
-    	$cache = munin_readconfig_part('htmlconf', 1);
-	return $cache if (defined $cache);
+    	my $newcache = munin_readconfig_part('htmlconf', 1);
+	if (defined $newcache) {
+		$cache = $newcache;
+		return $cache;
+	}
     }
     $categories = {};
     $problems = {"criticals" => [], "warnings" => [], "unknowns" => []};
@@ -55,19 +58,6 @@ sub generate_config {
     # if only limits changed, still update our cache
     if ($rev != munin_configpart_revision()) {
 	$cache = get_group_tree($config);
-	# htmlconf cache
-	#  munin-html writes it
-	#  munin-cgi-html reads it
-	#
-	#  full cron - written, never read
-	#  munin-html and munin-cgi-html - written, and read as cache
-	#  full munin-cgi-html - should not exist!
-	#    and here, we avoid leaving a never-updating cache file
-	if (!$use_cache) {
-	    my $cachefile = "$config->{dbdir}/htmlconf.storable";
-	    munin_writeconfig_storable($cachefile, $cache)
-		if (!$use_cache);
-	}
     }
 
     return $cache;

--- a/master/lib/Munin/Master/HTMLOld.pm
+++ b/master/lib/Munin/Master/HTMLOld.pm
@@ -168,6 +168,17 @@ sub get_config {
 
 		# Atomic move
 		rename($graphs_filename_tmp, $graphs_filename);
+
+		# htmlconf cache
+		#  munin-html writes it
+		#  munin-cgi-html reads it
+		#
+		#  full cron - written, never read
+		#  munin-html and munin-cgi-html - written, and read as cache
+		#  full munin-cgi-html - should not exist!
+		#    and here, we avoid leaving a never-updating cache file
+		my $cachefile = "$config->{dbdir}/htmlconf.storable";
+		munin_writeconfig_storable($cachefile, $htmlconfig);
 	}
 	return $htmlconfig;
 }

--- a/master/lib/Munin/Master/Utils.pm
+++ b/master/lib/Munin/Master/Utils.pm
@@ -1044,7 +1044,10 @@ sub munin_readconfig_part {
 	}
 	# missing ok, return last value if we have one, copy config if not
 	if (undef == $config_parts->{$what}{config}) {
-		$doupdate = 1;
+		# well, not if we shouldn't include the config
+		if ($config_parts->{$what}{include_base}) {
+			$doupdate = 1;
+		}
 	}
     } else {
     	my @stat = stat($filename);
@@ -1059,7 +1062,7 @@ sub munin_readconfig_part {
 	$part->{'#%#name'} = 'root';
 	$part->{'#%#parent'} = undef;
 	$part = munin_overwrite($part, $config)
-		if ($config_parts->${what}{include_base});
+		if ($config_parts->{$what}{include_base});
 	$config_parts->{$what}{config} = $part;
 	++$config_parts->{$what}{revision};
     }


### PR DESCRIPTION
previous commit provided a broken state, and was already included. now fixed.
