### PR TITLE
Fix GOODSH bad interpreter

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -89,7 +89,7 @@ JAVALIBDIR = $(LIBDIR)
 # On Linux /bin/sh, SunOS/Solaris /usr/xpg4/bin/sh or /bin/ksh
 # In general: bash or ksh will work
 #
-GOODSH     := $(shell PATH=`getconf PATH 2>/dev/null || echo $(PATH)` sh -c 'type sh | sed "s/.* //"')
+GOODSH     := $(shell PATH=`getconf PATH 2>/dev/null || echo $(PATH)` LANG=C sh -c 'type sh | sed "s/.* //"')
 
 # Path of bash for bash specific plugins
 BASH       := /bin/bash


### PR DESCRIPTION
GOODSH is break on non C locale environment.

```
$ LANG=ja_JP.UTF-8 sh -c 'type sh | sed "s/.* //"'
です
$ LANG=C sh -c 'type sh | sed "s/.* //"'
/bin/sh
```
