### PR TITLE
fw_conntrack: count both ipv4 and ipv6 connections together.

### DIFF
--- a/plugins/node.d.linux/fw_conntrack.in
+++ b/plugins/node.d.linux/fw_conntrack.in
@@ -124,7 +124,7 @@ EOF
 
 my $command;
 if ( -x $conntrack) {
-    $command = "$conntrack -L -o extended 2>/dev/null";
+    $command = "$conntrack -L -o extended -f ipv4 2>/dev/null; $conntrack -L -o extended -f ipv6 2>/dev/null";
 } elsif ( -r $nf_conntrack_file ) {
     $command = "cat $nf_conntrack_file";
 } else {


### PR DESCRIPTION
Without this change, only ipv4 connections are counted and they might
float more than expected.
