### PR TITLE
Fix multiping to show packetloss correctly

### DIFF
--- a/plugins/node.d/multiping.in
+++ b/plugins/node.d/multiping.in
@@ -82,5 +82,5 @@ do
     ${ping:-ping} ${ping_args:-'-c 2'} ${hosts} ${ping_args2} \
 	| perl -n -e 'print "site$ENV{'site'}.value ", $1 / 1000, "\n" 
         if m@min/avg/max.*\s\d+(?:\.\d+)?/(\d+(?:\.\d+)?)/\d+(?:\.\d+)?@; 
-        print "packetloss.value $1\n" if /(\d+)% packet loss/;'
+        print "site$ENV{'site'}_packetloss.value $1\n" if /(\d+)% packet loss/;'
 done


### PR DESCRIPTION
Fetch before:

packetloss.value 0
site1.value 0.041356
packetloss.value 0
site2.value 0.036522

after:

site1_packetloss.value 0
site1.value 0.04203
site2_packetloss.value 0
site2.value 0.037491
