### PR TITLE
Fixed parsing of first element in custom graph_data_size

### DIFF
--- a/master/lib/Munin/Master/UpdateWorker.pm
+++ b/master/lib/Munin/Master/UpdateWorker.pm
@@ -775,7 +775,7 @@ sub parse_custom_resolution {
 
 	# First element is always the full resoltion, converting to computer format
 	my $full_res = shift @elems; 
-	unshift @elems, "$update_rate for $full_res";
+	unshift @elems, "1 $full_res";
 
         foreach my $elem (@elems) {
                 if ($elem =~ m/(\d+) (\d+)/) {


### PR DESCRIPTION
Documentation (http://munin-monitoring.org/wiki/format-graph_data_size) and comments in the source code suggest that the first element in custom graph_data_size is full_rra_nb in "computer" format, while the actual logic in the code expected "human-readable" format. I think this was a bug, so I fixed it.
