### PR TITLE
New regexes for virus/spam count in amavis plugin.

### DIFF
--- a/plugins/node.d/amavis.in
+++ b/plugins/node.d/amavis.in
@@ -133,10 +133,10 @@ then
 	else
 	    $LOGTAIL ${AMAVIS_LOG} ${STATEFILE} | grep 'amavis\[.*\]:' > ${TEMP_FILE}
 	fi
-	total=$(grep -c 'Passed' ${TEMP_FILE})
-	virus=$(grep -c 'INFECTED' ${TEMP_FILE})
-	spamm=$(grep -c 'Passed.*Hits: 1[0-9][.]' ${TEMP_FILE})
-	spams=$(grep -c 'Passed.*Hits: [2-9][0-9][0-9]*[.]' ${TEMP_FILE})
+	total=$(grep -c 'Hits:' ${TEMP_FILE})
+	virus=$(grep -c 'INFECTED.*Hits:' ${TEMP_FILE})
+	spamm=$(grep -c 'SPAMMY.*Hits:' ${TEMP_FILE})
+	spams=$(grep -c 'SPAM .*Hits:' ${TEMP_FILE})
 
 	/bin/rm -f $TEMP_FILE
 fi


### PR DESCRIPTION
The old patterns didn't work correctly with the log output of current amavis versions.
