### PR TITLE
Fixed ejabberd plugin

### DIFF
--- a/plugins/node.d/ejabberd_.in
+++ b/plugins/node.d/ejabberd_.in
@@ -267,7 +267,7 @@ if [ "$MODE" = "statuses" ]; then
    for host in $vhosts; do
         formathost=$(echo $host | tr '.' '_' | tr '-' '_')
                 for status in $statuses; do
-                        num=$($EJCTL status-num-host $status $host)
+                        num=$($EJCTL status-num-host $host $status)
                         if [ "$?" != 0 ]; then
                                 num="U"
                         fi


### PR DESCRIPTION
The ejabberd plugin has following bugs, that this pull request, fixes:
- In case of an error, the script exits with the invalid status -1 (instead of 1), resulting in an exception, instead of showing the original error message.
- The statuses mode is broken, due to wrong order of arguments for `ejabberdctl status-num-host`.
