### PR TITLE
Escape $ in MKTEMP

### DIFF
--- a/test-mktemp
+++ b/test-mktemp
@@ -41,7 +41,7 @@ testfun () {
 	STATUS=$?
 	if [ $STATUS = 0 -a -n "$TEMP_FILE" -a -f "$TEMP_FILE" ]; then
 		rm -f $TEMP_FILE
-		echo "${MKTEMP/$/\\$}"
+		echo "$MKTEMP" | perl -pne 's/\$/\\\$/'
 		exit
 	else
 		rm -f $TEMP_FILE


### PR DESCRIPTION
Otherwise the substitution regex will interpret it as a back-
reference, resulting in:
our $MUNIN_MKTEMP     = q{mktemp -p /tmp/ MKTEMP     = };
instead of:
our $MUNIN_MKTEMP     = q{mktemp -p /tmp/ $1};
