### PR TITLE
build: create an install-minimal target that only installs the Node components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,9 @@ tags:
 
 ######################################################################
 
-install: install-master-prime install-common-prime install-node-prime install-plugins-prime $(JAVA_INSTALL) install-man install-async-prime
+install: install-master-prime install-minimal install-man
+
+install-minimal: install-common-prime install-node-prime install-plugins-prime $(JAVA_INSTALL) install-async-prime
 
 install-pre: Makefile Makefile.config
 	@$(CHECKUSER)


### PR DESCRIPTION
This is what Gentoo does right now manually, it's easier to maintain
here though, and users might want to do the same if they are
installing from sources, and only want a node.
