### PR TITLE
plugins: use the get method on the Munin::Plugin::HTTP instance instead ...

### DIFF
--- a/plugins/node.d/haproxy_.in
+++ b/plugins/node.d/haproxy_.in
@@ -58,7 +58,7 @@ my $UA = Munin::Plugin::HTTP->new;
 my $URL = exists $ENV{'url'} ? $ENV{'url'} : "http://localhost/haproxy-status;csv;norefresh";
 
 my $url = $URL;
-my $response = $UA->request(HTTP::Request->new('GET',$url));
+my $response = $UA->get($url);
 my $content = $response->content;
 my %backends = ();
 

--- a/plugins/node.d/haproxy_ng.in
+++ b/plugins/node.d/haproxy_ng.in
@@ -51,7 +51,7 @@ my $ua = Munin::Plugin::HTTP->new;
 
 my @types = qw(frontend backend server);
 my $url = $URL;
-my $response = $ua->request(HTTP::Request->new('GET',$url));
+my $response = $ua->get($url);
 my $content = $response->content;
 my $set;
 my @columns;

--- a/plugins/node.d/hp2000_.in
+++ b/plugins/node.d/hp2000_.in
@@ -463,8 +463,7 @@ my $md5_hash = md5_hex( $secret );
 
 $ua = Munin::Plugin::HTTP->new;
 $url = "http://$host/api/login/" . $md5_hash;
-$req = HTTP::Request->new(GET => $url);
-$res = $ua->request($req);
+$res = $ua->get($url);
 
 # Parse the XML content using LibXML to obtain the session key
 my $parser  = XML::LibXML->new();

--- a/plugins/node.d/nginx_request.in
+++ b/plugins/node.d/nginx_request.in
@@ -64,7 +64,7 @@ my $port = exists $ENV{'port'} ? $ENV{'port'} : "80";
 
 if ( exists $ARGV[0] and $ARGV[0] eq "autoconf" )
 {
-	my $response = $UA->request(HTTP::Request->new('GET',$URL));
+	my $response = $UA->get($URL);
 
 	unless ($response->is_success and $response->content =~ /server/im)
 	{
@@ -93,7 +93,7 @@ if ( exists $ARGV[0] and $ARGV[0] eq "config" )
 	exit 0;
 }
 
-my $response = $UA->request(HTTP::Request->new('GET',$URL));
+my $response = $UA->get($URL);
 
 if ($response->content =~ /^\s+(\d+)\s+(\d+)\s+(\d+)/m) {
     print "request.value $3\n";

--- a/plugins/node.d/nginx_status.in
+++ b/plugins/node.d/nginx_status.in
@@ -66,7 +66,7 @@ if ( exists $ARGV[0] and $ARGV[0] eq "autoconf" ) {
 	exit 0;
     }
 
-    my $response = $UA->request(HTTP::Request->new('GET',$URL));
+    my $response = $UA->get($URL);
 
     unless ($response->is_success and $response->content =~ /server/im) {
 	print "no (no nginx status on $URL)\n";
@@ -102,7 +102,7 @@ if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
     exit 0;
 }
 
-my $response = $UA->request(HTTP::Request->new('GET',$URL));
+my $response = $UA->get($URL);
 
 #Active connections: 1845 
 #server accepts handled requests

--- a/plugins/node.d/tomcat_access.in
+++ b/plugins/node.d/tomcat_access.in
@@ -75,7 +75,7 @@ if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
 	print "no ($ret)\n";
 	exit 0;
     }
-    my $repsonse = $UA->request(HTTP::Request->new('GET',$url));
+    my $repsonse = $UA->get($url);
     if($repsonse->is_success and $repsonse->content =~ /<status>.*<\/status>/im) {
 	print "yes\n";
 	exit 0;
@@ -98,7 +98,7 @@ if(exists $ARGV[0] and $ARGV[0] eq "config") {
 }
 
 my $xs = new XML::Simple;
-my $response = $UA->request(HTTP::Request->new('GET',$url));
+my $response = $UA->get($url);
 my %options = ( KeyAttr => { connector => 'name' }, ForceArray => 1 );
 my $xml = $xs->XMLin($response->content, %options);
 

--- a/plugins/node.d/tomcat_jvm.in
+++ b/plugins/node.d/tomcat_jvm.in
@@ -82,7 +82,7 @@ if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
 	print "no ($ret)\n";
 	exit 0;
     }
-    my $repsonse = $UA->request(HTTP::Request->new('GET',$url));
+    my $repsonse = $UA->get($url);
     if($repsonse->is_success and $repsonse->content =~ /<status>.*<\/status>/im) {
 	print "yes\n";
 	exit 0;
@@ -108,7 +108,7 @@ if(exists $ARGV[0] and $ARGV[0] eq "config") {
 }
 
 my $xs = new XML::Simple;
-my $response = $UA->request(HTTP::Request->new('GET',$url));
+my $response = $UA->get($url);
 my $xml = $xs->XMLin($response->content);
 
 if($xml->{'jvm'}->{'memory'}->{'free'} && 

--- a/plugins/node.d/tomcat_threads.in
+++ b/plugins/node.d/tomcat_threads.in
@@ -74,7 +74,7 @@ if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
 	print "no ($ret)\n";
 	exit 0;
     }
-    my $repsonse = $UA->request(HTTP::Request->new('GET',$url));
+    my $repsonse = $UA->get($url);
     if($repsonse->is_success and $repsonse->content =~ /<status>.*<\/status>/im) {
 	print "yes\n";
 	exit 0;
@@ -99,7 +99,7 @@ if(exists $ARGV[0] and $ARGV[0] eq "config") {
 }
 
 my $xs = new XML::Simple;
-my $response = $UA->request(HTTP::Request->new('GET',$url));
+my $response = $UA->get($url);
 my %options = ( KeyAttr => { connector => 'name' }, ForceArray => 1 );
 my $xml = $xs->XMLin($response->content, %options);
 

--- a/plugins/node.d/tomcat_volume.in
+++ b/plugins/node.d/tomcat_volume.in
@@ -92,7 +92,7 @@ if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
 	print "no ($ret)\n";
 	exit 0;
     }
-    my $repsonse = $UA->request(HTTP::Request->new('GET',$url));
+    my $repsonse = $UA->get($url);
     if($repsonse->is_success and $repsonse->content =~ /<status>.*<\/status>/im) {
 	print "yes\n";
 	exit 0;
@@ -115,7 +115,7 @@ if(exists $ARGV[0] and $ARGV[0] eq "config") {
 }
 
 my $xs = new XML::Simple;
-my $response = $UA->request(HTTP::Request->new('GET',$url));
+my $response = $UA->get($url);
 my %options = ( KeyAttr => { connector => 'name' }, ForceArray => 1 );
 my $xml = $xs->XMLin($response->content, %options);
 


### PR DESCRIPTION
...of request.

This allows to get rid of most references to HTTP::Request (with the
exception of hp2000_), as no extra headers are usually passed.

The Apache plugins are left untouched because a replacement for them
is already standing by.
