### PR TITLE
fail2ban: Handle the case where no jails are configured.

### DIFF
--- a/plugins/node.d/fail2ban.in
+++ b/plugins/node.d/fail2ban.in
@@ -71,7 +71,7 @@ list_jails() {
             *'Jail list:'*)
                 line="${line##*Jail list*:}"
                 line="${line//[ $'\t']/}"
-                printf "${line//,/$'\n'}\n"
+                [ -n "$line" ] && printf "${line//,/$'\n'}\n"
                 ;;
         esac
     done


### PR DESCRIPTION
This fixes https://bugzilla.novell.com/show_bug.cgi?id=795535
