### PR TITLE
ntp_: rewrite plugin to support IPv6

### DIFF
--- a/plugins/node.d/ntp_.in
+++ b/plugins/node.d/ntp_.in
@@ -1,145 +1,184 @@
 #!@@PERL@@ -w
-# -*- perl -*-
+# -*- mode: cperl; cperl-indent-level: 8; -*-
 
 =head1 NAME
 
-ntp_ - Plugin to monitor NTP statistics
+ntp_ - Wildcard plugin to monitor NTP statistics for a particular remote NTP peer
 
 =head1 CONFIGURATION
+
+This is a wildcard plugin. The wildcard suffix in the symlink is the
+hostname, IPv4, or IPv6 address of the NTP peer that you want to
+monitor. The IP address must be one which appears in C<ntpq -np>
+output. If given a hostname, it must resolve to an IP address which
+appears in C<ntpq -np> output; this plugin will try all of the A or
+AAAA records returned. If you use a dynamic association method, such
+as "pool" or one of the broadcast or multicast methods, this plugin
+will probably not work very well for you, as your NTP peers could be
+changing frequently.
+
+Examples:
+
+=over
+
+=item ntp_time.example.com
+
+=item ntp_203.0.113.1
+
+=item ntp_2001:db8::1
+
+=back
 
 The following environment variables are used by this plugin:
 
  [ntp_*]
-  env.lowercase       - lowercase hostnames after lookup
-  env.nodelay 1       - Set to 1 to remove delay
-
-=head1 NOTES
-
-This plugin is now "legacy" because it's not very useful, it is
-imposible to determine which peer is used as "master". The other ntp_*
-plugins are better. This one is no longer maintained.
+  env.lowercase - Lowercase hostnames after lookup
+  env.nodelay 1 - Set to 1 to disable graphing of delay
 
 =head1 AUTHOR
 
-Author unknown
+Original author unknown. Rewritten by Kenyon Ralph <kenyon@kenyonralph.com>.
 
 =head1 LICENSE
 
-License unknown
+Same as munin.
 
 =head1 MAGIC MARKERS
 
-  #%# family=legacy
-  #%# capabilities=autoconf suggest
+ #%# family=auto
+ #%# capabilities=autoconf suggest
 
 =cut
 
+use English qw( -no_match_vars );
 use strict;
-use Net::hostent;
-use Socket;
-
-my $nodelay = $ENV{'nodelay'} || 0;
+use warnings;
+use Net::DNS;
+use Net::IP;
 
 if ($ARGV[0] and $ARGV[0] eq "autoconf") {
-	`ntpq -c help >/dev/null 2>/dev/null`;
-	if ($? eq "0") {
-		if (`ntpq -c "hostnames no" -c peers | wc -l` > 0) {
-			print "yes\n";
-			exit 0;
-		} else {
-			print "no (unable to list peers)\n";
-			exit 0;
-		}
-	} else {
-		print "no (ntpq not found)\n";
-		exit 0;
-	}
+        `ntpq -c help >/dev/null 2>/dev/null`;
+        if ($CHILD_ERROR eq "0") {
+                if (`ntpq -n -c peers | wc -l` > 0) {
+                        print "yes\n";
+                        exit 0;
+                } else {
+                        print "no (ntpq -p returned no peers)\n";
+                        exit 0;
+                }
+        } else {
+                print "no (ntpq not found)\n";
+                exit 0;
+        }
 }
 
 if ($ARGV[0] and $ARGV[0] eq "suggest") {
-	my @lines = `ntpq -c "hostnames no" -c peers`;
-	foreach (@lines) {
-		next unless /^.(\d+\.\d+\.\d+\.\d+)/;
-		next if /^.224\.0\.1\.1/;
-		my $addr = $1;
-		my $name;
-		if( my $lcid= /^.127\.127\.1\.(\d+)/) {
-			$lcid = $lcid - 1;
-			$name = "LOCAL($lcid)";
-		} else {
-			$name = gethostbyaddr(inet_aton($addr));
-			$name = defined $name ? $name->name : $addr;
-		}
-		$name = lc $name if exists $ENV{"lowercase"};
-		$name =~ s/[\.\-()]/_/g;
-		print $name, "\n";
-	}
-	exit 0;
-}
-
-$0 =~ /ntp_(.+)*$/; 
-my $name = $1;
-die "No hostname provided" unless defined $name;
-
-if ($ARGV[0] and $ARGV[0] eq "config") {
-	my @lines = `ntpq -c "hostnames no" -c peers`;
-	my $host;
-	foreach (@lines) {
-		next unless /^.(\d+\.\d+\.\d+\.\d+)/;
-		next if /^.224\.0\.1\.1/;
-		my $addr = $1;
-		my $host;
-		if( my $lcid= /^.127\.127\.1\.(\d+)/) {
-			$lcid = $lcid - 1;
-			$host = "LOCAL($lcid)"
-		} else {
-			$host = gethostbyaddr(inet_aton($addr));
-			$host = defined $host ? $host->name : $addr;
-		}
-		$host = lc $host if exists $ENV{"lowercase"};
-		my $host_ = $host;
-		$host_ =~ s/[\.\-()]/_/g;
-		next unless $host_ eq $name;
-		print "graph_title NTP statistics for peer $host\n";
-	}
-	print "graph_args --base 1000 --vertical-label seconds --lower-limit 0\n";
-	print "graph_category time\n";
-	print "delay.label Delay\n";
-	print "delay.draw LINE\n";
-	print "delay.graph no\n" if $nodelay;
-	print "delay.cdef delay,1000,/\n";
-        print "offset.label Offset\n";
-        print "offset.draw LINE\n";
-	print "offset.cdef offset,1000,/\n";
-        print "jitter.label Jitter\n";
-        print "jitter.draw LINE\n";
-	print "jitter.cdef jitter,1000,/\n";
+        foreach my $line (`ntpq -c associations`) {
+                if ($line =~ m/^\s*\d+/) {
+                        my (undef, undef, $assid, undef, undef, undef, undef, undef, undef, undef) = split(/\s+/, $line);
+                        chomp(my $peerinfo = `ntpq -n -c "readvar $assid srcadr"`);
+                        $peerinfo =~ s/\R/ /g;
+                        my ($peer_addr) = ($peerinfo =~ m/srcadr=(.*)/);
+                        print $peer_addr, "\n" unless $peer_addr eq "0.0.0.0";
+                }
+        }
         exit 0;
 }
 
-my @lines = `ntpq -c "hostnames no" -c peers`;
-foreach (@lines) {
-	next unless /^.(\d+\.\d+\.\d+\.\d+)/;
-	next if /^.224\.0\.1\.1/;
-	my $addr = $1;
-	my $host;
-	if( my $lcid= /^.127\.127\.1\.(\d+)/) {
-		$lcid = $lcid - 1;
-		$host = "LOCAL($lcid)"
-	} else {
-		$host = gethostbyaddr(inet_aton($addr));
-		$host = defined $host ? $host->name : $addr;
-	}
-	$host = lc $host if exists $ENV{"lowercase"};
-	$host =~ s/[\.\-()]/_/g;
-	next unless $host eq $name;
-	my @F = split;
-	print <<"EOT";
-delay.value $F[7]
-offset.value $F[8]
-jitter.value $F[9]
-EOT
+my $nodelay = $ENV{'nodelay'} || 0;
+$0 =~ /ntp_(.+)*$/;
+my $name = $1;
+die "No hostname or IP address provided" unless defined $name;
+
+if ($ARGV[0] and $ARGV[0] eq "config") {
+        print "graph_title NTP statistics for peer $name\n";
+        print "graph_args --base 1000 --vertical-label seconds --lower-limit 0\n";
+        print "graph_category time\n";
+        print "delay.label Delay\n";
+        print "delay.graph no\n" if $nodelay;
+        print "delay.cdef delay,1000,/\n";
+        print "offset.label Offset\n";
+        print "offset.cdef offset,1000,/\n";
+        print "jitter.label Jitter\n";
+        print "jitter.cdef jitter,1000,/\n";
+        exit 0;
 }
+
+my $srcadr;
+my $delay;
+my $offset;
+my $jitter;
+my @associations = `ntpq -c associations`;
+
+foreach my $line (@associations) {
+        if ($line =~ m/^\s*\d+/) {
+                my (undef, undef, $assid, undef, undef, undef, undef, undef, undef, undef) = split(/\s+/, $line);
+                chomp(my $peerinfo = `ntpq -n -c "readvar $assid srcadr,delay,offset,jitter"`);
+                $peerinfo =~ s/\R/ /g;
+                ($srcadr, $delay, $offset, $jitter) = split(/, /, $peerinfo);
+                ($srcadr) = ($srcadr =~ m/srcadr=(.*)/);
+                ($delay) = ($delay =~ m/delay=(.*)/);
+                ($offset) = ($offset =~ m/offset=(.*)/);
+                ($jitter) = ($jitter =~ m/jitter=(.*)/);
+                last if lc($srcadr) eq lc($name);
+        }
+}
+
+my $matched = 0;
+
+if (lc($srcadr) ne lc($name)) {
+        my @addresses;
+        my $resolver = Net::DNS::Resolver->new;
+        my $query = $resolver->search($name, "AAAA");
+
+        if ($query) {
+                foreach my $rr ($query->answer) {
+                        if ("AAAA" eq $rr->type) {
+                                push(@addresses, new Net::IP($rr->address));
+                        }
+                }
+        }
+
+        $query = $resolver->search($name, "A");
+
+        if ($query) {
+                foreach my $rr ($query->answer) {
+                        if ("A" eq $rr->type) {
+                                push(@addresses, new Net::IP($rr->address));
+                        }
+                }
+        }
+
+        ASSOCS: foreach my $line (@associations) {
+                if ($line =~ m/^\s*\d+/) {
+                        my (undef, undef, $assid, undef, undef, undef, undef, undef, undef, undef) = split(/\s+/, $line);
+                        chomp(my $peerinfo = `ntpq -n -c "readvar $assid srcadr,delay,offset,jitter"`);
+                        $peerinfo =~ s/\R/ /g;
+                        ($srcadr, $delay, $offset, $jitter) = split(/, /, $peerinfo);
+                        ($srcadr) = new Net::IP($srcadr =~ m/srcadr=(.*)/);
+                        ($delay) = ($delay =~ m/delay=(.*)/);
+                        ($offset) = ($offset =~ m/offset=(.*)/);
+                        ($jitter) = ($jitter =~ m/jitter=(.*)/);
+
+                        ADDRS: foreach my $addr (@addresses) {
+                                if (defined($srcadr->overlaps($addr)) and $srcadr->overlaps($addr) == $IP_IDENTICAL) {
+                                        $matched = 1;
+                                        last ASSOCS;
+                                }
+                        }
+                }
+        }
+}
+
+if (lc($srcadr) ne lc($name) and $matched == 0) {
+        die "$name is not a peer of this ntpd";
+}
+
+print <<"EOT";
+delay.value $delay
+offset.value $offset
+jitter.value $jitter
+EOT
 
 exit 0;
 


### PR DESCRIPTION
Closes Debian bug #558800 and Munin trac ticket #775

This rewrite of ntp_ supports hostnames, like the original does. It will check all AAAA and A records of a hostname for a matching ntpd peer IP address.
