### PR TITLE
Treat empty query param as absent.

### DIFF
--- a/master/static/querystring.js
+++ b/master/static/querystring.js
@@ -33,7 +33,7 @@ function Querystring(qs) { // optionally pass a querystring to parse
 
 Querystring.prototype.get = function(key, default_) {
 	var value = this.params[key];
-	return (value != null) ? value : default_;
+	return (value != null) && (value != '') ? value : default_;
 }
 
 Querystring.prototype.contains = function(key) {


### PR DESCRIPTION
With this fix, both
    `dynazoom.html?cgiurl_graph=&plugin_name=...`
and
    `dynazoom.html?plugin_name=`
now fall back to the default value for `cgiurl_graph`.

This is needed to make fallback to the default path work if the user
hasn't specified it explicitly in `/etc/munin.conf`. Previously, the
empty string would have been used as path for `cgiurl_graph`.
