### PR TITLE
Supports of multiple postgres installation per host for #1196

### DIFF
--- a/plugins/node.d/postgres_autovacuum.in
+++ b/plugins/node.d/postgres_autovacuum.in
@@ -28,7 +28,7 @@ Configuration is done through libpq environment variables, for example
 PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 
 To monitor several instances, link to postgres_<tag>_autovacuum
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_bgwriter.in
+++ b/plugins/node.d/postgres_bgwriter.in
@@ -28,7 +28,7 @@ Configuration is done through libpq environment variables, for example
 PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 
 To monitor several instances, link to postgres_<tag>_bgwriter
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_cache_.in
+++ b/plugins/node.d/postgres_cache_.in
@@ -30,7 +30,7 @@ PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 To monitor a specific database, link to postgres_cache_<databasename>.
 To monitor all databases, link to postgres_cache_ALL.
 To monitor several instances, link to postgres_<tag>_cache_<databasename|ALL>
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_checkpoints.in
+++ b/plugins/node.d/postgres_checkpoints.in
@@ -28,7 +28,7 @@ Configuration is done through libpq environment variables, for example
 PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 
 To monitor several instances, link to postgres_<tag>_checkpoints
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_connections_.in
+++ b/plugins/node.d/postgres_connections_.in
@@ -30,7 +30,7 @@ PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 To monitor a specific database, link to postgres_connections_<databasename>.
 To monitor all databases, link to postgres_connections_ALL.
 To monitor several instances, link to postgres_<tag>_connections_<databasename|ALL>
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_connections_db.in
+++ b/plugins/node.d/postgres_connections_db.in
@@ -29,7 +29,7 @@ Configuration is done through libpq environment variables, for example
 PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 
 To monitor several instances, link to postgres_<tag>_connections_db
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_locks_.in
+++ b/plugins/node.d/postgres_locks_.in
@@ -30,7 +30,7 @@ PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 To monitor a specific database, link to postgres_locks_<databasename>.
 To monitor all databases, link to postgres_locks_ALL.
 To monitor several instances, link to postgres_<tag>_locks_<databasename|ALL>
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_oldest_prepared_xact_.in
+++ b/plugins/node.d/postgres_oldest_prepared_xact_.in
@@ -31,7 +31,7 @@ PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 To monitor a specific database, link to postgres_oldest_prepared_xact_<databasename>.
 To monitor all databases, link to postgres_oldest_prepared_xact_ALL.
 To monitor several instances, link to postgres_<tag>_oldest_prepared_xact_<databasename|ALL>
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_prepared_xacts_.in
+++ b/plugins/node.d/postgres_prepared_xacts_.in
@@ -31,7 +31,7 @@ PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 To monitor a specific database, link to postgres_prepared_xacts_<databasename>.
 To monitor all databases, link to postgres_prepared_xacts_ALL.
 To monitor several instances, link to postgres_<tag>_prepared_xacts_<databasename|ALL>
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_querylength_.in
+++ b/plugins/node.d/postgres_querylength_.in
@@ -30,7 +30,7 @@ PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 To monitor a specific database, link to postgres_querylength_<databasename>.
 To monitor all databases, link to postgres_querylength_ALL.
 To monitor several instances, link to postgres_<tag>_querylength_<databasename|ALL>
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_scans_.in
+++ b/plugins/node.d/postgres_scans_.in
@@ -29,7 +29,7 @@ PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 
 To monitor a specific database, link to postgres_scans_<databasename>.
 To monitor several instances, link to postgres_<tag>_scans_<databasename>
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_size_.in
+++ b/plugins/node.d/postgres_size_.in
@@ -30,7 +30,7 @@ PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 To monitor a specific database, link to postgres_size_<databasename>.
 To monitor all databases, link to postgres_size_ALL.
 To monitor several instances, link to postgres_<tag>_size_<databasename|ALL>
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_transactions_.in
+++ b/plugins/node.d/postgres_transactions_.in
@@ -30,7 +30,7 @@ PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 To monitor a specific database, link to postgres_transactions_<databasename>.
 To monitor all databases, link to postgres_transactions_ALL.
 To monitor several instances, link to postgres_<tag>_transactions_<databasename|ALL>
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_tuples_.in
+++ b/plugins/node.d/postgres_tuples_.in
@@ -29,7 +29,7 @@ PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 
 To monitor a specific database, link to postgres_tuples_<databasename>.
 To monitor several instances, link to postgres_<tag>_tuples_<databasename|ALL>
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_users.in
+++ b/plugins/node.d/postgres_users.in
@@ -28,7 +28,7 @@ Configuration is done through libpq environment variables, for example
 PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 
 To monitor several instances, link to postgres_<tag>_users
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :

--- a/plugins/node.d/postgres_xlog.in
+++ b/plugins/node.d/postgres_xlog.in
@@ -28,7 +28,7 @@ Configuration is done through libpq environment variables, for example
 PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 
 To monitor several instances, link to postgres_<tag>_xlog
-The <tag> can be what you want but without "_". It's allow you to define several
+The <tag> can be what you want but without "_". It allows you to define several
 database configuration.
 
 Example :


### PR DESCRIPTION
Allow you to monitor several postgresql instances. 
Just link to postgres_<tag>_size_<databasename|ALL>
The <tag> can be what you want but without "_". It's allow you to define several
database configuration.
Example :

```
    [postgres_pg91_*]
    env.PGPORT 5432
    [postgres_pg92_*]
    env.PGPORT 5433
```

After you can try with :

```
 munin-run postgres_pg91_size_ALL
 munin-run postgres_pg84_size_ALL
```

Probably it can be improved in pgsql.pm if anyone has any advice I am open.
