### PR TITLE
iostat and irqstats include/exclude list

### DIFF
--- a/plugins/node.d.linux/iostat.in
+++ b/plugins/node.d.linux/iostat.in
@@ -16,6 +16,7 @@ sda0.  By setting
 
    [iostat]
    env.SHOW_NUMBERED 1
+   env.include_only sda,sdb
 
 it will show numbered devices.  This is sometimes needed in
 virtualized environments (e.g. Xen) where sda1 to sda<n> exists but
@@ -55,6 +56,7 @@ use strict;
 
 use Munin::Plugin;
 
+my $include_only = $ENV{'include_only'} || "";
 my $detailed_present = 0;
 my $stat_present = 0;
 my $include_numbered = 0;    # By default we want sda but not sda1
@@ -136,6 +138,9 @@ sub fetch_stat() {
 	    next unless $dev =~ /\S/;
 	    next unless ($dev =~ /\((\d+),(\d+)\):\(\d+,(\d+),(\d+),(\d+),(\d+)\)/);
 	    my $name = "dev".$1."_".$2;
+
+	    next if ($include_only ne "" and $include_only !~ $name);
+
 	    $devs{$name} =
 	      {
 	       name => $name,
@@ -180,6 +185,8 @@ sub fetch_detailed() {
 		$tmpnam =~ s/\/[[:alpha:]]+(\d+)/\/$1/g;
 		$tmpnam =~ s/^([^\/]+)\//$1/;
 		$tmpnam =~ s/\/disc$//;
+
+		next if ($include_only ne "" and $include_only !~ $tmpnam);
 
 		$devs{"dev".$major."_".&get_disk_count($major)} = 
 		  {

--- a/plugins/node.d.linux/irqstats.in
+++ b/plugins/node.d.linux/irqstats.in
@@ -11,6 +11,11 @@ Any Linux system
 
 =head1 CONFIGURATION
 
+Specified devices may be skipped.
+
+   [irqstats]
+   env.skipdevs blkif,vif
+
 None needed
 
 =head1 USAGE
@@ -51,6 +56,8 @@ GPLv2
 
 use Munin::Plugin;
 use strict;
+
+my $skipdevs = $ENV{'skipdevs'} || "";
 
 if (defined $ARGV[0] && $ARGV[0] eq 'autoconf') {
     if(-r '/proc/interrupts') {
@@ -96,7 +103,7 @@ sub sum (@) {
     return $sum;
 }
 
-while (my $line = <$in>) {
+LINE: while (my $line = <$in>) {
     my ($irq, $label, $type);
     my @data;
     if ($sun) {
@@ -117,6 +124,11 @@ while (my $line = <$in>) {
 	# to divorce data from commentary
 	$label = join(" ",@data[$cpus..$#data]);
 	@data = @data[0..$cpus-1];
+    }
+
+    # skip devices specified in config
+    foreach my $skipdev (split(',', $skipdevs)) {
+        next LINE if ($label =~ $skipdev);
     }
 
     # Skip non-per-cpu values for per-cpu stats


### PR DESCRIPTION
- include_only config option for iostat
  one can set a list of devices which will be monitored
- skipdevs option for irqstats
  specified devices will be skip from monitoring
  it's very handy on citrix xenservers with many VMs
