### PR TITLE
Customize graph title for several postgres_* plugins

### DIFF
--- a/plugins/lib/Munin/Plugin/Pgsql.pm
+++ b/plugins/lib/Munin/Plugin/Pgsql.pm
@@ -50,6 +50,9 @@ The plugins will by default connect to the 'template1' database, except for
 wildcard per-database plugins. This can be overridden using the PGDATABASE
 variable, but this is usually a bad idea.
 
+If you are using plugin for several postgres instances, you can customize
+graph title with the environment variable PGNAME.
+
 =head2 Example
 
  [postgres_*]
@@ -267,12 +270,13 @@ sub Config {
     $self->ensure_version();
 
     print "multigraph $self->{multigraph}\n" if ($self->{multigraph});
+    my $pgname = defined($ENV{'PGNAME'}) ? ' '.$ENV{'PGNAME'} : ''; 
     my $w = $self->wildcard_parameter();
     if ($w) {
-      print "graph_title $self->{title} ($w)\n";
+      print "graph_title $self->{title}${pgname} ($w)\n";
     }
     else {
-      print "graph_title $self->{title}\n";
+      print "graph_title $self->{title}${pgname}\n";
     }
     print "graph_vlabel $self->{vlabel}\n";
     print "graph_category $self->{category}\n";


### PR DESCRIPTION
If you setup several postgres plugins like :

```
postgres_pg91_size_mydb
postgres_pg92_size_mydb
```

Your graph title display the same title for both : 

```
munin-run postgres_pg91_size_mydb config | grep graph_title
graph_title PostgreSQL database size (mydb)
munin-run postgres_pg92_size_mydb config | grep graph_title
graph_title PostgreSQL database size (mydb)
```

I propose a change in pgpsql.pm to take a environment variable in the graph title.
Example in the munin-node conf:

```
[postgres_pg91_ *]
env.PGNAME Pg 9.1
[postgres_pg92_ *]
env.PGNAME Pg 9.2
```

After that you have a different graph title for each plugin : 

```
munin-run postgres_pg91_size_mydb config | grep graph_title
graph_title PostgreSQL database size Pg 9.1 (mydb)
munin-run postgres_pg92_size_mydb config | grep graph_title
graph_title PostgreSQL database size Pg 9.2 (mydb)
```

I have also tested with different configuration and without PGNAME defined :

```
munin-run postgres_pg91_size_mydb config | grep graph_title
graph_title PostgreSQL database size (mydb)
```

By default this patch change nothing for plugins already installed and running. But if user want customize graph_title they can use the new environment variable. 

![munin_postgres](https://f.cloud.github.com/assets/2479183/129423/0a833e8a-6fdd-11e2-9ee0-18c279a5bd4d.png)
