### PR TITLE
Initialize site variable so /bin/sh on FreeBSD 8.3 is happy.

### DIFF
--- a/plugins/node.d/multiping.in
+++ b/plugins/node.d/multiping.in
@@ -59,6 +59,7 @@ if [ -z "$host" ]; then
     host=${host:-${file_host:-www.google.com}}
 fi
 
+site=0
 if [ "$1" = "config" ]; then
     echo graph_title Ping times
     echo 'graph_args --base 1000 -l 0'


### PR DESCRIPTION
Multiping isn't working on FreeBSD, it only returns one site.  This change fixes it for me and I don't see how it could be problematic for other shells.
