### PR TITLE
fix: different state files for cron job & as plugin

### DIFF
--- a/plugins/node.d.linux/apt_all.in
+++ b/plugins/node.d.linux/apt_all.in
@@ -52,7 +52,7 @@ use strict;
 $ENV{'LANG'}="C";
 $ENV{'LC_ALL'}="C";
 
-my $statefile = ($ENV{MUNIN_PLUGSTATE} || '@@PLUGSTATE@@/root/') . "/plugin-apt.state";
+my $statefile = ($ENV{MUNIN_PLUGSTATE} || '@@PLUGSTATE@@/nobody/') . "/plugin-apt.state";
 my @releases = ("stable", "testing","unstable");
 
 


### PR DESCRIPTION
Changes the default state file to /var/lib/munin-node/plugin-state/nobody/plugin-apt.state so the plugin can report anything of use.
