### PR TITLE
changed ntpq -n -c readvar regex for compatability

### DIFF
--- a/plugins/node.d/ntp_states.in
+++ b/plugins/node.d/ntp_states.in
@@ -76,7 +76,7 @@ sub make_hash {
                 if ($line =~ m/^\s*\d+/) {
                         my (undef, undef, $assid, undef, undef, undef, undef, $condition_str, undef, undef) = split(/\s+/, $line);
                         chomp(my $peerinfo = `ntpq -n -c "readvar $assid srcadr"`);
-                        $peerinfo =~ s/\R//g;
+                        $peerinfo =~ s/\r//g;
                         my ($peer_addr) = ($peerinfo =~ m/srcadr=(.*)/);
 
                         # some states get the last letter cut off in


### PR DESCRIPTION
\R was failing with ntp-4.2.2p1-15.el5.centos.1.x86_64 due to extra 0x0a printed at the end of ntpq -n -c "readvar xx srcadr"
ntp-4.2.4p8-3.el6.centos.x86_64 does not print the trailing 0x0a.
