### PR TITLE
snmp__if_multi: get the interface alias from SNMPv2 if it is defined

### DIFF
--- a/plugins/node.d/snmp__if_multi.in
+++ b/plugins/node.d/snmp__if_multi.in
@@ -596,7 +596,9 @@ sub do_config_root {
 sub do_config_if {
     my ($host,$version,$if) = @_;
 
-    my $alias = $snmpinfo->{$if}->{ifDescr} || "Interface $if";
+    my $alias = $snmpinfoX->{$if}->{ifAlias} ||
+        $snmpinfo->{$if}->{ifDescr} ||
+        "Interface $if";
 
     if (! ($alias =~ /\d+/) ) {
 	# If there are no numbers in the $alias add the if index


### PR DESCRIPTION
Hi,

I just modified the snmp__if_multi plugin for consistency with the non-multigraph version. My interface aliases are more meaningful than "TenGigabitEthernet1/0/10"...

Thanks,
Nicolas
