### PR TITLE
Updating HTTP loadtime plugin to add a more specific user agent

### DIFF
--- a/plugins/node.d/http_loadtime.in
+++ b/plugins/node.d/http_loadtime.in
@@ -43,7 +43,7 @@ if [ "$1" = "autoconf" ]; then
     	echo "no (need time and wget programs)"
 	    exit 0
     fi
-    if ! $wget_bin -q -O /dev/null $target; then
+    if ! $wget_bin -q -O /dev/null $target  --user-agent "Munin - http_loadtime"; then
         echo "no (Cannot run wget against \"$target\")"
         exit 0
     fi


### PR DESCRIPTION
I spent a bit of time looking what was calling http://127.0.0.1/ on my server with the defeault wget user agent string. Looked around a bit more and realized it was the Munin HTTP load time plugin. Please add this simple user agent string in so other sys-admins will know what it is when they look at their logs. :)
