### PR TITLE
htddtemp_smartctl: More than one type of drive answers smartctl on FreeBSD

### DIFF
--- a/plugins/node.d/hddtemp_smartctl.in
+++ b/plugins/node.d/hddtemp_smartctl.in
@@ -162,7 +162,7 @@ if ($^O eq 'linux') {
   
 } elsif ($^O eq 'freebsd') {
   opendir(DEV, '/dev');
-  @drives = grep /^ad[0-9]+$/, readdir DEV;
+  @drives = grep /^(ada?|da)[0-9]+$/, readdir DEV;
   closedir(DEV);
 } elsif ($^O eq 'solaris') {
   @drives = map { s@.*/@@ ; $_ } glob '/dev/rdsk/c*t*d*s2';


### PR DESCRIPTION
On FreeBSD devices named ad#, ada#, and da# all potentially respond to smartctl. This change broadens the regex to match all three disk patterns.
