### PR TITLE
asyncd: minrate defaults to update_rate

### DIFF
--- a/node/_bin/munin-asyncd.in
+++ b/node/_bin/munin-asyncd.in
@@ -37,14 +37,14 @@ my $metahostname;
 my $SPOOLDIR = "@@SPOOLDIR@@";
 my $intervalsize = 86400;
 my $timeout = 3600;
-my $minrate = 300;
+my $minrate;
 my $retaincount = 7;
 my $nocleanup;
 my $do_fork;
 my $verbose;
 my $debug;
 my $help;
-my $update_rate;
+my $update_rate = 300;
 
 
 GetOptions(
@@ -66,6 +66,9 @@ GetOptions(
 if ($help) {
 	pod2usage(1);
 }
+
+# $minrate defaults to $update_rate.
+$minrate = $update_rate if ! defined $minrate;
 
 # Debug implies Verbose
 $verbose = 1 if $debug;
@@ -148,7 +151,7 @@ MAIN: while(1) {
 	my $sock;
 	PLUGIN: foreach my $plugin (@plugins) {
 		# See if this plugin should be updated
-		my $plugin_rate = get_hash($plugin, $plugin_rate_filename) || $update_rate || 300;
+		my $plugin_rate = get_hash($plugin, $plugin_rate_filename) || $update_rate;
 		if ($when < ($last_updated{$plugin} || 0) + $plugin_rate) {
 			# not yet, next plugin
 			next;
@@ -313,7 +316,8 @@ munin-asyncd [options]
      -i --interval <seconds>    Override default interval size of one day [86400]
         --update-rate <seconds> Override default update_date [300]
         --timeout <seconds>     Wake up at least this number of seconds. [3600]
-        --minrate <seconds>     This is the minimal rate you want to poll a node [300]
+        --minrate <seconds>     This is the minimal rate you want to poll a node [$update_date]
+                                Note that having $update_date < $minrate leads to unexpected results.
      -r --retain <count>        Specify number of interval files to retain [7]
      -n --nocleanup             Disable automated spool dir cleanup
 


### PR DESCRIPTION
Having $minrate > $update_rate leads to unexpected results as it will not poll
as fast as expected.

This enables to only set $update_rate and have $minrate set automatically to a
sane value.
