### PR TITLE
fixed compatibility issue for "mysql_" plugin with MySQL 5.5/5.6.

### DIFF
--- a/plugins/node.d/mysql_.in
+++ b/plugins/node.d/mysql_.in
@@ -9,7 +9,7 @@ mysql_ - Munin plugin to display misc MySQL server status
 
 =head1 APPLICABLE SYSTEMS
 
-Any MySQL platform, tested by the author on MySQL 5.1.29 and 5.0.51
+Any MySQL platform, tested by the author on MySQL 5.6.12 and 5.5.32, 5.1.29, 5.0.51
 
 =head1 CONFIGURATION
 


### PR DESCRIPTION
I have found two compatibility issues for "mysql_" plugin with MySQL 5.5/5.6.
Would you please review to merge for plugin of "mysql_" to work with MySQL 5.5/5.6 ?
### 1. made a patch for "INDIVIDUAL BUFFER POOL INFO" section

The mysql plugin named "mysql_" have a problem. So It could not work fine with MySQL 5.5 or 5.6.
I have make a patch for "INDIVIDUAL BUFFER POOL INFO" section asskipped to work.
#### all of symlinked mysql_ pluugin gets error like below.

``` sh
$ /etc/munin/plugins/mysql_connections
Unknown section: INDIVIDUAL BUFFER POOL INFO at /etc/munin/plugins/mysql_connections line 1098.
```
#### related issue

https://github.com/kjellm/munin-mysql/commit/111293966ccd6e8df6c1347cb0f9a8b4025c0266
## 2. made a patch for "mysql_innodb_insert_buf" to work

The mysql plugin named "mysql_" have a problem. So It could not work fine with MySQL 5.5 or 5.6.
I have make a patch for "mysql_innodb_insert_buf" to work.
#### symlinked from mysql_innodb_insert_buf to mysql_ pluugin gets error below.

``` sh
$ /etc/munin/plugins/mysql_innodb_insert_buf
Use of uninitialized value in printf at /etc/munin/plugins/mysql_innodb_insert_buf line 885.
ib_ibuf_inserts.value
Use of uninitialized value in printf at /etc/munin/plugins/mysql_innodb_insert_buf line 885.
ib_ibuf_merged_rec.value
Use of uninitialized value in printf at /etc/munin/plugins/mysql_innodb_insert_buf line 885.
ib_ibuf_merges.value
```
#### related issue

https://github.com/kjellm/munin-mysql/issues/34#issuecomment-1487824
