### PR TITLE
master: do not use -p $port if unset in ssh url

### DIFF
--- a/master/lib/Munin/Master/Node.pm
+++ b/master/lib/Munin/Master/Node.pm
@@ -97,8 +97,12 @@ sub _do_connect {
 	    my $user_part = ($uri->user) ? ($uri->user . "@") : "";
 	    my $remote_cmd = ($uri->path ne '/') ? $uri->path : "";
 
+	    # we use $uri->_port and not $uri->port to have the raw, and avoid
+	    # the default being substituted if empty
+	    my $remote_port = ($uri->_port) ? " -p $uri->_port" : "";
+
 	    # Add any parameter to the cmd
-	    my $remote_connection_cmd = $ssh_command . " -p " . $uri->port . " " . $user_part . $uri->host . " " . $remote_cmd . " " . $params;
+	    my $remote_connection_cmd = $ssh_command . $remote_port . " " . $user_part . $uri->host . " " . $remote_cmd . " " . $params;
 
 	    # Open a triple pipe
    	    use IPC::Open3;


### PR DESCRIPTION
If the port part is not specified in the address url, we should not
substitute it to 22.

This enables the choice to be made in /etc/ssh/ssh_config
