### PR TITLE
Fix ping_ plugin's documentation to use _warning.

### DIFF
--- a/plugins/node.d/ping_.in
+++ b/plugins/node.d/ping_.in
@@ -11,14 +11,14 @@ ping_ - Plugin to monitor ping times
 
 The following environment variables are used by this plugin
 
- ping_args       - Arguments to ping (default "-c 2")
- ping_args2      - Arguments after the host name (required for Solaris)
- ping            - Ping program to use
- host            - Host to ping. By default taken from command name.
- ping_warn       - Warning limit for nagios notification
- ping_crit       - Critical limit for nagios notification
- packetloss_warn - Warning limit for nagios notification
- packetloss_crit - Critical limit for nagios notification
+ ping_args           - Arguments to ping (default "-c 2")
+ ping_args2          - Arguments after the host name (required for Solaris)
+ ping                - Ping program to use
+ host                - Host to ping. By default taken from command name.
+ ping_warning        - Warning limit for nagios notification
+ ping_critical       - Critical limit for nagios notification
+ packetloss_warning  - Warning limit for nagios notification
+ packetloss_critical - Critical limit for nagios notification
 
 =head2 CONFIGURATION EXAMPLES
 


### PR DESCRIPTION
The ping_ pluging recommended to use env.ping_warn and env.ping_crit in
/etc/munin/plugin-conf.d/conffile, but really it should be
env.ping_warning and env.ping_critical.

The plugin.sh file only looks for *_warning and *_critical, not *_warn
and *_crit.

This fix is for this ticket:
http://munin-monitoring.org/ticket/1353
