### PR TITLE
master: keep warning if cdef has $ds_name as a component

### DIFF
--- a/master/lib/Munin/Master/UpdateWorker.pm
+++ b/master/lib/Munin/Master/UpdateWorker.pm
@@ -610,6 +610,9 @@ sub _update_rrd_files {
 	    if (defined($service_data) and defined($service_data->{$ds_name})) {
 		$last_timestamp = max($last_timestamp, $self->_update_rrd_file($rrd_file, $ds_name, $service_data->{$ds_name}));
 	    }
+           elsif (defined $ds_config->{cdef} && $ds_config->{cdef} !~ /\b${ds_name}\b/) {
+               DEBUG "[DEBUG] Service $service on $nodedesignation label $ds_name is synthetic";
+           }
 	    else {
 		WARN "[WARNING] Service $service on $nodedesignation returned no data for label $ds_name";
 	    }


### PR DESCRIPTION
As kjetilho noticed on IRC :

```
< kjetilho> still looking at this from munin-update:  [WARNING] Service ece_cache.Global on n*...no/n*..no:4949 returned no data for label articlexml_ratio
< kjetilho> shouldn't _update_rrd_files skip services which has set .cdef in config ?
< kjetilho> sorry, skip ds_names where ds_var is "cdef"
< TheSnide> kjetilho: nope.
< kjetilho> what should the plugin do, then?
< kjetilho> to make the warning go away
< kjetilho> ah right.  so we have stuff like ntp_offset.delay.cdef delay,1000,/
```

< kjetilho> so I guess we could keep the warning if the cdef has $ds_name as a component
