### PR TITLE
Add format string for sensors that have humidity data

### DIFF
--- a/plugins/node.d/digitemp_.in
+++ b/plugins/node.d/digitemp_.in
@@ -58,7 +58,7 @@ if [ "$1" = "config" ]; then
     echo 'graph_vlabel degrees C'
     echo 'graph_category sensors'
     echo "graph_info This graph shows the temperature read from $model 1-wire sensors"
-    $digitemp -c "$digitemprc" -q -a -o '%s %R' | grep -v ^Found | while read sensor serial; do
+    $digitemp -c "$digitemprc" -q -a -o '%s %R' -H '%s %R' | grep -v ^Found | while read sensor serial; do
 	echo "sensor$serial.label sensor #$sensor"
 	echo "sensor$serial.type GAUGE"
 	echo "sensor$serial.info Temperature from sensor #$sensor"
@@ -68,4 +68,4 @@ if [ "$1" = "config" ]; then
    exit 0
 fi
 
-$digitemp -c "$digitemprc" -q -a -o 'sensor%R.value %C'|grep -v ^Found
+$digitemp -c "$digitemprc" -q -a -o 'sensor%R.value %C' -H 'sensor%R.value %C'|grep -v ^Found


### PR DESCRIPTION
When using combined temp/humidity sensors the -o format string
is not used. To get the temperature from such sensors in the
proper format for munin to use, a second format string (-H) has
to be provided.
