### PR TITLE
fix a handful of problems in rrdcopy

### DIFF
--- a/contrib/rrdcopy
+++ b/contrib/rrdcopy
@@ -107,7 +107,7 @@ for (my $epoch = $start; $epoch <= $stop; $epoch += $step_sample) {
 		print "Data:\n";
 	}
 
-        $fetched_epoch -= $fetched_step;
+	$fetched_epoch -= $fetched_step;
 
 	for my $line ( @$data ) {
 		$fetched_epoch += $fetched_step;


### PR DESCRIPTION
rrdcopy is a great start, but as it is in git, it isn't actually capable of migrating a Munin "normal" rrd to a "huge" rrd.  These changes fix rrdcopy so that it can copy normal->huge and huge->huge (normal->normal and custom haven't been tested).  I also added a bit to the documentation that might be obvious to some, but would have saved some time on IRC.
