### PR TITLE
Clean field names

### DIFF
--- a/plugins/node.d.linux/proc.in
+++ b/plugins/node.d.linux/proc.in
@@ -560,11 +560,11 @@ sub set_run
         $procuniq[$i] = clean_fieldname("$procname[$i]");
         if (length($procargs[$i]) > 0 ) {
             $proctitlec[$i] = "$proctitlec[$i] $procargs[$i]";
-            $procuniq[$i] = $procuniq[$i]."_".$procargs[$i];
+            $procuniq[$i] = $procuniq[$i]."_".clean_fieldname($procargs[$i]);
         }
         if (length($procuser[$i]) > 0 ) {
             $proctitlec[$i] = "$proctitlec[$i] by $procuser[$i]";
-            $procuniq[$i] = $procuniq[$i]."___".$procuser[$i];
+            $procuniq[$i] = $procuniq[$i]."___".clean_fieldname($procuser[$i]);
             $useruid{$procuser[$i]} = `getent passwd $procuser[$i] | cut -d : -f 3`;
             chomp($useruid{$procuser[$i]});
         }


### PR DESCRIPTION
Non-clean field names cause problems with drawing, e.g. when there are spaces
or dashes in the process name. This commit cleans the field name by using the
appropriate support module. For more information, see:

http://munin-monitoring.org/wiki/notes_on_datasource_names
