### PR TITLE
This corrects the truncating of negative values in the diskstats plugin

### DIFF
--- a/plugins/node.d.linux/diskstats.in
+++ b/plugins/node.d.linux/diskstats.in
@@ -148,6 +148,28 @@ sub add_new_state {
     return;
 }
 
+# subtract_wrapping_numbers
+#
+# Will subtract two numbers, but takes into account that the numbers
+# are represented as either a 32-bit value which wraps at 2 ** 32 - 1,
+# or a 64-bit value.
+
+sub subtract_wrapping_numbers {
+    my ( $cur_value, $prev_value ) = @_;
+
+    return $cur_value - $prev_value if $cur_value >= $prev_value;
+
+    # The numbers seems to have wrapped.
+    if ($prev_value <= 2 ** 32) {
+        # Unsigned int wraps here.
+        $cur_value += 2 ** 32;
+    } else {
+        $cur_value += 2 ** 64;
+    }
+
+    return $cur_value - $prev_value;
+}
+
 # calculate_values
 #
 # Calculates all data that get's graphed
@@ -159,16 +181,16 @@ sub calculate_values {
 
     my $interval = time() - $prev_time;
 
-    my $read_ios  = $cur_stats->{'rd_ios'} - $prev_stats->{'rd_ios'};
-    my $write_ios = $cur_stats->{'wr_ios'} - $prev_stats->{'wr_ios'};
+    my $read_ios  = subtract_wrapping_numbers($cur_stats->{'rd_ios'}, $prev_stats->{'rd_ios'});
+    my $write_ios = subtract_wrapping_numbers($cur_stats->{'wr_ios'}, $prev_stats->{'wr_ios'});
 
-    my $rd_ticks = $cur_stats->{'rd_ticks'} - $prev_stats->{'rd_ticks'};
-    my $wr_ticks = $cur_stats->{'wr_ticks'} - $prev_stats->{'wr_ticks'};
+    my $rd_ticks = subtract_wrapping_numbers($cur_stats->{'rd_ticks'}, $prev_stats->{'rd_ticks'});
+    my $wr_ticks = subtract_wrapping_numbers($cur_stats->{'wr_ticks'}, $prev_stats->{'wr_ticks'});
 
-    my $rd_sectors = $cur_stats->{'rd_sectors'} - $prev_stats->{'rd_sectors'};
-    my $wr_sectors = $cur_stats->{'wr_sectors'} - $prev_stats->{'wr_sectors'};
+    my $rd_sectors = subtract_wrapping_numbers($cur_stats->{'rd_sectors'}, $prev_stats->{'rd_sectors'});
+    my $wr_sectors = subtract_wrapping_numbers($cur_stats->{'wr_sectors'}, $prev_stats->{'wr_sectors'});
 
-    my $tot_ticks = $cur_stats->{'tot_ticks'} - $prev_stats->{'tot_ticks'};
+    my $tot_ticks = subtract_wrapping_numbers($cur_stats->{'tot_ticks'}, $prev_stats->{'tot_ticks'});
 
     my $read_io_per_sec  = $read_ios / $interval;
     my $write_io_per_sec = $write_ios / $interval;
@@ -194,13 +216,6 @@ sub calculate_values {
       $total_ios ? ( $rd_ticks + $wr_ticks ) / $total_ios / 1000 : 0;
     my $average_rd_wait_in_sec = $read_ios  ? $rd_ticks / $read_ios / 1000  : 0;
     my $average_wr_wait_in_sec = $write_ios ? $wr_ticks / $write_ios / 1000 : 0;
-
-    if ( $average_rd_wait_in_sec < 0 ) {
-      $average_rd_wait_in_sec = 0;
-    }
-    if ( $average_wr_wait_in_sec < 0 ) {
-      $average_wr_wait_in_sec = 0;
-    }
 
     my $average_rd_rq_size_in_kb =
       $read_ios ? $rd_sectors * $bytes_per_sector / 1000 / $read_ios : 0;


### PR DESCRIPTION
and calculates its value based on the evidence that this is a overflow
value.

This patch was created by ksmadsen in
http://munin-monitoring.org/ticket/1275

The description provided was:

I've traced this problem to the fact that on the RH kernel we are using,
the rd_ticks/wr_ticks in /sys/block/*/stat are 32-bit numbers, so when
the ticks wraps, a negative value is reported.

Looking at the kernel source code, the tick counters are internally all
64-bit, but when they are read from the stat file, the output is limited
to 32-bits.
