### PR TITLE
add support for subsections

### DIFF
--- a/plugins/node.d/mysql_.in
+++ b/plugins/node.d/mysql_.in
@@ -1113,6 +1113,9 @@ my $innodb_bigint_rx = qr{([[a-fA-F\d]+)(?: (\d+))?};
 sub match_dashes { return m/\G-+\n(?!-)/gc; }
 
 
+sub match_subsection { return m/\G-+[ a-zA-Z]+-+\n/gc; }
+
+
 sub skip_line    { return m/\G.*\n/gc; }
 
 
@@ -1126,10 +1129,17 @@ sub skip_heading {
 
 sub parse_section {
     my ($parser) = @_;
-
+    my $in_subsection = 0;
     #warn substr($_, pos(), 10);
     for (;;) {
-	return if match_dashes();
+        $in_subsection = $in_subsection || match_subsection();
+        if (match_dashes()) {
+           if ($in_subsection) {
+              $in_subsection = 0;
+           } else {
+              return;
+           }
+        }
 	next if $parser->();
 	skip_line();
     }


### PR DESCRIPTION
SHOW ENGINE INNODB STATUS in percona 5.5 may include subsections such as below which breaks the current parser.  Only tested against the data below, so may have unintended consequences.

---
## ROW OPERATIONS

0 queries inside InnoDB, 0 queries in queue
1 read views open inside InnoDB
---OLDEST VIEW---
Normal read view
Read view low limit trx n:o 99B6EF2
Read view up limit trx id 99B6EF2
Read view low limit trx id 99B6EF2
## Read view individually stored trx ids:

Main thread process no. 3328, id 140214808643328, state: flushing log
Number of rows inserted 145554, updated 735808, deleted 25854, read 7725121678
## 0.00 inserts/s, 0.00 updates/s, 0.00 deletes/s, 0.00 reads/s
