### PR TITLE
added --servicedir cli switch to munin-node

### DIFF
--- a/node/sbin/munin-node
+++ b/node/sbin/munin-node
@@ -35,12 +35,12 @@ use Munin::Node::OS;
 use Munin::Node::Service;
 use Munin::Node::Server;
 
-my $servicedir;
-my $sconfdir = "$Munin::Common::Defaults::MUNIN_CONFDIR/plugin-conf.d";
-my $conffile = "$Munin::Common::Defaults::MUNIN_CONFDIR/munin-node.conf";
-my $DEBUG    = 0;
-my $PIDEBUG  = 0;
-my $paranoia = 0;
+my $servicedir = "$Munin::Common::Defaults::MUNIN_CONFDIR/plugins";
+my $sconfdir   = "$Munin::Common::Defaults::MUNIN_CONFDIR/plugin-conf.d";
+my $conffile   = "$Munin::Common::Defaults::MUNIN_CONFDIR/munin-node.conf";
+my $DEBUG      = 0;
+my $PIDEBUG    = 0;
+my $paranoia   = 0;
 
 sub main
 {
@@ -101,6 +101,7 @@ sub parse_args
 
     print_usage_and_exit() unless GetOptions(
         "config=s"     => \$conffile,
+        "servicedir=s" => \$servicedir,
         "debug!"       => \$DEBUG,
         "pidebug!"     => \$PIDEBUG,
         "paranoia!"    => \$paranoia,
@@ -165,6 +166,10 @@ and returning the output they produce.
 =item B<< --config <configfile> >>
 
 Use E<lt>fileE<gt> as configuration file. [@@CONFDIR@@/munin-node.conf]
+
+=item B<< --servicedir <dir> >>
+
+Override plugin directory [@@CONFDIR@@/plugins/]
 
 =item B< --[no]paranoia >
 


### PR DESCRIPTION
The same switch was in munin-node-configure but not in munin-node. Copied over the GetOptions() line, the default value and the pod docs.

Requested by this kind chap @iElectric.
