### PR TITLE
/node.d/tomcat_threads.in: Fix if {'currentThreadsBusy'} go false when i...

### DIFF
--- a/plugins/node.d/tomcat_threads.in
+++ b/plugins/node.d/tomcat_threads.in
@@ -119,7 +119,7 @@ if($xml->{'connector'}->{$CONNECTOR}->{'threadInfo'}->[0]->{'currentThreadsBusy'
 } else {
     print "busy.value U\n";
     print "idle.value U\n";
-    print "total.value U\n";
+    print "total.value  U\n";
 }
 
 # vim:syntax=perl


### PR DESCRIPTION
/node.d/tomcat_threads.in: Fix if {'currentThreadsBusy'} go false when it is 0, and add a total value as 'currentThreadCount' so that the chart looks more readable.
