### PR TITLE
Add a lower limit of 0 to postgres database size

### DIFF
--- a/plugins/node.d/postgres_size_.in
+++ b/plugins/node.d/postgres_size_.in
@@ -30,6 +30,12 @@ PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
 To monitor a specific database, link to postgres_size_<databasename>.
 To monitor all databases, link to postgres_size_ALL.
 
+Since munin 2.0.18, this graph starts at 0 (zero) on the y-axis. If you want
+to restore the old behaviour, then set in the plugin config:
+
+ [postgres_size_*]
+ env.legacy_y_axis yes
+
 =head1 SEE ALSO
 
 L<Munin::Plugin::Pgsql>
@@ -59,6 +65,8 @@ use warnings;
 
 use Munin::Plugin::Pgsql;
 
+my $graphmin = ($ENV{'legacy_y_axis'} ? undef : '0');
+
 my $pg = Munin::Plugin::Pgsql->new(
     basename => 'postgres_size_',
     title    => 'PostgreSQL database size',
@@ -73,7 +81,7 @@ my $pg = Munin::Plugin::Pgsql->new(
     graphdraw => 'AREA',
     stack     => 1,
     base      => 1024,
-    graphmin  => 0
+    graphmin  => $graphmin
 );
 
 $pg->Process();


### PR DESCRIPTION
This ensures that the graph always starts at 0 in stead of somewhere near the
smallest database size. This makes sure that database sizes are shown
proportionally correct.
