### PR TITLE
Allow spaces in the mount point in the plugin 'df'

### DIFF
--- a/plugins/node.d.linux/df.in
+++ b/plugins/node.d.linux/df.in
@@ -146,7 +146,8 @@ while (<DF>) {
     next if m{//};
 
     # Parse the output
-    my ($name, undef, $used, $avail, undef, $mountpt, undef) = split(/\s+/, $_, 7);
+    chomp($_);
+    my ($name, undef, $used, $avail, undef, $mountpt) = split(/\s+/, $_, 6);
 
     next if skip($name, $mountpt);
 


### PR DESCRIPTION
The "df" plugin on linux only shows the first part of the mount point when it contains spaces.
This change should fix it and 
