### PR TITLE
native ssh transport should not override .ssh/config by default

### DIFF
--- a/master/lib/Munin/Master/Node.pm
+++ b/master/lib/Munin/Master/Node.pm
@@ -96,10 +96,11 @@ sub _do_connect {
     } elsif ($uri->scheme eq "ssh") {
 	    my $ssh_command = "ssh -o ChallengeResponseAuthentication=no -o StrictHostKeyChecking=no ";
 	    my $user_part = ($uri->user) ? ($uri->user . "@") : "";
+	    my $port_part = ($uri->port != 22) ? (" -p " . $uri->port) : "";
 	    my $remote_cmd = ($uri->path ne '/') ? $uri->path : "";
 
 	    # Add any parameter to the cmd
-	    my $remote_connection_cmd = $ssh_command . " -p " . $uri->port . " " . $user_part . $uri->host . " " . $remote_cmd . " " . $params;
+	    my $remote_connection_cmd = $ssh_command . $port_part . " " . $user_part . $uri->host . " " . $remote_cmd . " " . $params;
 
 	    # Open a triple pipe
    	    use IPC::Open3;


### PR DESCRIPTION
This patch makes the native SSH transport's port and username handling consistent; they'll both use settings from .ssh/config unless explicitly overridden in the URI. Adding "-p 22" on the SSH command line broke this for non-standard port assignments.
