### PR TITLE
fix irqstats

### DIFF
--- a/plugins/node.d.linux/irqstats.in
+++ b/plugins/node.d.linux/irqstats.in
@@ -50,6 +50,7 @@ GPLv2
 =cut
 
 use Munin::Plugin;
+use Scalar::Util qw(looks_like_number);
 use strict;
 
 if (defined $ARGV[0] && $ARGV[0] eq 'autoconf') {
@@ -92,7 +93,7 @@ my @irqs;
 
 sub sum (@) {
     my $sum = 0;
-    $sum += $_ || 0 for @_;	# Avoid complaints about empty strings
+    $sum += (looks_like_number($_) ? $_ : 0) || 0 for @_;	# Avoid complaints about empty strings
     return $sum;
 }
 


### PR DESCRIPTION
my `/proc/interupts` looks like the following:

```
           CPU0       
  3:   10494710   ARMCTRL  BCM2708 Timer Tick
 32:   75437760   ARMCTRL  dwc_otg, dwc_otg_pcd, dwc_otg_hcd:usb1
 52:          0   ARMCTRL  BCM2708 GPIO catchall handler
 65:     461242   ARMCTRL  ARM Mailbox IRQ
 66:      33844   ARMCTRL  VCHIQ doorbell
 75:          1   ARMCTRL
 77:    2412182   ARMCTRL  bcm2708_sdhci (dma)
 83:         19   ARMCTRL  uart-pl011
 84:    3222800   ARMCTRL  mmc0
FIQ:              usb_fiq
Err:          0
```

In the `FIQ` row there is no number so i get these warning messages from `munin-node.log`:

```
2013/12/07-06:28:55 [4973] Error output from irqstats:
2013/12/07-06:28:55 [4973]      Argument "usb_fiq" isn't numeric in addition (+) at /etc/munin/plugins/irqstats line 95, <$in> line 11.
```

This pull request fixes these warnings
