### PR TITLE
proc plugin - Remove unrecognised symbols from "$procuniq"

### DIFF
--- a/plugins/node.d.linux/proc.in
+++ b/plugins/node.d.linux/proc.in
@@ -541,7 +541,7 @@ sub set_run
             $useruid{$procuser[$i]} = `getent passwd $procuser[$i] | cut -d : -f 3`;
             chomp($useruid{$procuser[$i]});
         }
-        $procuniq[$i] =~ s/[^a-zA-Z0-9_]//g;
+        $procuniq[$i] = clean_fieldname($procuniq[$i]);
         $i++;
     }
 }


### PR DESCRIPTION
Errors in log files and can't draw images, but removing some symbols in "$procuniq[$i]" (everything which is not not "a-zA-Z0-9_" internal variable removes some problems.
Removed symbols are minuses, dots, slashes,... probably need to add more for different cases, but in mine this was the problem.
My setup: nginx + FastCGI to generate PNGs and HTMLs
Example what procs I am drawing:
java -Djava.util.logging.config.file=/opt/tomcat-1/conf
So, there are lot of similar java processes, and grep line (procargs) was "tomcat-1/", now internal name for this replaced to "tomcat1" 
