### PR TITLE
Use perl instead of GNU sed; fix spelling error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ install-doc: build-doc
 # Dummy rule to enable parallel building
 infiles: $(INFILES)
 
-build: infiles build-master build-common-prime build-node build-plugins $(JAVA_BUILD) build-man substitue-confvar-inline
+build: infiles build-master build-common-prime build-node build-plugins $(JAVA_BUILD) build-man substitute-confvar-inline
 
 build/%: %.in
 	@echo "$< -> $@"
@@ -257,38 +257,37 @@ build/%: %.in
 
 build-common-prime: build-common-pre common/blib/lib/Munin/Common/Defaults.pm build-common
 
-substitue-confvar-inline:
-	@sed -e 's|@@PREFIX@@|$(PREFIX)|g'                      \
-             -e 's|@@CONFDIR@@|$(CONFDIR)|g'                    \
-             -e 's|@@BINDIR@@|$(BINDIR)|g'                      \
-             -e 's|@@SBINDIR@@|$(SBINDIR)|g'                    \
-             -e 's|@@DOCDIR@@|$(DOCDIR)|g'                      \
-             -e 's|@@LIBDIR@@|$(LIBDIR)|g'                      \
-             -e 's|@@MANDIR@@|$(MANDIR)|g'                      \
-             -e 's|@@LOGDIR@@|$(LOGDIR)|g'                      \
-             -e 's|@@HTMLDIR@@|$(HTMLDIR)|g'                    \
-             -e 's|@@DBDIR@@|$(DBDIR)|g'                        \
-             -e 's|@@STATEDIR@@|$(STATEDIR)|g'                  \
-             -e 's|@@SPOOLDIR@@|$(SPOOLDIR)|g'                  \
-             -e 's|@@PERL@@|$(PERL)|g'                          \
-             -e 's|@@PERLLIB@@|$(PERLLIB)|g'                    \
-             -e 's|@@PYTHON@@|$(PYTHON)|g'                      \
-             -e 's|@@RUBY@@|$(RUBY)|g'                          \
-             -e 's|@@JAVARUN@@|$(JAVARUN)|g'                    \
-             -e 's|@@JAVALIBDIR@@|$(JAVALIBDIR)|g'              \
-             -e 's|@@OSTYPE@@|$(OSTYPE)|g'                      \
-             -e 's|@@HOSTNAME@@|$(HOSTNAME)|g'                  \
-             -e 's|@@MKTEMP@@|$(MKTEMP)|g'                      \
-             -e 's|@@VERSION@@|$(VERSION)|g'                    \
-             -e 's|@@PLUGSTATE@@|$(PLUGSTATE)|g'                \
-             -e 's|@@CGIDIR@@|$(CGIDIR)|g'                      \
-             -e 's|@@USER@@|$(USER)|g'                          \
-             -e 's|@@GROUP@@|$(GROUP)|g'                        \
-             -e 's|@@PLUGINUSER@@|$(PLUGINUSER)|g'              \
-             -e 's|@@GOODSH@@|$(GOODSH)|g'                      \
-             -e 's|@@BASH@@|$(BASH)|g'                          \
-             -e 's|@@HASSETR@@|$(HASSETR)|g'                    \
-             --in-place                                         \
+substitute-confvar-inline:
+	@perl -p -i -e 's|\@\@PREFIX\@\@|$(PREFIX)|g;'               \
+             -e 's|\@\@CONFDIR\@\@|$(CONFDIR)|g;'                    \
+             -e 's|\@\@BINDIR\@\@|$(BINDIR)|g;'                      \
+             -e 's|\@\@SBINDIR\@\@|$(SBINDIR)|g;'                    \
+             -e 's|\@\@DOCDIR\@\@|$(DOCDIR)|g;'                      \
+             -e 's|\@\@LIBDIR\@\@|$(LIBDIR)|g;'                      \
+             -e 's|\@\@MANDIR\@\@|$(MANDIR)|g;'                      \
+             -e 's|\@\@LOGDIR\@\@|$(LOGDIR)|g;'                      \
+             -e 's|\@\@HTMLDIR\@\@|$(HTMLDIR)|g;'                    \
+             -e 's|\@\@DBDIR\@\@|$(DBDIR)|g;'                        \
+             -e 's|\@\@STATEDIR\@\@|$(STATEDIR)|g;'                  \
+             -e 's|\@\@SPOOLDIR\@\@|$(SPOOLDIR)|g;'                  \
+             -e 's|\@\@PERL\@\@|$(PERL)|g;'                          \
+             -e 's|\@\@PERLLIB\@\@|$(PERLLIB)|g;'                    \
+             -e 's|\@\@PYTHON\@\@|$(PYTHON)|g;'                      \
+             -e 's|\@\@RUBY\@\@|$(RUBY)|g;'                          \
+             -e 's|\@\@JAVARUN\@\@|$(JAVARUN)|g;'                    \
+             -e 's|\@\@JAVALIBDIR\@\@|$(JAVALIBDIR)|g;'              \
+             -e 's|\@\@OSTYPE\@\@|$(OSTYPE)|g;'                      \
+             -e 's|\@\@HOSTNAME\@\@|$(HOSTNAME)|g;'                  \
+             -e 's|\@\@MKTEMP\@\@|$(MKTEMP)|g;'                      \
+             -e 's|\@\@VERSION\@\@|$(VERSION)|g;'                    \
+             -e 's|\@\@PLUGSTATE\@\@|$(PLUGSTATE)|g;'                \
+             -e 's|\@\@CGIDIR\@\@|$(CGIDIR)|g;'                      \
+             -e 's|\@\@USER\@\@|$(USER)|g;'                          \
+             -e 's|\@\@GROUP\@\@|$(GROUP)|g;'                        \
+             -e 's|\@\@PLUGINUSER\@\@|$(PLUGINUSER)|g;'              \
+             -e 's|\@\@GOODSH\@\@|$(GOODSH)|g;'                      \
+             -e 's|\@\@BASH\@\@|$(BASH)|g;'                          \
+             -e 's|\@\@HASSETR\@\@|$(HASSETR)|g;'                    \
              ./master/blib/libdoc/Munin::Master::HTMLOld.3pm    \
              ./master/blib/lib/Munin/Master/HTMLOld.pm          \
              ./node/blib/sbin/munin-node-configure              \


### PR DESCRIPTION
This changeset is already merged in the stable-2.0 branch so it should also gi to devel.
- Use Perl to replace configuration variables in place instead of GNU sed to
  help some poor souls without a proper GNU installation. This solves
  ticket:1403, thanks to sthen for the report.
- Also fix my previous spelling error: substitue vs. substitute. Again thanks to sthen :)
