### PR TITLE
Update snmp__df.in

### DIFF
--- a/plugins/node.d/snmp__df.in
+++ b/plugins/node.d/snmp__df.in
@@ -185,7 +185,9 @@ foreach my $storage (keys %$stor_id)
 
 foreach my $part (keys %partitions)
 {
-    print (&get_name_by_mp ($part), ".value ", ($partitions{$part}{used}*100/$partitions{$part}{size}), "\n");
+    my $used = $partitions{$part}{used} < 0 ? ($partitions{$part}{used}+4294967296) : $partitions{$part}{used};
+    my $size = $partitions{$part}{size} < 0 ? ($partitions{$part}{size}+4294967296) : $partitions{$part}{size};
+    print (&get_name_by_mp ($part), ".value ", ($used*100/$size), "\n");
 }
 
 sub get_single


### PR DESCRIPTION
Handle large partitions.

hrStorageSize and hrStorageUsed might "wrap around". 
Example:
pj_.value 211.998954212829
pi_.value -13.1452642689504

Both values are bonkers.

By adding the patch, I get this:
pj_.value 68.6950857122177
pi_.value 7.88728932007461

Which is what the correct percentage usage is.
