### PR TITLE
Add filename to debug output for tail_open()

### DIFF
--- a/plugins/lib/Munin/Plugin.pm
+++ b/plugins/lib/Munin/Plugin.pm
@@ -420,7 +420,7 @@ sub tail_open ($$) {
 
     my $size = (stat($file))[7];
 
-    warn "**Size is $size\n" if $DEBUG;
+    warn "**Size of $file is $size\n" if $DEBUG;
 
     if (!defined($size)) {
 	warn "$me: Could not stat input file '$file': $!\n";


### PR DESCRIPTION
It is helpful to see the detected size of a file in DEBUG mode, but even better to see which file this size belongs to.
