### PR TITLE
Only get non-parameter parts of @ARGV to @graphs (Fix #1418)

### DIFF
--- a/master/_bin/munin-graph.in
+++ b/master/_bin/munin-graph.in
@@ -85,7 +85,13 @@ my $nb_request = 0;
 my $nb_request_max = 0;
 
 # Use args urls. If none specified, revert to plain graph
-my @graphs = @ARGV;
+my @graphs;
+foreach (@ARGV) {
+	if ( $_ !~ /^--/ ) {
+		push(@graphs, $_);
+	}
+}
+
 if (! @graphs) {
 	my $fh = new IO::File($config->{dbdir} . "/graphs");
 


### PR DESCRIPTION
- munin-graph expects ether no cli parameter at all or a specific string which
  graph to render. When called with --debug or any other parameter it throws
  error messages to the log and does not render the graphs.
  
  This patch changes this. It pushes only params from @ARGV to @graphs which
  doesn't start with --.
  See trac ticket #1418 .
