### PR TITLE
Quota usage: map soft/hard quotas to warning/critical thresholds

### DIFF
--- a/plugins/node.d.linux/quota_usage_.in
+++ b/plugins/node.d.linux/quota_usage_.in
@@ -54,22 +54,22 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
 	print "graph_category disk\n";
 	for my $user (@users_by_usage) {
 		my ($uid, $name) = (getpwnam($user))[2,6];
+		my $id = clean_fieldname($user);
 		$name = $user if (length($name) < length($user));
-		$user = clean_fieldname($user);
 		$name = (split(/,/, $name))[0];
 
-		printf "%s.label %s\n", $user, $name;
-		printf "%s.cdef %s,1024,*\n", $user, $user;
+		printf "%s.label %s\n", $id, $name;
+		printf "%s.cdef %s,1024,*\n", $id, $id;
 
 		if ($users{$user}[1] && $users{$user}[1] > 0) {
-		  printf "%s.warning %s\n", $user, $users{$user}[1];
+		  printf "%s.warning %s\n", $id, $users{$user}[1];
 		}
 		if ($users{$user}[2] && $users{$user}[2] > 0) {
-		  printf "%s.critical %s\n", $user, $users{$user}[2];
+		  printf "%s.critical %s\n", $id, $users{$user}[2];
 		}
 
 		if ($uid < 200) {
-		  printf "%s.graph no\n", $user
+		  printf "%s.graph no\n", $id
 		}
 	}
 } else {


### PR DESCRIPTION
Hi,

this change maintains the warning/critical thresholds on the quota usage using configured soft/hard quotas.

I am using this change in production since 8 months, with no problems. I also managed to got this patch included in [OpenSUSE's server:monitoring package](https://build.opensuse.org/package/show/server:monitoring/munin).
