### PR TITLE
remove several race conditions around lock file by opening it once

### DIFF
--- a/master/lib/Munin/Master/Utils.pm
+++ b/master/lib/Munin/Master/Utils.pm
@@ -191,7 +191,7 @@ sub munin_getlock {
 	    $pid = $1;
 	    kill(0, $pid);
 	    # Ignore ESRCH as not found is as good as if it worked
-	    if ($! == EPERM)) {
+	    if ($! == EPERM) {
 		LOGCROAK("[FATAL ERROR] kill -0 $pid attempted - it is still alive and we can't kill it. Locking failed.\n");
 		close LOCK;
 	        return 0;


### PR DESCRIPTION
During a strace of munin-limits and munin-update I saw several race conditions around the locking mechanism:

<pre>
stat("/usr/local/munin/openquery/var/run/munin-datafile.lock", 0x1e42130) = -1 ENOENT (No such file or directory)
open("/usr/local/munin/openquery/var/run/munin-datafile.lock", O_WRONLY|O_CREAT|O_EXCL, 0666) = 6
....
unlink("/usr/local/munin/openquery/var/run/munin-datafile.lock") = 0
</pre>


While the comment in munin_getlock reflects one behavior, this may not be the case. I'm currently using munin-update/munin-limits in a ssh forced command after an ssh-rsync across.

```
   # To check this is inteligent and so on.  It also makes for a
   # nice locking racing-condition.  BUT, since munin-* runs from
   # cron every 5 minutes this should not be a real threat.  This
   # ream of code should complete in less than 5 minutes.
```

The attached code opens the file once for read/write, and closes with the PID written in or fails.
