### PR TITLE
Fix unreasonable die in iostat_io plugin for linux

### DIFF
--- a/plugins/node.d.linux/iostat_ios.in
+++ b/plugins/node.d.linux/iostat_ios.in
@@ -121,11 +121,10 @@ sub get_ios {
 
     if (-r "/proc/diskstats") {
         $kernel = 2.6;
-        $parts = new IO::File("/proc/diskstats") || die();
+        $parts = new IO::File("/proc/diskstats") || die("unable to open /proc/diskstats\n");
     } else {
         $kernel = 2.4;
-        $parts = new IO::File("/proc/partitions");
-        die("kernel $kernel not supported yet\n");
+        $parts = new IO::File("/proc/partitions") || die("unable to open /proc/partitions\n");
     }
 
     unless ($parts) {


### PR DESCRIPTION
If `/proc/diskstats` is unreadable by some reasons, iostat_ios fallbacks to `/proc/partitions` and dies without give a change to read data from it with very weird reason. Better not to say users that their kernel isn't supported, but what feature is required to have such support.
