### PR TITLE
Add Airflow_Temperature_Cel as temperature reading

### DIFF
--- a/plugins/node.d/hddtemp_smartctl.in
+++ b/plugins/node.d/hddtemp_smartctl.in
@@ -238,6 +238,9 @@ foreach my $drive (@drives) {
   } elsif ($output =~ /^(231 Temperature_Celsius.*)/m) {
     my @F = split ' ', $1;
     print "$drive.value $F[9]\n";
+  } elsif ($output =~ /^(190 Airflow_Temperature_Cel.*)/m) {
+    my @F = split ' ', $1;
+    print "$drive.value $F[9]\n";
   } else {
       print "$drive.value U\n";
       print "$drive.extinfo Temperature not detected in smartctl output\n";


### PR DESCRIPTION
Samsung SSD 830 Pro (at least) only provides Airflow_Temperature_Cel from smartctl
