### PR TITLE
Update dhcpd3.in

### DIFF
--- a/plugins/node.d/dhcpd3.in
+++ b/plugins/node.d/dhcpd3.in
@@ -53,7 +53,7 @@ of a subnet definition (Munin trac ticket #829)
 
 =head1 AUTHOR
 
-Rune Nordbøe Skillingstad.
+Rune Nordbï¿½e Skillingstad.
 
 =head1 LICENSE
 
@@ -141,8 +141,8 @@ if($ARGV[0] and $ARGV[0] eq "config") {
 	print "$network.min 0\n";
 	print "$network.max " . $limits{$network} ."\n"
 	  if ($limits{$network} > 0);
-	my $warn = int($limits{$network} * 0.9);
-	my $crit = int($limits{$network} * 0.95);
+	my $warn = int($limits{$network} * $WARNING);
+	my $crit = int($limits{$network} * $CRITICAL);
 	print "$network.warning $warn\n" if $warn;
 	print "$network.critical $crit\n" if $crit;
     }
@@ -170,14 +170,13 @@ sub parseconfig {
 	}
 	if($name && /^\}$/) {
 	    print "# DEBUG: End of subnet... NO RANGE?\n" if $DEBUG;
-	    delete($leases{$name});
+	    delete($leases{$name}) unless $limits{$name} > 0;
 	    $name = "";
 	}
-	if($name && /range\s+((?:\d+\.){3}\d+)\s+((?:\d+\.){3}\d+)/) {
+	if($name && /^\s*range\s+((?:\d+\.){3}\d+)\s+((?:\d+\.){3}\d+)/) {
 	    print "# DEBUG: range $1 -> $2\n" if $DEBUG;
 	    $limits{$name} += &rangecount($1, $2);
 	    print "# DEBUG: limit for $name is " . $limits{$name} . "\n" if $DEBUG;
-	    $name = "";
 	}
 	if(/^include \"([^\"]+)\";/) {
 	    my $includefile = $1;


### PR DESCRIPTION
1. Use $WARNING and $CRITICAL values instead of hardcoded values
2. Don't take into account commented lines with "range" values
3. Allow for networks with multiple definitions of "range"
4. Don't show networks without defined ranges (where only know clients are allowed
