### PR TITLE
Update munin-node

### DIFF
--- a/node/sbin/munin-node
+++ b/node/sbin/munin-node
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -wT
+#!@@PERL@@ -wT
 # -*- cperl -*-
 #
 # Copyright (C) 2002-2009 Audun Ytterdal, Jimmy Olsen, Tore Anderson,


### PR DESCRIPTION
Allow for perl installed on non standard places.

"sed --in-place" call at Makefile line 257 takes care of this.

An alternative is to create a *.in file for this without using "sed --in-place"
