### PR TITLE
Update munin-node-configure

### DIFF
--- a/node/sbin/munin-node-configure
+++ b/node/sbin/munin-node-configure
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!@@PERL@@ -w
 # -*- cperl -*-
 #
 # Copyright (C) 2003-2006 Jimmy Olsen, Nicolai Langfeldt.


### PR DESCRIPTION
Allow for perl installed on non standard places.

"sed --in-place" call at Makefile line 257 takes care of this.

An alternative is to create a *.in file for this without using "sed --in-place"
