### PR TITLE
Update munin-run

### DIFF
--- a/node/sbin/munin-run
+++ b/node/sbin/munin-run
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -T
+#!@@PERL@@ -T
 # -*- perl -*-
 #
 # Copyright (C) 2004-2009


### PR DESCRIPTION
Allow for perl installed on non standard places.

"sed --in-place" call at Makefile line 257 takes care of this.

An alternative is to create a *.in file for this without using "sed --in-place"
