### PR TITLE
Update munin-sched

### DIFF
--- a/node/sbin/munin-sched
+++ b/node/sbin/munin-sched
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -wT
+#!@@PERL@@ -wT
 # -*- cperl -*-
 #
 # Copyright (C) 2002-2010 Audun Ytterdal, Jimmy Olsen, Tore Anderson,


### PR DESCRIPTION
Allow for perl installed on non standard places.

"sed --in-place" call at Makefile line 257 takes care of this.

An alternative is to create a *.in file for this without using "sed --in-place"
