### PR TITLE
Replace Date::Manip::UnixDate with Date::Parse::str2time

### DIFF
--- a/master/_bin/munin-cgi-graph.in
+++ b/master/_bin/munin-cgi-graph.in
@@ -27,11 +27,7 @@ $Id$
 use strict;
 use warnings;
 use IO::Handle;
-BEGIN {
-    no warnings;
-    $Date::Manip::Backend = 'DM5';
-}
-use Date::Manip;
+use Date::Parse;
 use POSIX qw(strftime locale_h);
 use CGI::Fast qw(:cgi);
 use CGI::Carp qw(fatalsToBrowser);
@@ -513,7 +509,7 @@ sub rfctime_newer_than {
     # Format of since_string If-Modified-Since: Wed, 23 Jun 2004 16:11:06 GMT
     my $since_string = shift;
     my $created      = shift;
-    my $ifmodsec = &UnixDate (&ParseDateString ($since_string), "%s");
+    my $ifmodsec = str2time ($since_string);
 
     return 1 if ($ifmodsec < $created);
     return 0;

--- a/master/_bin/munin-graph.in
+++ b/master/_bin/munin-graph.in
@@ -30,16 +30,7 @@ use strict;
 use warnings;
 use IO::Handle;
 
-BEGIN {
-    # This is needed because Date::Manip has deprecated the functional
-    # interface in >= 6.x. So, we force the use of the 5.x API.
-    $Date::Manip::Backend = 'DM5';
-
-    # Double line here to avoid spurious warnings about D::M::Backend being
-    # used only once.
-    $Date::Manip::Backend = 'DM5';
-}
-use Date::Manip;
+use Date::Parse;
 use POSIX qw(strftime);
 use Time::HiRes qw(gettimeofday tv_interval);
 use IO::File;
@@ -333,7 +324,7 @@ sub rfctime_newer_than {
     # Format of since_string If-Modified-Since: Wed, 23 Jun 2004 16:11:06 GMT
     my $since_string = shift;
     my $created      = shift;
-    my $ifmodsec = &UnixDate (&ParseDateString ($since_string), "%s");
+    my $ifmodsec = str2time ($since_string);
 
     return 1 if ($ifmodsec < $created);
     return 0;


### PR DESCRIPTION
From http://munin-monitoring.org/ticket/1389

Terry:

munin-cgi-graph invokes UnixDate? from Date::Manip which invokes the system's date command under a shell. This makes it difficult to create a tight MAC security profile (such as AppArmor? or SELinux) since it becomes necessary to permit Munin to exec a shell, which is a gaping hole.

Christoph:

Also due to the shell execution, Date::Manip is sloooow. On my small test box, the entire Date::Manip::ParseDate? and ::UnixDate? line takes 120 ms, after replacing it with Date::Parse::str2time it is down to 3ms(sic!). Keep in mind this code is run for every graph a browser requests.

Another issue mit Date::Manip is its API change, and at some point in the future the legacy DM5 munin uses might be obsoleted anyway. It should be noted Date::Parse::str2time understands all three timestamp formats as required by RFC 2616 in "3.3.1 Full Date". So if there's really breakage due to weird date strings specified by a client, it's rather their fault. So I'm in strong favour, patch attached. The usage in master/_bin/munin-graph.in appears to be dead code by the way.
