### PR TITLE
master/Update: atomic write datafile with tmp+ren

### DIFF
--- a/master/lib/Munin/Master/Update.pm
+++ b/master/lib/Munin/Master/Update.pm
@@ -268,13 +268,19 @@ sub _write_new_service_configs_locked {
     my $lock_file = "$config->{rundir}/munin-datafile.lock";
     munin_runlock($lock_file);
 
-    open my $dump, '>', $self->{config_dump_file}
-        or croak "Fatal error: Could not open '$self->{config_dump_file}' for writing: $!";
+    my $config_dump_file = $self->{config_dump_file};
+    my $config_dump_file_tmp = "$config_dump_file.$$";
+
+    open my $dump, '>', $config_dump_file_tmp
+        or croak "Fatal error: Could not open '$config_dump_file_tmp' for writing: $!";
 
     $self->_write_new_service_configs($dump);
 
     close $dump
-        or croak "Fatal error: Could not close '$self->{config_dump_file}': $!";
+        or croak "Fatal error: Could not close '$config_dump_file_tmp': $!";
+
+    rename $config_dump_file_tmp, $config_dump_file
+	or croak "Fatal error: Could not rename '$config_dump_file_tmp' to '$config_dump_file': $!";
 
     munin_removelock($lock_file);
 }


### PR DESCRIPTION
As kjetilho noticed on IRC :

```
The problem is that if "munin-limits --force" is run outside munin-cron, it
typically might run while munin-update is writing a new datafile.

As writing a new datafile takes many seconds, munin-limits only sends OK
for a subset of the nodes
```

So now we just use a temporary file, that is updated via a atomic rename().
Note that we should also be able to remove the lock, but let's remain on the
safe side in the stable-2.0 branch.
