### PR TITLE
master: fix kill invocation

### DIFF
--- a/master/lib/Munin/Master/UpdateWorker.pm
+++ b/master/lib/Munin/Master/UpdateWorker.pm
@@ -235,7 +235,7 @@ sub do_work {
 	# kill the remaining process if needed
 	if ($self->{node}->{pid} && kill(0, $self->{node}->{pid})) {
 		INFO "[INFO] Killing subprocess $self->{node}->{pid}";
-		kill $self->{node}->{pid};
+		kill 'TERM', $self->{node}->{pid};
 	}
 
 	if ($EVAL_ERROR =~ m/^NO_SPOOLFETCH_DATA /) {


### PR DESCRIPTION
As Matija Grabnar noticed on the mailing-list:

> Kill with a single parameter doesn't do anything useful

So, this commit fixes that. We use the TERM signal, further test will say if we
do need to revert to the KILL signal.
