### PR TITLE
Update lpstat.in

### DIFF
--- a/plugins/node.d/lpstat.in
+++ b/plugins/node.d/lpstat.in
@@ -145,6 +145,7 @@ foreach $printer ( @printers ) {
         exit 2;
     }
     @jobs = ( <LPSTAT> );
+    $n_jobs = @jobs;
     $jobs{$printer}=$n_jobs || 0;
 }
 


### PR DESCRIPTION
jobsize was always zero because the variable $n_jobs had been assigned no value.
