### PR TITLE
Update Makefile to get system Perl's man3 suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ MANCENTER        := "Munin Documentation"
 MAN8		 := master/_bin/munin-update master/_bin/munin-limits master/_bin/munin-html master/_bin/munin-graph
 PODMAN8          := build/master/doc/munin-cron master/doc/munin master/doc/munin-check
 PODMAN5          := build/master/doc/munin.conf node/doc/munin-node.conf
+MAN3EXT		 := $(shell $(PERL) -e 'use Config; print $$Config{man3ext};')
+
 
 .PHONY: install install-pre install-master-prime install-node-prime install-node-pre install-common-prime install-doc install-man \
         build build-common-prime build-common-pre build-doc \
@@ -258,43 +260,43 @@ build/%: %.in
 build-common-prime: build-common-pre common/blib/lib/Munin/Common/Defaults.pm build-common
 
 substitue-confvar-inline:
-	@sed -e 's|@@PREFIX@@|$(PREFIX)|g'                      \
-             -e 's|@@CONFDIR@@|$(CONFDIR)|g'                    \
-             -e 's|@@BINDIR@@|$(BINDIR)|g'                      \
-             -e 's|@@SBINDIR@@|$(SBINDIR)|g'                    \
-             -e 's|@@DOCDIR@@|$(DOCDIR)|g'                      \
-             -e 's|@@LIBDIR@@|$(LIBDIR)|g'                      \
-             -e 's|@@MANDIR@@|$(MANDIR)|g'                      \
-             -e 's|@@LOGDIR@@|$(LOGDIR)|g'                      \
-             -e 's|@@HTMLDIR@@|$(HTMLDIR)|g'                    \
-             -e 's|@@DBDIR@@|$(DBDIR)|g'                        \
-             -e 's|@@STATEDIR@@|$(STATEDIR)|g'                  \
-             -e 's|@@SPOOLDIR@@|$(SPOOLDIR)|g'                  \
-             -e 's|@@PERL@@|$(PERL)|g'                          \
-             -e 's|@@PERLLIB@@|$(PERLLIB)|g'                    \
-             -e 's|@@PYTHON@@|$(PYTHON)|g'                      \
-             -e 's|@@RUBY@@|$(RUBY)|g'                          \
-             -e 's|@@JAVARUN@@|$(JAVARUN)|g'                    \
-             -e 's|@@JAVALIBDIR@@|$(JAVALIBDIR)|g'              \
-             -e 's|@@OSTYPE@@|$(OSTYPE)|g'                      \
-             -e 's|@@HOSTNAME@@|$(HOSTNAME)|g'                  \
-             -e 's|@@MKTEMP@@|$(MKTEMP)|g'                      \
-             -e 's|@@VERSION@@|$(VERSION)|g'                    \
-             -e 's|@@PLUGSTATE@@|$(PLUGSTATE)|g'                \
-             -e 's|@@CGIDIR@@|$(CGIDIR)|g'                      \
-             -e 's|@@USER@@|$(USER)|g'                          \
-             -e 's|@@GROUP@@|$(GROUP)|g'                        \
-             -e 's|@@PLUGINUSER@@|$(PLUGINUSER)|g'              \
-             -e 's|@@GOODSH@@|$(GOODSH)|g'                      \
-             -e 's|@@BASH@@|$(BASH)|g'                          \
-             -e 's|@@HASSETR@@|$(HASSETR)|g'                    \
-             --in-place                                         \
-             ./master/blib/libdoc/Munin::Master::HTMLOld.3pm    \
-             ./master/blib/lib/Munin/Master/HTMLOld.pm          \
-             ./node/blib/sbin/munin-node-configure              \
-             ./node/blib/sbin/munin-node                        \
-             ./node/blib/sbin/munin-run                         \
-             ./node/blib/sbin/munin-sched                       \
+	@sed -e 's|@@PREFIX@@|$(PREFIX)|g'                      	\
+             -e 's|@@CONFDIR@@|$(CONFDIR)|g'                    	\
+             -e 's|@@BINDIR@@|$(BINDIR)|g'                      	\
+             -e 's|@@SBINDIR@@|$(SBINDIR)|g'                    	\
+             -e 's|@@DOCDIR@@|$(DOCDIR)|g'                      	\
+             -e 's|@@LIBDIR@@|$(LIBDIR)|g'                      	\
+             -e 's|@@MANDIR@@|$(MANDIR)|g'                      	\
+             -e 's|@@LOGDIR@@|$(LOGDIR)|g'                      	\
+             -e 's|@@HTMLDIR@@|$(HTMLDIR)|g'                    	\
+             -e 's|@@DBDIR@@|$(DBDIR)|g'                        	\
+             -e 's|@@STATEDIR@@|$(STATEDIR)|g'                  	\
+             -e 's|@@SPOOLDIR@@|$(SPOOLDIR)|g'                  	\
+             -e 's|@@PERL@@|$(PERL)|g'                          	\
+             -e 's|@@PERLLIB@@|$(PERLLIB)|g'                    	\
+             -e 's|@@PYTHON@@|$(PYTHON)|g'                      	\
+             -e 's|@@RUBY@@|$(RUBY)|g'                          	\
+             -e 's|@@JAVARUN@@|$(JAVARUN)|g'                    	\
+             -e 's|@@JAVALIBDIR@@|$(JAVALIBDIR)|g'              	\
+             -e 's|@@OSTYPE@@|$(OSTYPE)|g'                      	\
+             -e 's|@@HOSTNAME@@|$(HOSTNAME)|g'                  	\
+             -e 's|@@MKTEMP@@|$(MKTEMP)|g'                      	\
+             -e 's|@@VERSION@@|$(VERSION)|g'                    	\
+             -e 's|@@PLUGSTATE@@|$(PLUGSTATE)|g'                	\
+             -e 's|@@CGIDIR@@|$(CGIDIR)|g'                      	\
+             -e 's|@@USER@@|$(USER)|g'                          	\
+             -e 's|@@GROUP@@|$(GROUP)|g'                        	\
+             -e 's|@@PLUGINUSER@@|$(PLUGINUSER)|g'              	\
+             -e 's|@@GOODSH@@|$(GOODSH)|g'                      	\
+             -e 's|@@BASH@@|$(BASH)|g'                          	\
+             -e 's|@@HASSETR@@|$(HASSETR)|g'                    	\
+             --in-place                                         	\
+             ./master/blib/libdoc/Munin::Master::HTMLOld.$(MAN3EXT)	\
+             ./master/blib/lib/Munin/Master/HTMLOld.pm          	\
+             ./node/blib/sbin/munin-node-configure              	\
+             ./node/blib/sbin/munin-node                        	\
+             ./node/blib/sbin/munin-run                         	\
+             ./node/blib/sbin/munin-sched                       	\
              ./build/doc/munin-node.conf.5
 
 


### PR DESCRIPTION
Gets configured man3ext from Perl instead of assuming 3pm suffix. Assuming 3pm breaks building from source on Perl distributions configured with a different suffix (3perl, 3, et c.). Observed on a fresh install of Slackware 14.1.
