### PR TITLE
master: fix reload of config

### DIFF
--- a/master/lib/Munin/Master/Utils.pm
+++ b/master/lib/Munin/Master/Utils.pm
@@ -996,7 +996,8 @@ sub munin_refreshconfig {
 	my $dbdir = $config->{dbdir};
 	# purge cyclic current config
 	purge_cycles($config);
-	$config = munin_readconfig("$dbdir/datafile");
+	my $new_config = munin_readconfig("$dbdir/datafile");
+	$config = munin_overwrite($new_config, $config);
 	$config->{dbdir} = $dbdir;
     }
 


### PR DESCRIPTION
As helmut noticed on IRC, some vars were not replicated when refreshing the
config (such as $config->{cgitmpdir}). This patch fixes that.

That it is only a slightly edited version of what he proposed, mostly for
clarity.

This patch is made obsolete by 6d62e6b0782ecfa0f4e0c2bec14434d675734962, which
rewrites the offending code, but it is only in 2.0.10+. That one is the one
that does fix #1289.

Closes: D:742203
