### PR TITLE
master/limits: global default for always_send

### DIFF
--- a/master/lib/Munin/Master/LimitsOld.pm
+++ b/master/lib/Munin/Master/LimitsOld.pm
@@ -198,11 +198,6 @@ sub initialize_for_nagios {
         and defined $config->{'nsca'}) {
         $config->{'contact'}->{'old-nagios'}->{'command'}
             = "$config->{nsca} $config->{nsca_server} -c $config->{nsca_config} -to 60";
-        $config->{'contact'}->{'old-nagios'}->{'always_send'}
-            = "critical warning";
-    }
-    if (!defined $config->{'contact'}->{'nagios'}->{'always_send'}) {
-        $config->{'contact'}->{'nagios'}->{'always_send'} = "critical warning";
     }
 }
 
@@ -650,9 +645,13 @@ sub generate_service_message {
         }
         else {
             # List of severities from contact configuration
-            my $always_send_config = munin_get( $contactobj, "always_send" );
-            my @always_send_config = ($always_send_config);
-            $always_send = \@always_send_config;
+            if (my $always_send_config = munin_get( $contactobj, "always_send" )) {
+                my @always_send_config = ($always_send_config);
+                $always_send = \@always_send_config;
+            }
+            else {
+                $always_send = ['critical', 'warning'];
+            }
         }
 
         $always_send = validate_severities($always_send);


### PR DESCRIPTION
On "nagios" and "old-nagios" contact, there is a default for the "always_send"
directive : "critical warning".

This commit makes it the default for _every_ contact.
