### PR TITLE
Graph system peer's stratum

### DIFF
--- a/plugins/node.d/ntp_states.in
+++ b/plugins/node.d/ntp_states.in
@@ -12,6 +12,7 @@ The following configuration parameters are used by this plugin:
 
  [ntp_states]
   env.lowercase - Lowercase hostnames after lookup
+  env.show_syspeer_stratum - Display the stratum of the system peer, field sys_peer_stratum
 
 Set the variable env.lowercase to anything to lowercase hostnames.
 
@@ -19,6 +20,7 @@ Set the variable env.lowercase to anything to lowercase hostnames.
 
  [ntp_states]
   env.lowercase <undefined>
+  env.show_syspeer_stratum <undefined>
 
 =head1 AUTHORS
 
@@ -59,6 +61,7 @@ my %stateval = (
                  "insane"    => 8
                );
 my %peers_condition;
+my $syspeer_stratum_value = 15;
 my $resolver = Net::DNS::Resolver->new;
 $resolver->tcp_timeout(5);
 $resolver->udp_timeout(5);
@@ -88,6 +91,13 @@ sub make_hash {
                         }
                         if ($condition_str eq "falsetic") {
                                 $condition_str = "falsetick";
+                        }
+
+                        # save the sys.peer's stratum if configured to graph it
+                        if ($condition_str eq "sys.peer" and exists $ENV{"show_syspeer_stratum"}) {
+                                chomp(my $stratum = `ntpq -n -c "readvar $assid stratum"`);
+                                $stratum =~ s/\s//g;
+                                $syspeer_stratum_value = ($stratum =~ m/stratum=(.*)/);
                         }
 
                         if (exists $stateval{$condition_str}) {
@@ -151,11 +161,18 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
         print "graph_title NTP states\n";
         print "graph_args --base 1000 --vertical-label state --lower-limit 0\n";
         print "graph_category time\n";
-        print "graph_info These are graphs of the states of this system's NTP peers. The states translate as follows: 0=reject, 1=falsetick, 2=excess, 3=backup, 4=outlyer, 5=candidate, 6=system peer, 7=PPS peer. See http://www.eecis.udel.edu/~mills/ntp/html/decode.html for more information on the meaning of these conditions.\n";
+        print "graph_info These are graphs of the states of this system's NTP peers. The states translate as follows: 0=reject, 1=falsetick, 2=excess, 3=backup, 4=outlyer, 5=candidate, 6=system peer, 7=PPS peer. See http://www.eecis.udel.edu/~mills/ntp/html/decode.html for more information on the meaning of these conditions. If show_syspeer_stratum is specified, the sys.peer stratum is also graphed.\n";
 
         foreach my $addr (keys %peers_condition) {
                 my ($fieldname, $hostname) = &make_names($addr);
                 print "$fieldname.label $hostname\n";
+        }
+
+        # print config for the sys.peer's stratum if configured to graph it
+        if (exists $ENV{"show_syspeer_stratum"}) {
+            print "sys_peer_stratum.label sys.peer stratum\n";
+            print "sys_peer_stratum.draw LINE1\n";
+            print "sys_peer_stratum.colour 000000\n";
         }
 
         exit 0;
@@ -164,6 +181,10 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
 foreach my $addr (keys %peers_condition) {
         my ($fieldname, $hostname) = &make_names($addr);
         print "$fieldname.value ", $peers_condition{$addr}, "\n";
+}
+# include the sys.peer's stratum if configured to graph it
+if (exists $ENV{"show_syspeer_stratum"} ) {
+    print "sys_peer_stratum.value ", $syspeer_stratum_value, "\n";
 }
 
 exit 0;


### PR DESCRIPTION
Although not ideal to dual purpose the state axis as stratum for this field, I don't think it warrants a separate plugin. Also, it is only enabled if env.show_syspeer_stratum is set (similar to env.lowercase). Especially with the use of NTP pools, this also allows for warn/crit levels if the system peer's stratum is above an expected stratum.
