### PR TITLE
Fix broken http loadtime

### DIFF
--- a/plugins/node.d/http_loadtime.in
+++ b/plugins/node.d/http_loadtime.in
@@ -42,7 +42,7 @@ target=${target:-"http://localhost/"}
 requisites=${requisites:-"false"}
 
 urls=`echo $target | tr "," "\n"`
-wget_opt="--user-agent \"Munin - http_loadtime\" --no-cache -q"
+wget_opt="--user-agent \"Munin_-_http_loadtime\" --no-cache -q"
 if [ "$requisites" == "true" ]; then
   wget_opt="$wget_opt --page-requisites"
 fi


### PR DESCRIPTION
Hi,

this pull request contains three commits:
https://github.com/mattthias/munin/commit/1cca3f82c6692c9f83f4f14184274dfc5f413f00 - Adds the missing 'fi' to the if clause in autoconf (the one that checks if one or more urls are in env.target).

https://github.com/mattthias/munin/commit/84767770ff06db66ef33aa28cd9b592d7cca3169 - Don't use $wget_bin anymore. The variable was remove two years ago and all $wget_bin were replaced by wget. Only that one in the autoconf section was missed.

https://github.com/mattthias/munin/commit/b3170f4538e8751273123dde7ad03a9dbc7060bf - Use only one word as user-agent string. Again a fix for the autoconf section. When more urls are in env.target the escaping of the user-agent does not work and a invalid wget call is fired. So autoconf alway returns "no". For more information how to reproduce the problem see the commit message

best wishes,
Matthias
