### PR TITLE
Comatibility with PostgreSQL 9.2

### DIFF
--- a/plugins/node.d/postgres_autovacuum.in
+++ b/plugins/node.d/postgres_autovacuum.in
@@ -74,7 +74,7 @@ my $pg = Munin::Plugin::Pgsql->new(
     basequery   => [
         "SELECT 'active', count(*) FROM pg_stat_activity WHERE query LIKE 'autovacuum: %'",
         [
-            9.1,
+            9.2,
             "SELECT 'active', count(*) FROM pg_stat_activity WHERE current_query LIKE 'autovacuum: %'"
         ]
     ],

--- a/plugins/node.d/postgres_connections_.in
+++ b/plugins/node.d/postgres_connections_.in
@@ -85,7 +85,7 @@ my $pg = Munin::Plugin::Pgsql->new(
                 ON tmp.mstate=tmp2.mstate
                 ORDER BY 1;
 		",
-            [ 9.1, "SELECT tmp.state,COALESCE(count,0) FROM
+            [ 9.2, "SELECT tmp.state,COALESCE(count,0) FROM
                  (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(state)
 	        LEFT JOIN
                  (SELECT CASE WHEN waiting THEN 'waiting' WHEN current_query='<IDLE>' THEN 'idle' WHEN current_query='<IDLE> in transaction' THEN 'idletransaction' WHEN current_query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END AS state,

--- a/plugins/node.d/postgres_connections_db.in
+++ b/plugins/node.d/postgres_connections_db.in
@@ -74,7 +74,7 @@ my $pg = Munin::Plugin::Pgsql->new(
     basequery => [
         "SELECT pg_database.datname,COALESCE(count,0) AS count FROM pg_database LEFT JOIN (SELECT datname,count(*) FROM pg_stat_activity WHERE pid != pg_backend_pid() GROUP BY datname) AS tmp ON pg_database.datname=tmp.datname WHERE datallowconn ORDER BY 1",
         [
-            9.1,
+            9.2,
             "SELECT pg_database.datname,COALESCE(count,0) AS count FROM pg_database LEFT JOIN (SELECT datname,count(*) FROM pg_stat_activity WHERE procpid != pg_backend_pid() GROUP BY datname) AS tmp ON pg_database.datname=tmp.datname WHERE datallowconn ORDER BY 1",
         ]
     ],

--- a/plugins/node.d/postgres_querylength_.in
+++ b/plugins/node.d/postgres_querylength_.in
@@ -78,7 +78,7 @@ my $pg = Munin::Plugin::Pgsql->new(
                      UNION ALL
                     SELECT 'transaction',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-xact_start)),0) FROM pg_stat_activity WHERE 1=1 %%FILTER%%",
         [
-            9.1,
+            9.2,
             "SELECT 'query',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-query_start)),0) FROM pg_stat_activity WHERE current_query NOT LIKE '<IDLE%' %%FILTER%%
                      UNION ALL
                     SELECT 'transaction',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-xact_start)),0) FROM pg_stat_activity WHERE 1=1 %%FILTER%%",

--- a/plugins/node.d/postgres_users.in
+++ b/plugins/node.d/postgres_users.in
@@ -73,7 +73,7 @@ my $pg = Munin::Plugin::Pgsql->new(
     basequery => [
         "SELECT usename,count(*) FROM pg_stat_activity WHERE pid != pg_backend_pid() GROUP BY usename ORDER BY 1",
         [
-            9.1,
+            9.2,
             "SELECT usename,count(*) FROM pg_stat_activity WHERE procpid != pg_backend_pid() GROUP BY usename ORDER BY 1",
         ]
     ],


### PR DESCRIPTION
Postgres_\* plugins didn't work with PostgreSQL 9.2.x because
they used queries designed for pre-9.1 DB versions.

Columns from pg_stat_activity that are used by these plugins are the same in 9.1 and 9.2.
