### PR TITLE
add the Accept-Encoding header to the wget call

### DIFF
--- a/plugins/node.d/http_loadtime.in
+++ b/plugins/node.d/http_loadtime.in
@@ -102,7 +102,7 @@ cd $TEMPO_DIR || exit 1
 
 for uri in $urls
 do
-    loadtime=`$time_bin --quiet -f "%e" wget $wget_opt $uri 2>&1`
+    loadtime=`$time_bin --quiet -f "%e" wget $wget_opt --header='Accept-Encoding: gzip,deflate' $uri 2>&1`
 
     esc_uri="$(clean_fieldname "$uri")"
     echo $esc_uri".value $loadtime"


### PR DESCRIPTION
This is necessary to have results comparable to a users browser.
