### PR TITLE
Improve kstat compatibility in sunos if_ plugins

### DIFF
--- a/plugins/node.d.sunos/if_.in
+++ b/plugins/node.d.sunos/if_.in
@@ -56,7 +56,7 @@ fi
 
 if [ "$1" = "suggest" ]; then
 	if [ -x /usr/bin/kstat ]; then
-		kstat -p -m '/^(link)/' -s rbytes64 | awk -F: '{ print $3 }'
+		kstat -p -s rbytes64 | awk -F: '$3 != "mac" { print $3 }'
 		exit 0
 	else
 		exit 1
@@ -87,5 +87,5 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi;
 
-kstat -p -m '/^(link)/' -n $INTERFACE -s '*bytes64' | sed \
+kstat -p -n $INTERFACE -s '*bytes64' | sed \
 	's/.*\(.bytes\)64./\1.value /'

--- a/plugins/node.d.sunos/if_err_.in
+++ b/plugins/node.d.sunos/if_err_.in
@@ -56,7 +56,7 @@ fi
 
 if [ "$1" = "suggest" ]; then
 	if [ -x /usr/bin/kstat ]; then
-		kstat -p -m '/^(?!unix)/' -n '/^(?!mac$)/' -s ierrors | awk -F: '{ print $3 }'
+		kstat -p -s ierrors | awk -F: '$1 != "unix" && $3 != "mac" { print $3 }'
 		exit 0
 	else
 		exit 1
@@ -88,8 +88,8 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi;
 
-kstat -p -m '/^(?!unix)/' -n $INTERFACE -s '/^([io]errors|collisions)$/' | awk -F: '
-{
+kstat -p -n $INTERFACE -s '/^([io]errors|collisions)$/' | awk -F: '
+$1 != "unix" {
 	split($4, four, "\t")
 	print four[1] ".value", four[2]
 }'


### PR DESCRIPTION
A long time ago, I made the sunos if_ plugins do magic with kstat to only get
the right statistics.  In newer versions of Illumos, some of the pattern
matching magic no longer works (I suspect this is because kstat was converted
from perl script into binary).

This commit fixes the plugins to support the whole spectrum again by moving the
matching magic to awk.
