### PR TITLE
Generate correct rrd filename

### DIFF
--- a/master/lib/Munin/Master/Utils.pm
+++ b/master/lib/Munin/Master/Utils.pm
@@ -1161,7 +1161,7 @@ sub munin_get_keypath {
     }
 
     if ($asfile) {
-	return join('/',@group).'-'.join('-',@service);
+	return (shift @group).'/'.join('/',@group).'-'.join('-',@service);
     } else {
 	return join(';',@group).':'.join('.',@service);
     }


### PR DESCRIPTION
This commit fixes discrepancies in filenames between those expected by munin-cgi-graph and those generated by munin-cron after the fix for 1224, and may not require reopening 1224 as well.
