### PR TITLE
mysql plugin: Subquery cache

### DIFF
--- a/plugins/node.d/mysql_.in
+++ b/plugins/node.d/mysql_.in
@@ -552,6 +552,8 @@ $graphs{qcache} = {
     data_sources => [
 	{name => 'Qcache_queries_in_cache', label => 'Queries in cache'},
 	{name => 'Qcache_hits',             label => 'Cache hits'},
+	{name => 'Subquery_cache_hit',      label => 'Subquery Cache hits'},
+	{name => 'Subquery_cache_miss',     label => 'Subquery Cache misses'},
 	{name => 'Qcache_inserts',          label => 'Inserts'},
 	{name => 'Qcache_not_cached',       label => 'Not cached'},
 	{name => 'Qcache_lowmem_prunes',    label => 'Low-memory prunes'},


### PR DESCRIPTION
The subquery cache was added in mysql-5.6 and mariadb-5.3.2.

Mariadb provides separate status variables to determine if enabling/disabling the feature will provide benefits.

As such this plots it with the rest of the query cache numbers.

https://mariadb.com/kb/en/subquery-cache/
https://dev.mysql.com/doc/refman/5.6/en/query-cache-operation.html
