### PR TITLE
mysql plugin : Optimiser components

### DIFF
--- a/plugins/node.d/mysql_.in
+++ b/plugins/node.d/mysql_.in
@@ -708,7 +708,7 @@ $graphs{icp} = {
 	},
 	data_source_attrs => {
 	    draw  => 'LINE2',
-	    type => 'GAUGE',
+	    type => 'DERIVE',
 	},
     },
     data_sources => [
@@ -726,7 +726,7 @@ $graphs{mrr} = {
 	},
 	data_source_attrs => {
 	    draw  => 'LINE2',
-	    type => 'GAUGE',
+	    type => 'DERIVE',
 	},
     },
     data_sources => [


### PR DESCRIPTION
Mariadb has an index condition pushdown. Its useful to monitor its use to see if it is worth enabling.

https://mariadb.com/kb/en/server-status-variables/#handler_icp_match

Both mariadb and mysql have Multi Range Read optimisations that can be graphed.
