### PR TITLE
cgi/graph: Set RRDCACHED_ADDRESS during each request

### DIFF
--- a/master/_bin/munin-cgi-graph.in
+++ b/master/_bin/munin-cgi-graph.in
@@ -150,6 +150,10 @@ while (new CGI::Fast) {
 	next;
     }
 
+    # Environment variables are cleared each request
+    # so we must set RRDCACHED_ADDRESS each time
+    $ENV{RRDCACHED_ADDRESS} = $config->{rrdcached_socket} if $config->{rrdcached_socket};
+
     my $filename = get_picture_filename ($config, $dom, $host, $serv, $scale, $ENV{QUERY_STRING});
 
     my $time = time;


### PR DESCRIPTION
RRDCACHED_ADDRESS is normally set during graph_startup. However
CGI drops all external environment variables and replaces them
with CGI variables. We have to set RRDCACHED_ADDRESS each time
so rrdgraph will use it and flush data correctly.
