### PR TITLE
Fix minor typos in Munin master index.rst

### DIFF
--- a/doc/master/index.rst
+++ b/doc/master/index.rst
@@ -8,9 +8,9 @@ Role
 ====
 
 The munin master is responsible for gathering data from munin nodes.
-It stores this data in RRD [#]_. files, and graphs them on request. 
-It also checks wether the fetched values fell below or go over specific 
-threshholds (warning, critical) and will send alerts if this happens and
+It stores this data in RRD [#]_, files, and graphs them on request. 
+It also checks whether the fetched values fell below or go over specific 
+thresholds (warning, critical) and will send alerts if this happens and
 the administrator configured it to do so.
 
 .. [#] RRDtool (acronym for round-robin database tool) aims to handle time-series data like network bandwidth, temperatures, CPU load, etc. The data are stored in a round-robin database (circular buffer), thus the system storage footprint remains constant over time. Source Wikipedia: http://en.wikipedia.org/wiki/RRDtool


### PR DESCRIPTION
Fixed some minor typos I found while reading some of the docs. Though...it looks like this section isn't complete, so I don't know if this is all that helpful.
