### PR TITLE
If value is defined and not "U", try to ensure it looks like a number

### DIFF
--- a/master/lib/Munin/Master/LimitsOld.pm
+++ b/master/lib/Munin/Master/LimitsOld.pm
@@ -45,6 +45,7 @@ use POSIX qw ( strftime );
 use Getopt::Long;
 use Time::HiRes;
 use Text::Balanced qw ( extract_bracketed );
+use Scalar::Util qw( looks_like_number );
 use Munin::Common::Logger;
 
 use Munin::Master::Utils;
@@ -373,13 +374,26 @@ sub process_service {
 		}
 	}
 
-        # De-taint.
-        if (!defined $value || $value eq "U") {
-            $value = "unknown";
-        }
-        else {
-            $value = sprintf "%.2f", $value;
-        }
+    # De-taint.
+    if ( !defined $value || $value eq "U" ) {
+        $value = "unknown";
+    }
+    elsif ( looks_like_number($value) ) {
+        $value = sprintf "%.2f", $value;
+    }
+    else {
+        WARNING(  "Expected number, got \""
+                . $value . "\":"
+                . " group="
+                . $hash->{group}
+                . " host="
+                . $hash->{host}
+                . " plugin="
+                . $hash->{plugin}
+                . " field="
+                . $fname );
+        $value = "unknown";
+    }
 
         # Some fields that are nice to have in the plugin output
         $field->{'value'} = $value;


### PR DESCRIPTION
This is a "quick fix" not to pass non-numeric data to "RRD".

Log line changes from:

```
2014-07-07 19:05:08 [error]: In RRD: Error updating /var/lib/munin/localdomain/localhost.localdomain-df_inode-_dev_sda2-g.rrd: /var/lib/munin/localdomain/localhost.localdomain-df_inode-_dev_sda2-g.rrd: conversion of '-' to float not complete: tail '-'
```

to

```
2014-07-08 19:00:10 [warning]: Expected number, got "-": group=localdomain host=localhost.localdomain plugin=df_inode field=_dev_sda2
```

However, a "more correct fix" may be to introduce better validation in munin-update, so we do not end up with these kind of values in the first place.  May be more work, though.
