### PR TITLE
Fix iostat on FreeBSD

### DIFF
--- a/plugins/node.d.freebsd/iostat.in
+++ b/plugins/node.d.freebsd/iostat.in
@@ -4,8 +4,8 @@
 # Original script (NetBSD) by he
 # 
 # Adapted to FreeBSD 6.2 / PC-BSD 1.4 by Pierre Bauduin (pierre@baudu.in)
-# Version 0.0.2
-# October 24 2007
+# Version 0.0.3
+# September 2 24 2014
 #
 # Plugin for watching io-bound traffic (in bytes) on disks.
 #
@@ -41,7 +41,7 @@ fi
 if [ "$1" = "config" ]; then
     echo 'graph_title IOstat by bytes'
     echo 'graph_args --base 1024 -l 0'
-    echo 'graph_vlabel MB per ${graph_period} read+written'
+    echo 'graph_vlabel Bytes per ${graph_period} read+written'
     echo 'graph_category disk'
     echo 'graph_info This graph shows the I/O to and from block devices'
     # We don't give a XXXX about device or extended
@@ -56,13 +56,13 @@ if [ "$1" = "config" ]; then
     for d in $drives; do
        echo "${d}_read.label ${d}"
        echo "${d}_read.type DERIVE"
-       echo "${d}_read.max 2000"
+       echo "${d}_read.max 1073741824"
        echo "${d}_read.min 0"
        echo "${d}_read.graph no"
        echo "${d}_write.label ${d}"
        echo "${d}_write.info I/O on device ${d}"
        echo "${d}_write.type DERIVE"
-       echo "${d}_write.max 2000"
+       echo "${d}_write.max 1073741824"
        echo "${d}_write.min 0"
        echo "${d}_write.negative ${d}_read"
     done
@@ -79,5 +79,5 @@ fi
 		awk '/^device/ { next; } //'  | 
 		awk '/extended/ { next; } //' |
 		awk ' {
-    			print $1 "_read.value " int($4);
-    			print $1 "_write.value " int($5);}'
+    			print $1 "_read.value " int($4)*1024;
+    			print $1 "_write.value " int($5)*1024;}'


### PR DESCRIPTION
Current iostat says it shows the graph in MiBps, but it uses iostat's kiB output, so it's not. In this change I've changed the "MB" on the graph to "Bytes" and multiplied the iostat output (it's in kiB as stated by the comments and despite of this handled wrong) by 1024, so munin will correctly SI-scale the graph and numbers (2 MiBps will be 2 MiBps, not 2kiBps [MB] as now).
Also, I've changed the max values from 2 MBps (2000 kiBps) to 8 Gibps (1 GiBps), which is more sane nowadays.
MFM days are long gone.
