### PR TITLE
fix autoconf for nfsd plugin

### DIFF
--- a/plugins/node.d.linux/nfsd.in
+++ b/plugins/node.d.linux/nfsd.in
@@ -32,7 +32,12 @@ proc="getattr setattr lookup access readlink read write create mkdir symlink mkn
 
 if [ "$1" = "autoconf" ]; then
 	if [ -f "$NFSD" ]; then
-		echo yes
+		grep -q proc3 "$NFSD"
+		if [ $? = 0 ]; then
+			echo yes
+		else
+			echo "no (no proc3 in $NFSD)"
+		fi
 		exit 0
 	else
 		echo "no (no $NFSD)"


### PR DESCRIPTION
The nfsd plugin tries to read a line containing 'proc3', but it's gone
on some recent systems that don't use nfsv3 any more. Check for the
presence of this line in autoconf, and report 'no' if it's not there.
