### PR TITLE
p/apt_all: Be able to override /etc/apt.conf

### DIFF
--- a/plugins/node.d.linux/apt_all.in
+++ b/plugins/node.d.linux/apt_all.in
@@ -20,6 +20,9 @@ your /etc/apt.conf defaults.
 [apt_all]
 env.options -o Debug::pkgDepCache::AutoInstall=false -o APT::Get::Show-Versions=false
 
+Note that apt is called with no extra options by default, so it fully honors
+your /etc/apt.conf defaults.
+
 =head1 USAGE
 
 This plugin needs a cronjob that runs apt-get update every hour or so

--- a/plugins/node.d.linux/apt_all.in
+++ b/plugins/node.d.linux/apt_all.in
@@ -14,7 +14,11 @@ graphs.
 
 =head1 CONFIGURATION
 
-No configuration needed
+You can add some extra options to the apt call, in order to override
+your /etc/apt.conf defaults.
+
+[apt_all]
+env.options -o Debug::pkgDepCache::AutoInstall=false -o APT::Get::Show-Versions=false
 
 =head1 USAGE
 
@@ -79,7 +83,8 @@ sub update_state() {
 	open(STATE, ">$statefile")
 		or die("Couldn't open state file $statefile for writing.");
 	foreach my $release (@releases) {
-	    my $apt="apt-get -u dist-upgrade --print-uris --yes -t $release |";
+	    my $options = $ENV{options} || "";
+	    my $apt="apt-get $options -u dist-upgrade --print-uris --yes -t $release |";
 	    open (APT, "$apt") or exit 22;
 
 	    my @pending = ();


### PR DESCRIPTION
When you use some nasty options in /etc/apt.conf, you might break the parsing
of the apt-get. This enables to restore these options to a sane value.

Closes: D:761190