### PR TITLE
Multigraph huge

### DIFF
--- a/plugins/node.d.debug/multigraph_huge
+++ b/plugins/node.d.debug/multigraph_huge
@@ -7,11 +7,12 @@
 
 nb=${nb:-"300"}
 dirty_config=${dirty_config:-""}
+all="$(seq 1 $nb)"
 
 config() {
 	echo "multigraph $1"
 	echo "graph_title Main for $1"
-	for field_id in $(seq 1 $nb)
+	for field_id in $all
 	do
 		echo "field_${field_id}.label Field $field_id for $1"
 	done
@@ -19,7 +20,7 @@ config() {
 
 fetch() {
 	echo "multigraph $1"
-	for field_id in $(seq 1 $nb)
+	for field_id in $all
 	do
 		echo "field_${field_id}.value $(($i - $field_id))"
 	done
@@ -29,7 +30,7 @@ if [ "$1" = "config" ]; then
 	config a
 	config b
 	config c
-	for i in $(seq 1 $nb)
+	for i in $all
 	do
 		config a.$i
 		config b.$i
@@ -43,7 +44,7 @@ fi
 fetch a
 fetch b
 fetch c
-for i in $(seq 1 $nb)
+for i in $all
 do
 	fetch a.$i
 	fetch b.$i


### PR DESCRIPTION
Ganneff on IRC reported some performance issue with munin-update and huge
multigraph plugins. As it can happen on LUN-flooded hosts, with the stock
diskstats plugin, it has to be fixed.

Therefore this plugin will serve as a test one, to emulate those gigantic
plugins outputs.
