### PR TITLE
make proc plugin more careful in /proc/

### DIFF
--- a/plugins/node.d.linux/proc.in
+++ b/plugins/node.d.linux/proc.in
@@ -320,7 +320,7 @@ sub populate_stats
         $procstats{$procuniq[$i]}{"write_bytes"} = 0;
         $procstats{$procuniq[$i]}{"cancelled_write_bytes"} = 0;
 
-        STATLINE: foreach my $line(`grep -h \\\($procname[$i]\\\) /proc/*/stat`) {
+        STATLINE: foreach my $line(`grep -h \\\($procname[$i]\\\) /proc/[0-9]*/stat`) {
             $line =~ /^(\d+)/;
             my $cmdline = `cat /proc/$1/cmdline | @@PERL@@ -F\"\\0\" -lane '\$s = join(\" \", \@F); print \$s;'`;
             my $cmduid = `cat /proc/$1/status | egrep '^Uid:' | awk '{ print \$2 }'`;


### PR DESCRIPTION
the proc plugin is using a glob for its grep thats hitting more than
intended. It wants to grep from /proc/$PIDS/stats, but with the current
line it does also take things like /proc/net/stat, and as such leading
to loads of lines like the following in the munin-update.log:

2014/09/16-13:15:26 [587369] Error output from proc:
2014/09/16-13:15:26 [587369]       grep: /proc/net/stat: Is a directory

Thats still a hack, but now it limits to anything starting with a number.
