### PR TITLE
doc: Add the refernce to github

### DIFF
--- a/doc/preface/bugreport.rst
+++ b/doc/preface/bugreport.rst
@@ -125,8 +125,7 @@ Where to Report
 ===============
 
 In general fill in the bug report web-form available at the project's
-:ref:`web site<website>`. Entering a bug report this way causes it to be mailed to the
-<bugs@munin-monitoring.org> mailing list.
+:ref:`GitHub<github>`.
 
 If your bug report has security implications and you'd prefer that it not
 become immediately visible in public archives, don't send it to bugs. Security

--- a/doc/preface/moreinfo.rst
+++ b/doc/preface/moreinfo.rst
@@ -20,6 +20,28 @@ contains most answers to a wide array of questions.
 
 __ http://munin-monitoring.org/wiki/faq
 
+.. _github:
+
+GitHub
+======
+
+The `Munin GitHub`__ has slowly become the center of all the community-driven
+development. It is a very solid platform, which has its drawbacks, but given
+the importance it has today one cannot ignore it.
+
+__ https://github.com/munin-monitoring/munin
+
+Therefore we have moved all our code pull requests there, and the issues are
+slowly migrating there also.
+
+The `contrib`__ part is even more lively than before. It has succesfully
+replaced the old MuninExchange site. Now with the `Plugin Gallery`__ it offer
+as much features as the old site.
+
+__ https://github.com/munin-monitoring/contrib
+
+__ http://gallery.munin-monitoring.org/
+
 .. _mailing-lists:
 
 Mailing Lists


### PR DESCRIPTION
Trac is slowly going into the back burner, in favor of GitHub.
