### PR TITLE
haproxy_backend was not being picked up by munin, modified to haproxy_ng

### DIFF
--- a/plugins/node.d/haproxy_ng.in
+++ b/plugins/node.d/haproxy_ng.in
@@ -33,7 +33,7 @@
 #
 # Example:
 #
-#   [haproxy_backend]
+#   [haproxy_ng]
 #   env.url http://backend.example.com/haproxy-status;csv;norefresh
 #   env.http_username monitor
 #   env.http_password somepasswordorother


### PR DESCRIPTION
The haproxy_backend configuration parameter was not being picked up when being run, I've updated this to haproxy_ng which now works.
