### PR TITLE
Issue warning if no data

### DIFF
--- a/master/lib/Munin/Master/Update.pm
+++ b/master/lib/Munin/Master/Update.pm
@@ -359,8 +359,12 @@ sub _print_old_service_configs_for_failed_workers {
 	    next if ($datum eq 'group')
 		or ($datum eq 'host_name');
 
-	    printf $handle "%s:%s %s\n", $worker, $datum, $workerdata->{$datum};
-	    munin_set_var_path($datafile_hash, $worker . ":". $datum, $workerdata->{$datum});
+	    if (defined $workerdata->{$datum}) {
+        printf $handle "%s:%s %s\n", $worker, $datum, $workerdata->{$datum};
+        munin_set_var_path($datafile_hash, $worker . ":". $datum, $workerdata->{$datum});
+	    } else {
+	      WARN "[Warning] no data $worker -> $datum";
+	    }
 	}
 	
     }


### PR DESCRIPTION
rather than dieing when there was no workerdata->{$datum} issue a warning

I lost track of indenting rules. I don't think I'm the only one.
