### PR TITLE
Primary key on url table

### DIFF
--- a/master/lib/Munin/Master/Update.pm
+++ b/master/lib/Munin/Master/Update.pm
@@ -378,8 +378,7 @@ sub _dump_into_sql {
 	my $sth_ds_attr = $dbh->prepare('INSERT INTO ds_attr (id, name, value) VALUES (?, ?, ?)');
 
 	# Table that contains all the URL paths, in order to have a very fast lookup
-	$dbh->do("CREATE TABLE IF NOT EXISTS url (id INTEGER, type VARCHAR, path VARCHAR)");
-	$dbh->do("CREATE UNIQUE INDEX IF NOT EXISTS pk_url ON url (type, id)");
+	$dbh->do("CREATE TABLE IF NOT EXISTS url (id INTEGER NOT NULL, type VARCHAR NOT NULL, path VARCHAR NOT NULL, PRIMARY KEY(id,type))");
 	$dbh->do("CREATE UNIQUE INDEX IF NOT EXISTS u_url_path ON url (path)");
 	my $sth_url = $dbh->prepare('INSERT INTO url (id, type, path) VALUES (?, ?, ?)');
 	$sth_url->{RaiseError} = 1;


### PR DESCRIPTION
use primary key in preference to unique keys. type,id was the common JOIN criteria so using that as PRIMARY over path. Enforce NOT NULL constraints on this table.

Its almost tempting to split the url table up into url_node, url_group, url_service and change "SELECT id, type FROM url WHERE path =" into SELECT id,'node' as type FROM url_node WHERE path=? UNION SELECT id,'group' as type WHERE path=? ....  but that would be just a little premature.

please forgive cascading PRs, too many conflicts otherwise. 03e9f2e is the focus here.
