### PR TITLE
ip/iostat_ios: also support /dev/xvdX devices

### DIFF
--- a/plugins/node.d.linux/iostat_ios.in
+++ b/plugins/node.d.linux/iostat_ios.in
@@ -105,7 +105,7 @@ sub filter {
     }
     if(defined($tmpnam)) {
         return 0 if ($tmpnam =~ /part\d+$/);
-        return 0 if ($tmpnam =~ /^\s*(?:sd|hd|vd)[a-z]\d+\s*$/);
+        return 0 if ($tmpnam =~ /^\s*(?:sd|hd|x?vd)[a-z]\d+\s*$/);
     }
 
     return 1;


### PR DESCRIPTION
Xen kernels use xvdX:

brw-rw---T 1 root disk 202, 32 Jun 27 00:27 /dev/xvdc
