### PR TITLE
Add 5 new plugins to monitor Jenkins servers.

### DIFF
--- a/plugins/node.d/jenkins_builds.in
+++ b/plugins/node.d/jenkins_builds.in
@@ -1,0 +1,73 @@
+#!/bin/sh
+# -*- sh -*-
+
+: << =cut
+
+=head1 NAME
+
+jenkins_builds - Plugin to measure number of jenkins builds
+
+=head1 AUTHOR
+
+Contributed by Holger Levsen. I wrote and used them first for
+https://jenkins.debian.net and very much like to hear about
+other users of these plugins! Please do tell me!
+
+Use at your own risk and monitor the ressource usage of the plugins
+too - it will vary depending on your setup!
+
+Patches, postcards and pancakes are all very much welcome!
+
+=head1 LICENSE
+
+Copyright 2012-2014 Holger Levsen <holger@layer-acht.org>
+
+Released under the GPLv2.
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf
+
+=cut
+
+. $MUNIN_LIBDIR/plugins/plugin.sh
+
+if [ "$1" = "autoconf" ]; then
+	echo yes
+	exit 0
+fi
+
+STATEFILE=$MUNIN_PLUGSTATE/$(basename $0)
+
+# delete statefile if it's older than ${jenkins_update_interval} set in /etc/munin/plugin-conf.d/jenkins
+if test $(find $STATEFILE -mmin +${jenkins_update_interval}) ; then
+	rm -f $STATEFILE
+fi
+
+if [ -f $STATEFILE ] && [ "$1" = "" ] ; then
+	cat $STATEFILE
+	exit 0
+fi
+
+JOB_PREFIXES=$(ls -1 /var/lib/jenkins/jobs/|cut -d "_" -f1|sort -f -u)
+if [ "$1" = "config" ]; then
+	echo 'graph_title Jenkins Builds in the last 24h'
+	echo 'graph_args --base 1000 -l 0 '
+	echo 'graph_scale no'
+	echo 'graph_total total'
+	echo 'graph_vlabel Jenkins Builds per category in the last 24h'
+	echo 'graph_category jenkins'
+	draw=AREA
+	for PREFIX in $JOB_PREFIXES ; do
+		echo "jenkins_builds_$PREFIX.label $PREFIX builds"
+		echo "jenkins_builds_$PREFIX.draw $draw"
+		if [ "$draw" = "AREA" ] ; then draw=STACK ; fi
+	done
+	exit 0
+fi
+
+for PREFIX in $JOB_PREFIXES ; do
+	NR=$(find /var/lib/jenkins/jobs/$PREFIX*/builds/ -type d -mtime -1 -name "*_*"| wc -l)
+	echo "jenkins_builds_$PREFIX.value $NR" | tee -a $STATEFILE
+done

--- a/plugins/node.d/jenkins_builds_results.in
+++ b/plugins/node.d/jenkins_builds_results.in
@@ -1,0 +1,84 @@
+#!/bin/sh
+# -*- sh -*-
+
+: << =cut
+
+=head1 NAME
+
+jenkins_builds_results - Plugin to measure number of jenkins builds
+
+=head1 AUTHOR
+
+Contributed by Holger Levsen. I wrote and used them first for
+https://jenkins.debian.net and very much like to hear about
+other users of these plugins! Please do tell me!
+
+Use at your own risk and monitor the ressource usage of the plugins
+too - it will vary depending on your setup!
+
+Patches, postcards and pancakes are all very much welcome!
+
+=head1 LICENSE
+
+Copyright 2012-2014 Holger Levsen <holger@layer-acht.org>
+
+Released under the GPLv2.
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf
+
+=cut
+
+. $MUNIN_LIBDIR/plugins/plugin.sh
+
+if [ "$1" = "autoconf" ]; then
+	echo yes
+	exit 0
+fi
+
+STATEFILE=$MUNIN_PLUGSTATE/$(basename $0)
+
+# delete statefile if it's older than ${jenkins_update_interval} set in /etc/munin/plugin-conf.d/jenkins
+if test $(find $STATEFILE -mmin +${jenkins_update_interval}) ; then
+	rm -f $STATEFILE
+fi
+
+if [ -f $STATEFILE ] && [ "$1" = "" ] ; then
+	cat $STATEFILE
+	exit 0
+fi
+
+JOB_PREFIXES=$(ls -1 /var/lib/jenkins/jobs/|cut -d "_" -f1|sort -f -u)
+if [ "$1" = "config" ]; then
+	echo 'graph_title Jenkins Builds results'
+	echo 'graph_args --base 1000 -l 0 '
+	echo 'graph_scale no'
+	echo 'graph_total total'
+	echo 'graph_vlabel Jenkins Builds results per category'
+	echo 'graph_category jenkins'
+	draw=AREA
+	for PREFIX in $JOB_PREFIXES ; do
+		for STATE in success unstable failure ; do
+			echo "jenkins_builds_results_${PREFIX}_${STATE}.label ${PREFIX} ${STATE}"
+			echo "jenkins_builds_results_${PREFIX}_${STATE}.draw $draw"
+			if [ "$draw" = "AREA" ] ; then draw=STACK ; fi
+		done
+	done
+	exit 0
+fi
+
+for PREFIX in $JOB_PREFIXES ; do
+	PREFIX_RESULTS=$(for i in /var/lib/jenkins/jobs/${PREFIX}*/builds/*_*/log ; do tail -1 $i 2>/dev/null; echo " \n"; done )
+	for STATE in success unstable failure ; do
+		NR=0
+		if [ "$STATE" = "failure" ] ; then
+			# count aborted as failed
+			NR=$(echo -e "$PREFIX_RESULTS" | egrep -i -c "($STATE|aborted)")
+		else
+			NR=$(echo -e "$PREFIX_RESULTS" | grep -i -c $STATE)
+		fi
+		echo "jenkins_builds_results_${PREFIX}_${STATE}.value $NR" | tee -a $STATEFILE
+	done
+done

--- a/plugins/node.d/jenkins_builds_results_summary.in
+++ b/plugins/node.d/jenkins_builds_results_summary.in
@@ -1,0 +1,79 @@
+#!/bin/sh
+# -*- sh -*-
+
+: << =cut
+
+=head1 NAME
+
+jenkins_builds_results_summary - Plugin to measure results of all jenkins builds
+
+=head1 AUTHOR
+
+Contributed by Holger Levsen. I wrote and used them first for
+https://jenkins.debian.net and very much like to hear about
+other users of these plugins! Please do tell me!
+
+Use at your own risk and monitor the ressource usage of the plugins
+too - it will vary depending on your setup!
+
+Patches, postcards and pancakes are all very much welcome!
+
+=head1 LICENSE
+
+Copyright 2012-2014 Holger Levsen <holger@layer-acht.org>
+
+Released under the GPLv2.
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf
+
+=cut
+
+. $MUNIN_LIBDIR/plugins/plugin.sh
+
+if [ "$1" = "autoconf" ]; then
+	echo yes
+	exit 0
+fi
+
+STATEFILE=$MUNIN_PLUGSTATE/$(basename $0)
+
+# delete statefile if it's older than ${jenkins_update_interval} set in /etc/munin/plugin-conf.d/jenkins
+if test $(find $STATEFILE -mmin +${jenkins_update_interval}) ; then
+	rm -f $STATEFILE
+fi
+
+if [ -f $STATEFILE ] && [ "$1" = "" ] ; then
+	cat $STATEFILE
+	exit 0
+fi
+
+if [ "$1" = "config" ]; then
+	echo 'graph_title Jenkins Builds results summary'
+	echo 'graph_args --base 1000 -l 0 '
+	echo 'graph_scale no'
+	echo 'graph_total total'
+	echo 'graph_vlabel Jenkins Builds results summary'
+	echo 'graph_category jenkins'
+	draw=AREA
+	for STATE in success unstable failure ; do
+		echo "jenkins_builds_results_all_${STATE}.label ${PREFIX} ${STATE}"
+		echo "jenkins_builds_results_all_${STATE}.draw $draw"
+		if [ "$draw" = "AREA" ] ; then draw=STACK ; fi
+	done
+	exit 0
+fi
+
+RESULTS=$(for i in /var/lib/jenkins/jobs/*/builds/*_*/log ; do tail -1 $i 2>/dev/null; echo " \n"; done )
+for STATE in success unstable failure ; do
+	NR=0
+	if [ "$STATE" = "failure" ] ; then
+		# count aborted as failed
+		NR=$(echo -e "$RESULTS" | egrep -i -c "($STATE|aborted)")
+	else
+		NR=$(echo -e "$RESULTS" | grep -i -c $STATE)
+	fi
+	echo "jenkins_builds_results_all_${STATE}.value $NR" | tee -a $STATEFILE
+done

--- a/plugins/node.d/jenkins_builds_running.in
+++ b/plugins/node.d/jenkins_builds_running.in
@@ -1,0 +1,52 @@
+#!/bin/sh
+# -*- sh -*-
+
+: << =cut
+
+=head1 NAME
+
+jenkins_builds_running - Plugin to measure number of jenkins builds which are currently running
+
+=head1 AUTHOR
+
+Contributed by Holger Levsen. I wrote and used them first for
+https://jenkins.debian.net and very much like to hear about
+other users of these plugins! Please do tell me!
+
+Use at your own risk and monitor the ressource usage of the plugins
+too - it will vary depending on your setup!
+
+Patches, postcards and pancakes are all very much welcome!
+
+=head1 LICENSE
+
+Copyright 2012-2014 Holger Levsen <holger@layer-acht.org>
+
+Released under the GPLv2.
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf
+
+=cut
+
+. $MUNIN_LIBDIR/plugins/plugin.sh
+
+if [ "$1" = "autoconf" ]; then
+	echo yes
+	exit 0
+fi
+
+if [ "$1" = "config" ]; then
+	echo 'graph_title Jenkins Builds running'
+	echo 'graph_args --base 1000 -l 0 '
+	echo 'graph_scale no'
+	echo 'graph_vlabel Jenkins Builds currently running'
+	echo 'graph_category jenkins'
+	echo "jenkins_builds_running.label $PREFIX builds_running"
+	echo "jenkins_builds_running.draw AREA"
+	exit 0
+fi
+
+echo "jenkins_builds_running.value $(ps fax|grep /tmp/hudson|grep -v grep|wc -l)"

--- a/plugins/node.d/jenkins_jobs.in
+++ b/plugins/node.d/jenkins_jobs.in
@@ -1,0 +1,73 @@
+#!/bin/sh
+# -*- sh -*-
+
+: << =cut
+
+=head1 NAME
+
+jenkins_jobs - Plugin to measure number of jenkins jobs
+
+=head1 AUTHOR
+
+Contributed by Holger Levsen. I wrote and used them first for
+https://jenkins.debian.net and very much like to hear about
+other users of these plugins! Please do tell me!
+
+Use at your own risk and monitor the ressource usage of the plugins
+too - it will vary depending on your setup!
+
+Patches, postcards and pancakes are all very much welcome!
+
+=head1 LICENSE
+
+Copyright 2012-2014 Holger Levsen <holger@layer-acht.org>
+
+Released under the GPLv2.
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf
+
+=cut
+
+. $MUNIN_LIBDIR/plugins/plugin.sh
+
+if [ "$1" = "autoconf" ]; then
+	echo yes
+	exit 0
+fi
+
+STATEFILE=$MUNIN_PLUGSTATE/$(basename $0)
+
+# delete statefile if it's older than ${jenkins_update_interval} set in /etc/munin/plugin-conf.d/jenkins
+if test $(find $STATEFILE -mmin +${jenkins_update_interval}) ; then
+	rm -f $STATEFILE
+fi
+
+if [ -f $STATEFILE ] && [ "$1" = "" ] ; then
+	cat $STATEFILE
+	exit 0
+fi
+
+JOB_PREFIXES=$(ls -1 /var/lib/jenkins/jobs/|cut -d "_" -f1|sort -f -u)
+if [ "$1" = "config" ]; then
+	echo 'graph_title Jenkins Jobs'
+	echo 'graph_args --base 1000 -l 0 '
+	echo 'graph_scale no'
+	echo 'graph_total total'
+	echo 'graph_vlabel Jenkins Jobs per category'
+	echo 'graph_category jenkins'
+	draw=AREA
+	for PREFIX in $JOB_PREFIXES ; do
+		echo "jenkins_jobs_$PREFIX.label $PREFIX jobs"
+		echo "jenkins_jobs_$PREFIX.draw $draw"
+		if [ "$draw" = "AREA" ] ; then draw=STACK ; fi
+	done
+	exit 0
+fi
+
+for PREFIX in $JOB_PREFIXES ; do
+	NR=$(find /var/lib/jenkins/jobs/ -maxdepth 1 -name "$PREFIX*" -type d | wc -l)
+	echo "jenkins_jobs_$PREFIX.value $NR" | tee -a $STATEFILE
+done


### PR DESCRIPTION
These are the the five new plugins:

jenkins_builds - to measure number of jenkins builds
jenkins_builds_results - to measure number of jenkins builds
jenkins_builds_running - to measure number of jenkins builds
which are currently running
jenkins_builds_results_summary - to measure results of all
jenkins builds
jenkins_jobs - to measure number of jenkins jobs

The plugins were written and are copyrighted by
Holger Levsen holger@layer-acht.org in 2012 and have been
released under the GNU Public Licence, version 2.
