### PR TITLE
handle servers with "unspecified" unit for fans

### DIFF
--- a/plugins/node.d/ipmi_.in
+++ b/plugins/node.d/ipmi_.in
@@ -119,7 +119,7 @@ BEGIN {
 	}
 }
 
-/RPM/ { 
+/RPM/ || /^Fan / { 
         NAME=THING=$1;
 	gsub(/[^A-Za-z0-9]/,"",NAME);
 	SPEED=$2;


### PR DESCRIPTION
if the name is self-explanatory, graph them even if the unit is unknown.

observed on ProLiant DL360p Gen8 running Ubuntu Precise, ipmitool version 1.8.11.dell19 (package 
1.8.11-5ubuntu1).
