### PR TITLE
Use configured plugin group as primary group

### DIFF
--- a/lib/Munin/Node/Service.pm
+++ b/lib/Munin/Node/Service.pm
@@ -185,10 +185,11 @@ sub _resolve_gids
 
     # Support running with more than one group in effect. See documentation on
     # $EFFECTIVE_GROUP_ID in the perlvar(1) manual page.  Need to specify the
-    # default group twice: once for setegid(2), and once for setgroups(2).
-    my $egids = join ' ', ($default_gid) x 2, @groups;
-
-    return ($default_gid, $egids);
+    # primary group twice: once for setegid(2), and once for setgroups(2).
+    if (scalar(@groups) != 0) {
+        return ($groups[0], join ' ', $groups[0], @groups);
+    }
+    return ($default_gid, join ' ', ($default_gid) x 2);
 }
 
 

--- a/t/munin_node_service.t
+++ b/t/munin_node_service.t
@@ -55,8 +55,8 @@ $config->reinitialize({
         opt_bad_gname => { group => [ '(%%SSKK¤¤)'  ] },
         opt_bad_gid   => { group => [ '(999999999)' ] },
 
-        several_groups => { group => [ 0, "($gname)" ] },
-        several_groups_required => { group => [ 0, $gname ] },
+        several_groups => { group => [ 0, "($gname)" ,0 ] },
+        several_groups_required => { group => [ 0, $gname, 0 ] },
         several_groups_mixture => { group => [ '(%%SSKK¤¤)', 0 ] },
     },
     ignores => [
@@ -187,8 +187,8 @@ $ENV{MUNIN_MASTER_IP} = '';
 
     eq_or_diff([ $services->_resolve_gids('no_groups')   ], [ $gid, "$gid $gid" ], 'default group by gid');
 
-    eq_or_diff([ $services->_resolve_gids('gid')   ], [ $gid, "$gid $gid 0" ], 'extra group by gid');
-    eq_or_diff([ $services->_resolve_gids('gname') ], [ $gid, "$gid $gid 0" ], 'extra group by name');
+    eq_or_diff([ $services->_resolve_gids('gid')   ], [ 0, "0 0" ], 'different group by gid');
+    eq_or_diff([ $services->_resolve_gids('gname') ], [ 0, "0 0" ], 'different group by name');
 
     eval { $services->_resolve_gids('bad_gid') };
     like($@, qr/'999999999'/, 'Exception thrown if an additional group could not be resolved');
@@ -196,25 +196,25 @@ $ENV{MUNIN_MASTER_IP} = '';
     eval { $services->_resolve_gids('bad_gname') };
     like($@, qr/'%%SSKK¤¤'/, 'Exception thrown if an additional group could not be resolved');
 
-    eq_or_diff([ $services->_resolve_gids('opt_gname')     ], [ $gid, "$gid $gid 0" ], 'extra optional group by name');
-    eq_or_diff([ $services->_resolve_gids('opt_bad_gname') ], [ $gid, "$gid $gid" ],   'unresolvable extra groups are ignored');
+    eq_or_diff([ $services->_resolve_gids('opt_gname')     ], [ 0, "0 0" ], 'optional group by name');
+    eq_or_diff([ $services->_resolve_gids('opt_bad_gname') ], [ $gid, "$gid $gid" ],   'unresolvable groups are ignored');
 
-    eq_or_diff([ $services->_resolve_gids('opt_gid')         ], [ $gid, "$gid $gid 0" ], 'extra optional group by gid');
-    eq_or_diff([ $services->_resolve_gids('opt_bad_gid') ], [ $gid, "$gid $gid" ],   'unresolvable extra gids are ignored');
+    eq_or_diff([ $services->_resolve_gids('opt_gid')         ], [ 0, "0 0" ], 'optional group by gid');
+    eq_or_diff([ $services->_resolve_gids('opt_bad_gid') ], [ $gid, "$gid $gid" ],   'unresolvable gids are ignored');
 
     eq_or_diff(
         [$services->_resolve_gids('several_groups') ],
-        [$gid, "$gid $gid 0 $gid"],
+        [0, "0 0 $gid 0"],
         'several extra groups'
     );
     eq_or_diff(
         [$services->_resolve_gids('several_groups_required')],
-        [$gid, "$gid $gid 0 $gid"],
+        [0, "0 0 $gid 0"],
         'several groups, less whitespace'
     );
     eq_or_diff(
         [$services->_resolve_gids('several_groups_mixture')],
-        [$gid, "$gid $gid 0"],
+        [0, "0 0"],
         'resolvable and unresolvable extra groups'
     );
 


### PR DESCRIPTION
Instead of always having the munin group as real and effective group
while executing a plugin, and only using configured group(s) as
additional groups, use the configured groups instead.

When specifying group in plugin-conf, I expect munin to set this group
as the primary group. Maybe I even want to set a group for my plugin to
prevent it from being able to access anything that is owned by the group
that the munin-node daemon is running at!

I stumbled into this issue when writing a plugin that reads from
/proc/<pid>/smaps. When setting the user and group in the plugin config,
access was still denied, because the real/effective user got set to the
specified user, but the group did not get changed. I guess this is a bit
of an edge case, because in most of the cases just having the specified
group available as additional group will "work".

This change will no longer automagically include the munin group itself
in the group list when executing a plugin if it's not expicitely added
in that list. IMHO, this should be the expected behaviour.