### PR TITLE
m/limits: remove warning about uninitialized

### DIFF
--- a/master/lib/Munin/Master/LimitsOld.pm
+++ b/master/lib/Munin/Master/LimitsOld.pm
@@ -839,7 +839,7 @@ will return a reference to an empty array.
 
 sub validate_severities {
     my $severities_ref = shift;
-    my @severities     = @{$severities_ref};
+    my @severities     = grep { defined $_ }  @{$severities_ref};
 
     my @allowed_severities = qw{ok warning critical unknown};
 


### PR DESCRIPTION
undef severities should just be silenced

Closes: munin-monitoring/munin#304
