### PR TITLE
master/graph: fix cdef expansion to handle repeated field names

### DIFF
--- a/master/lib/Munin/Master/GraphOld.pm
+++ b/master/lib/Munin/Master/GraphOld.pm
@@ -1855,9 +1855,9 @@ sub expand_cdef {
         my $fieldname = munin_get_node_name($field);
         my $rrdname = &orig_to_cdef($service, $fieldname);
         if ($cdef =~ /\b$fieldname\b/) {
-            $max =~ s/([,=])$fieldname([,=]|$)/$1a$rrdname$2/g;
-            $min =~ s/([,=])$fieldname([,=]|$)/$1i$rrdname$2/g;
-            $avg =~ s/([,=])$fieldname([,=]|$)/$1g$rrdname$2/g;
+            $max =~ s/([,=])$fieldname(?=[,=]|$)/$1a$rrdname/g;
+            $min =~ s/([,=])$fieldname(?=[,=]|$)/$1i$rrdname/g;
+            $avg =~ s/([,=])$fieldname(?=[,=]|$)/$1g$rrdname/g;
         }
     }
 


### PR DESCRIPTION
This fixes handling of a cdef such as
 hit.cdef hit,hit,miss,+,/
which computes hit rate hit/(hit+miss) from hits and misses.
Without this patch, only the first hit is expanded as substitutions overlap. The fix was to use look-aheads (which are not part or substitutions). After this the substitutions do not overlap any more.
