### PR TITLE
feature/certificate chain file

### DIFF
--- a/common/lib/Munin/Common/TLS.pm
+++ b/common/lib/Munin/Common/TLS.pm
@@ -176,9 +176,8 @@ sub _load_certificate {
 
     if ($self->{tls_cert} && -e $self->{tls_cert}) {
         if (defined $self->{tls_cert} and length $self->{tls_cert}) {
-	    if (!Net::SSLeay::CTX_use_certificate_file($self->{tls_context}, 
-                                                       $self->{tls_cert}, 
-                                                       &Net::SSLeay::FILETYPE_PEM)) {
+	    if (!Net::SSLeay::CTX_use_certificate_chain_file($self->{tls_context},
+	                                                     $self->{tls_cert})) {
 	        WARNING("Problem occurred when trying to read file with certificate \"$self->{tls_cert}\": $!. Continuing without certificate.");
 	    }
         }

--- a/master/doc/munin.conf.pod.in
+++ b/master/doc/munin.conf.pod.in
@@ -164,9 +164,10 @@ certificate can be stored in the same file.  Affects: munin-update.
 
 =item B<tls_certificate> <value>
 
-This directive sets the location of the TLS certificate to be used for
-TLS.  Default is @@CONFDIR@@/munin.pem.  The private key and
-certificate can be stored in the same file.  Affects: munin-update.
+This directive sets the location of the TLS certificate and optional
+intermediate CA certificates to be used for TLS.  Default is
+@@CONFDIR@@/munin.pem.  The private key and certificate can be
+stored in the same file.  Affects: munin-update.
 
 =item B<tls_ca_certificate> <value>
 

--- a/node/doc/munin-node.conf.pod
+++ b/node/doc/munin-node.conf.pod
@@ -96,9 +96,10 @@ certificate can be stored in the same file.
 
 =item B<tls_certificate> <value>
 
-This directive sets the location of the TLS certificate to be used for
-TLS.  Default is @@CONFDIR@@/munin-node.pem.  The private key and
-certificate can be stored in the same file.
+This directive sets the location of the TLS certificate and optional
+intermediate CA certificates to be used for TLS.  Default is
+@@CONFDIR@@/munin-node.pem.  The private key and certificate can be
+stored in the same file.
 
 =item B<tls_ca_certificate> <value>
 


### PR DESCRIPTION
This aligns Munin TLS configuration with other TLS clients and servers such as Postfix, Dovecot and OpenLDAP and allows separation of intermediate client and server CA certificates.
