### PR TITLE
Auto-virtual-host capable munin-asyncd

### DIFF
--- a/node/_bin/munin-asyncd.in
+++ b/node/_bin/munin-asyncd.in
@@ -45,7 +45,8 @@ my $verbose;
 my $debug;
 my $help;
 my $update_rate = 300;
-
+my @nodes;
+my %spoolwriter;
 
 GetOptions(
 	"host=s" => \$host,
@@ -73,32 +74,45 @@ $minrate = $update_rate if ! defined $minrate;
 # Debug implies Verbose
 $verbose = 1 if $debug;
 
-unless (-d $SPOOLDIR) {
-	mkpath($SPOOLDIR, { verbose => $verbose, } ) 
-		or die ("Cannot create '$SPOOLDIR': $!");
-}
-
 my $sock = new IO::Socket::INET(
 	PeerAddr        => "$host",
 	Proto   => 'tcp'
 ) || die "Error creating socket: $!";
 my $nodeheader = <$sock>;
+print STDERR "[sock][>] nodes\n" if $debug;
+print $sock "nodes\n";
+
+# get all virtual node names exposed by one physical node
+while(my $line = <$sock>) {
+	chomp($line);
+	print STDERR "[sock][<] $line\n" if $debug;
+	last if $line =~ /^\./;
+	push(@nodes, $line);
+}
+
 print $sock "quit\n";
 close ($sock);
 ( $metahostname ) = ( $nodeheader =~ /munin node at (\S+)\n/);
 $metahostname = "unknown" unless $metahostname;
 
-my $spoolwriter = Munin::Node::SpoolWriter->new(
-	spooldir => $SPOOLDIR,
+foreach my $node (@nodes) {
+	unless (-d "$SPOOLDIR/$node") {
+		mkpath("$SPOOLDIR/$node", { verbose => $verbose, } )
+			or die ("Cannot create '$SPOOLDIR/$node': $!");
+	}
+	$spoolwriter{$node} = Munin::Node::SpoolWriter->new(
+	spooldir => "$SPOOLDIR/$node",
 	interval_size => $intervalsize,
 	interval_keep => $retaincount,
 	hostname  => $metahostname,
-);
+	);
+}
+
 $0 = "munin-asyncd [$metahostname] [idle]";
 
 my $process_name = "main";
 
-my @plugins;
+my $plugins = {};
 {
 	print STDERR "[$$][$process_name] Reading config from $host\n" if $verbose;
 	my $sock = new IO::Socket::INET( 
@@ -109,24 +123,25 @@ my @plugins;
 	local $0 = "munin-asyncd [$metahostname] [list]";
 	print STDERR "[sock][>] cap multigraph\n" if $debug;
 	print $sock "cap multigraph\n";
-	print STDERR "[sock][>] list\n" if $debug;
-	print $sock "list\n";
 	<$sock>; # Read the first header comment line
 	<$sock>; # Read the multigraph response line
-	my $plugins_line = <$sock>;
-	chomp($plugins_line);
-
+	foreach my $node (@nodes)
 	{
-		my $fh_list = IO::File->new(
-			"$SPOOLDIR/munin-daemon.list",
-			"w",
-		);
-
-		print $fh_list $plugins_line;
-		print $fh_list "\n";
+		print STDERR "[sock][>] list $node\n" if $debug;
+		print $sock "list $node\n";
+		my $plugins_line = <$sock>;
+		chomp($plugins_line);
+		print STDERR "[sock][<] $plugins_line\n" if $debug;
+		{
+			my $fh_list = IO::File->new(
+				"$SPOOLDIR/$node/munin-daemon.list",
+				"w",
+			);
+			print $fh_list $plugins_line;
+			print $fh_list "\n";
+		}
+		$plugins->{$node} = [ split(/ /, $plugins_line) ];
 	}
-
-	@plugins = split(/ /, $plugins_line);
 }
 
 my $keepgoing = 1;
@@ -149,66 +164,70 @@ MAIN: while($keepgoing) {
 	my $when = time;
 
 	my $when_next = $when + $timeout; # wake up at least every $timeout sec
-	my $sock;
-	PLUGIN: foreach my $plugin (@plugins) {
-		# See if this plugin should be updated
-		my $plugin_rate = $spoolwriter->get_metadata("plugin_rates/$plugin") || 300;
-		if ($when < ($last_updated{$plugin} || 0) + $plugin_rate) {
-			# not yet, next plugin
-			next;
-		}
-
-		# Should update it - based on wall clock time
-		my $should_have_been = $when - ($when % $plugin_rate);
-		my $should_be_next = $should_have_been + $plugin_rate;
-
-		$last_updated{$plugin} = $should_have_been;
-		if ($should_be_next < $when_next) {
-			$when_next = $should_be_next;
-		}
-
-		if ($do_fork && fork()) {
-			# parent, return directly
-			next PLUGIN;
-		}
-
-		unless ($sock) {
-			$sock = new IO::Socket::INET(
-				PeerAddr	=> "$host",
-				Proto	=> 'tcp'
-			);
-
-			unless ($sock) {
-				warn "Error creating socket: $!, moving to next plugin to try again";
+	foreach my $node (@nodes)
+	{
+		my $sock;
+		PLUGIN: foreach my $plugin ( @{$plugins->{$node}} ) {
+			# See if this plugin should be updated
+			my $plugin_rate = $spoolwriter{$node}->get_metadata("plugin_rates/$plugin") || 300;
+			if ($when < ($last_updated{$plugin} || 0) + $plugin_rate) {
+				# not yet, next plugin
 				next;
 			}
 
-			<$sock>; # skip header
+			# Should update it - based on wall clock time
+			my $should_have_been = $when - ($when % $plugin_rate);
+			my $should_be_next = $should_have_been + $plugin_rate;
+
+			$last_updated{$plugin} = $should_have_been;
+			if ($should_be_next < $when_next) {
+				$when_next = $should_be_next;
+			}
+
+			if ($do_fork && fork()) {
+				# parent, return directly
+				next PLUGIN;
+			}
+
+			unless ($sock) {
+				$sock = new IO::Socket::INET(
+					PeerAddr	=> "$host",
+					Proto	=> 'tcp'
+				);
+				unless ($sock) {
+					warn "Error creating socket: $!, moving to next plugin to try again";
+					next;
+				}
+				<$sock>; # skip header
+			}
+
+			# Setting the command name for a useful top information
+			$process_name = "plugin:$plugin";
+			local $0 = "munin-asyncd [$metahostname] [$process_name]";
+
+			fetch_data($node, $plugin, $when, $sock);
+
+			# We end here if we forked
+			last MAIN if $do_fork;
 		}
-
-
-		# Setting the command name for a useful top information
-		$process_name = "plugin:$plugin";
-		local $0 = "munin-asyncd [$metahostname] [$process_name]";
-
-		fetch_data($plugin, $when, $sock);
-
-		# We end here if we forked
-		last MAIN if $do_fork;
+		$spoolwriter{$node}->set_metadata("lastruntime", $when);
 	}
 
-	print STDERR "[$$][$process_name][>] quit\n" if $verbose;
-	print $sock "quit\n" if $sock;
-
-	print STDERR "[$$][$process_name] closing sock\n" if $verbose;
-	$sock = undef;
-
-	$spoolwriter->set_metadata("lastruntime", $when);
+	$process_name = "main";
+	if ($sock)
+	{
+		if ( $sock->connected ) {
+			print STDERR "[$$][$process_name][>] quit\n" if $verbose;
+			print $sock "quit\n" ;
+		}
+		print STDERR "[$$][$process_name] closing sock\n" if $verbose;
+		$sock = undef;
+	}
 
 	# Clean spool dir
 	if (!$nocleanup && $last_cleanup<(time - 600)) {
 		$last_cleanup = time;
-		$spoolwriter->cleanup();
+		foreach ( @nodes ) { $spoolwriter{$_}->cleanup() };
 	}
 
 	# Sleep until next plugin exec.
@@ -221,11 +240,12 @@ MAIN: while($keepgoing) {
 		print STDERR "[$$][$process_name] Already late : should sleep $sleep_sec sec\n" if $verbose;
 	}
 }
-		
+
 print STDERR "[$$][$process_name] Exiting\n" if $verbose;
 
 sub fetch_data
 {
+	my $node = shift;
 	my $plugin = shift;
 	my $when = shift;
 	my $sock = shift;
@@ -252,7 +272,7 @@ sub fetch_data
 				# XXX - Doesn't take into account a per field update_rate
 
 				# This has to be sent back to the master
-				$spoolwriter->set_metadata("plugin_rates/$plugin", $1);
+				$spoolwriter{$node}->set_metadata("plugin_rates/$plugin", $1);
 			}
 		}
 
@@ -279,7 +299,7 @@ sub fetch_data
 		}
 
 		# Write the whole load into the spool
-		$spoolwriter->write($when, $plugin, $output_rows);
+		$spoolwriter{$node}->write($when, $plugin, $output_rows);
 }
 
 __END__
@@ -296,10 +316,10 @@ munin-asyncd [options]
         --host <hostname:port>  Connect to this munin-node [localhost:4949]
      -s --spooldir <spooldir>   Store the spooled data in this dir [@@SPOOLDIR@@]
      -i --interval <seconds>    Override default interval size of one day [86400]
-        --update-rate <seconds> Override default update_date [300]
+        --update-rate <seconds> Override default update_rate [300]
         --timeout <seconds>     Wake up at least this number of seconds. [3600]
-        --minrate <seconds>     This is the minimal rate you want to poll a node [$update_date]
-                                Note that having $update_date < $minrate leads to unexpected results.
+        --minrate <seconds>     This is the minimal rate you want to poll a node [$update_rate]
+                                Note that having $update_rate < $minrate leads to unexpected results.
      -r --retain <count>        Specify number of interval files to retain [7]
      -n --nocleanup             Disable automated spool dir cleanup
 


### PR DESCRIPTION
Even if a munin-node has multiple virtual nodes, munin-asyncd fetches data from a single node only. Currently, there is no way to have munin-asyncd to access other virtual nodes. So, I enhanced munin-asyncd to fetch data from all virtual nodes. I believe this is what is called "auto-virtual-host capable" in Milestone Munin 2.2 (http://munin-monitoring.org/milestone/Munin%202.2).

Enhanced minin-asyncd will obtain virtual node names by the response of "nodes" command from nunin-node. If the response is as follows:

vnode1
vnode2
.

, minin-asyncd will fetch data from these virtual nodes and spool data at $SPOOLDIR/vnode1, $SPOOLDIR/vnode2.
