### PR TITLE
multips: reject 'autoconf' unless $names is set

### DIFF
--- a/plugins/node.d/multips.in
+++ b/plugins/node.d/multips.in
@@ -56,6 +56,11 @@ GPLv2
 . $MUNIN_LIBDIR/plugins/plugin.sh
 
 if [ "$1" = "autoconf" ]; then
+	if [ -z "$names" ]; then
+		echo "no (Configuration required)"
+		exit 0
+	fi
+
 	echo yes
 	exit 0
 fi


### PR DESCRIPTION
Without this, the plugin will accept a non-working (empty) config at
configure time and will exit with error each time it is run for real.

The 'multips_memory' plugin already handles it this way.