### PR TITLE
select correct avcstats location

### DIFF
--- a/plugins/node.d.linux/selinux_avcstat.in
+++ b/plugins/node.d.linux/selinux_avcstat.in
@@ -22,7 +22,11 @@ GPLv2
 
 =cut
 
-AVCSTATS="/selinux/avc/cache_stats"
+if [ -r /selinux/avc/cache_stats ]; then
+  AVCSTATS="/selinux/avc/cache_stats"
+else
+  AVCSTATS="/sys/fs/selinux/avc/cache_stats"
+fi
 
 if [ "$1" = "autoconf" ]; then
         if [ -r $AVCSTATS ]; then


### PR DESCRIPTION
Newer systems (RHEL/CentOS 7) expose the selinuxfs and hence the cache_stats within /sys