### PR TITLE
haproxy_ng: add SessionRate and adjust title of current sessions value

### DIFF
--- a/plugins/node.d/haproxy_ng.in
+++ b/plugins/node.d/haproxy_ng.in
@@ -96,6 +96,20 @@ my %aspects = (
             }
         }
     },
+    'SessionRate' => {
+        'title' => 'SessionRate',
+        'category' => 'HAProxy',
+        'vlabel' => 'current',
+        'values' => {
+            'stot' => {
+                'type' => 'DERIVE',
+                'draw' => 'AREASTACK',
+                'min' => 0,
+                'label' => 'sessions',
+                'info' => 'sessions',
+            }
+        }
+    },
     'Uptime' => {
         'title' => 'Uptime',
         'category' => 'HAProxy',
@@ -172,18 +186,33 @@ my %graphs = (
     },
     'SessionsFront' => {
         'lines' => 'frontend',
-        'title' => 'Session rate by Frontend',
+        'title' => 'Current Sessions by Frontend',
         'aspect' => 'Sessions'
     },
     'SessionsBack' => {
         'lines' => 'backend',
-        'title' => 'Session rate by Backend',
+        'title' => 'Current Sessions by Backend',
         'aspect' => 'Sessions'
     },
     'SessionsBack.BACKEND' => {
         'lines' => 'server',
-        'title' => 'Session rate by backend: BACKEND',
+        'title' => 'Current Sessions by backend: BACKEND',
         'aspect' => 'Sessions'
+    },
+    'SessionRateFront' => {
+        'lines' => 'frontend',
+        'title' => 'Session rate by Frontend',
+        'aspect' => 'SessionRate'
+    },
+    'SessionRateBack' => {
+        'lines' => 'backend',
+        'title' => 'Session rate by Backend',
+        'aspect' => 'SessionRate'
+    },
+    'SessionRateBack.BACKEND' => {
+        'lines' => 'server',
+        'title' => 'Session rate by backend: BACKEND',
+        'aspect' => 'SessionRate'
     },
     'Uptime' => {
         'lines' => 'backend',


### PR DESCRIPTION
The haproxy_ng check currently graphs the Current Sessions, BUT the title is 'Session Rate'.
As the haproxy status page also shows a session rate (new sessions per second), its quite confusing.

This patch adds a Session Rate (which use the difference between the total sessions) and renames the 'Session Rate' title to 'Current Sessions' to make it more clear.
