### PR TITLE
add threads running to mysql plugin on connections graph

### DIFF
--- a/plugins/node.d/mysql_.in
+++ b/plugins/node.d/mysql_.in
@@ -627,6 +627,8 @@ $graphs{connections} = {
 	{name => 'Aborted_connects',     label => 'Aborted connects'},
 	{name => 'Threads_connected',    label => 'Threads connected',
 					 type  => 'GAUGE'},
+	{name => 'Threads_running',      label => 'Threads running',
+					 type  => 'GAUGE'},
 	{name => 'Connections',          label => 'New connections'},
     ],
 };


### PR DESCRIPTION
nice easy one to add threads_running to connections graph.

This is useful to match up to the threads_connected on the graph