### PR TITLE
Signature was renamed to authenticator for FreeRADIUS v2.2.1

### DIFF
--- a/plugins/node.d/freeradius_acct.in
+++ b/plugins/node.d/freeradius_acct.in
@@ -87,10 +87,10 @@ if [ "$1" = "config" ]; then
     echo 'malformed.type DERIVE'
     echo 'malformed.min 0'
 
-    echo 'bad_signature.label Requests with bad signature'
-    echo 'bad_signature.info total request packets with a bad signature'
-    echo 'bad_signature.type DERIVE'
-    echo 'bad_signature.min 0'
+    echo 'bad_authenticator.label Requests with bad authenticator'
+    echo 'bad_authenticator.info total request packets with a bad authenticator'
+    echo 'bad_authenticator.type DERIVE'
+    echo 'bad_authenticator.min 0'
 
     echo 'dropped.label Dropped requests'
     echo 'dropped.info total request packets dropped for other reasons'
@@ -105,4 +105,4 @@ if [ "$1" = "config" ]; then
     exit 0
 fi
 
-$RADMIN -f $SOCKETFILE -e "stats client acct" | awk '{print $1".value " $2}'
+$RADMIN -f $SOCKETFILE -e "stats client acct" | awk '{print $1".value " $2}' | sed 's/signature/authenticator/'

--- a/plugins/node.d/freeradius_auth.in
+++ b/plugins/node.d/freeradius_auth.in
@@ -102,10 +102,10 @@ if [ "$1" = "config" ]; then
     echo 'malformed.type DERIVE'
     echo 'malformed.min 0'
 
-    echo 'bad_signature.label Requests with bad signature'
-    echo 'bad_signature.info total request packets with a bad signature'
-    echo 'bad_signature.type DERIVE'
-    echo 'bad_signature.min 0'
+    echo 'bad_authenticator.label Requests with bad authenticator'
+    echo 'bad_authenticator.info total request packets with a bad authenticator'
+    echo 'bad_authenticator.type DERIVE'
+    echo 'bad_authenticator.min 0'
 
     echo 'dropped.label Dropped requests'
     echo 'dropped.info total request packets dropped for other reasons'
@@ -120,4 +120,4 @@ if [ "$1" = "config" ]; then
     exit 0
 fi
 
-$RADMIN -f $SOCKETFILE -e "stats client auth" | awk '{print $1".value " $2}'
+$RADMIN -f $SOCKETFILE -e "stats client auth" | awk '{print $1".value " $2}' | sed 's/signature/authenticator/'

--- a/plugins/node.d/freeradius_proxy_acct.in
+++ b/plugins/node.d/freeradius_proxy_acct.in
@@ -87,10 +87,10 @@ if [ "$1" = "config" ]; then
     echo 'malformed.type DERIVE'
     echo 'malformed.min 0'
 
-    echo 'bad_signature.label Requests with bad signature'
-    echo 'bad_signature.info total request packets with a bad signature'
-    echo 'bad_signature.type DERIVE'
-    echo 'bad_signature.min 0'
+    echo 'bad_authenticator.label Requests with bad authenticator'
+    echo 'bad_authenticator.info total request packets with a bad authenticator'
+    echo 'bad_authenticator.type DERIVE'
+    echo 'bad_authenticator.min 0'
 
     echo 'dropped.label Dropped requests'
     echo 'dropped.info total request packets dropped for other reasons'
@@ -105,4 +105,4 @@ if [ "$1" = "config" ]; then
     exit 0
 fi
 
-$RADMIN -f $SOCKETFILE -e "stats home_server acct" | awk '{print $1".value " $2}'
+$RADMIN -f $SOCKETFILE -e "stats home_server acct" | awk '{print $1".value " $2}' | sed 's/signature/authenticator/'

--- a/plugins/node.d/freeradius_proxy_auth.in
+++ b/plugins/node.d/freeradius_proxy_auth.in
@@ -102,10 +102,10 @@ if [ "$1" = "config" ]; then
     echo 'malformed.type DERIVE'
     echo 'malformed.min 0'
 
-    echo 'bad_signature.label Requests with bad signature'
-    echo 'bad_signature.info total request packets with a bad signature'
-    echo 'bad_signature.type DERIVE'
-    echo 'bad_signature.min 0'
+    echo 'bad_authenticator.label Requests with bad authenticator'
+    echo 'bad_authenticator.info total request packets with a bad authenticator'
+    echo 'bad_authenticator.type DERIVE'
+    echo 'bad_authenticator.min 0'
 
     echo 'dropped.label Dropped requests'
     echo 'dropped.info total request packets dropped for other reasons'
@@ -120,4 +120,4 @@ if [ "$1" = "config" ]; then
     exit 0
 fi
 
-$RADMIN -f $SOCKETFILE -e "stats home_server auth" | awk '{print $1".value " $2}'
+$RADMIN -f $SOCKETFILE -e "stats home_server auth" | awk '{print $1".value " $2}' | sed 's/signature/authenticator/'


### PR DESCRIPTION
Fairly simple one. The output from the radmin control socket changed slightly with the release of v3.0.x. This fixes the definitions so the bad authenticator values are displayed again.
