### PR TITLE
Calculate diskspace/inode usage percent accurately

### DIFF
--- a/plugins/node.d.freebsd/df.in
+++ b/plugins/node.d.freebsd/df.in
@@ -38,7 +38,7 @@ if [ "$1" = "config" ]; then
 	echo 'graph_scale no'
 	echo 'graph_info This graph shows disk usage on the machine.'
 	mfs=0
-	/bin/df -P $EXCLUDEDFS | tail -n +2 | grep -v '^/sys' | grep -v "//" | while read i; do
+	/bin/df -P $EXCLUDEDFS | tail -n +2 | sort | grep -v '^/sys' | grep -v "//" | while read i; do
 		case $i in
 		mfs:*) name=mfs$mfs; mfs=`expr $mfs + 1`;;
 		*) name=`echo $i | awk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;
@@ -52,7 +52,7 @@ if [ "$1" = "config" ]; then
 fi
 
 mfs=0
-/bin/df -P $EXCLUDEDFS | tail -n +2 | grep -v '^/sys' | grep -v "//" | while read i; do
+/bin/df -P $EXCLUDEDFS | tail -n +2 | sort | grep -v '^/sys' | grep -v "//" | while read i; do
 	case $i in
 	mfs:*) name=mfs$mfs; mfs=`expr $mfs + 1`;;
 	*) name=`echo $i | awk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;

--- a/plugins/node.d.freebsd/df.in
+++ b/plugins/node.d.freebsd/df.in
@@ -58,5 +58,5 @@ mfs=0
 	*) name=`echo $i | awk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;
 	esac
 	echo -n "$name.value "
-	echo $i | awk '{ print $5 }' | cut -f1 -d%
+	echo $i | awk '{ if ($2 == 0) print 0; else printf("%.2f\n", 100.0 * ($2 - $4) / $2); }'
 done

--- a/plugins/node.d.freebsd/df_inode.in
+++ b/plugins/node.d.freebsd/df_inode.in
@@ -23,7 +23,7 @@ print_values() {
 		*) name=`echo $i | awk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;
 		esac
 		printf "$name.value "
-		echo $i | awk '{ print $8 }' | cut -f1 -d%
+		echo $i | awk '{ total = $6 + $7; if (total == 0) print 0; else printf("%.2f\n", 100.0 * $6 / total); }'
 	done
 }
 


### PR DESCRIPTION
Instead of using rounded one from df

Also, sort df output as it's output is not sorted by default which makes graph harder to read.