### PR TITLE
backport http_loadtime from devel

### DIFF
--- a/plugins/node.d/http_loadtime.in
+++ b/plugins/node.d/http_loadtime.in
@@ -5,13 +5,20 @@
 
 =head1 NAME
 
-http_loadtime - Plugin to graph HTTP response time of a specific page
+http_loadtime - Plugin to graph the HTTP response times of specific pages
 
 =head1 CONFIGURATION
 
 The following environment variables are used by this plugin
 
- target - URL to fetch (default: "http://localhost/")
+ target - comma separated URL(s) to fetch (default: "http://localhost/")
+ example:
+   [http_loadtime]
+   env.target http://localhost.de,http://localhost.de/some-site.html
+   env.requisites true
+
+ Do not enable the download of page requisites (env.requisites) for https
+ sites since wget needs incredible long to perform this on big sites...
 
 =head1 AUTHOR
 
@@ -29,8 +36,17 @@ GPLv2
 
 =cut
 
+. $MUNIN_LIBDIR/plugins/plugin.sh
+
 target=${target:-"http://localhost/"}
-wget_opt="--user-agent munin/http_loadtime --no-cache -q --delete-after"
+requisites=${requisites:-"false"}
+
+urls=`echo $target | tr "," "\n"`
+wget_opt="--user-agent munin/http_loadtime --no-cache -q"
+if [ "$requisites" == "true" ]; then
+  wget_opt="$wget_opt --page-requisites"
+fi
+
 time_bin=`which time`
 
 if [ "$1" = "autoconf" ]; then
@@ -40,16 +56,22 @@ if [ "$1" = "autoconf" ]; then
     command -v wget      2>&1 >/dev/null || result=1
     if [ "$result" != "yes" ]; then
 	echo "no (programs time, wget and tr required)"
-	    exit 0
+	exit 0
     fi
-    if ! $wget_bin -q -O /dev/null $target; then
 
-    # check if url responds
-    #
-    wget --spider $target $wget_opt
-    if [ "$?" != "0" ]; then
-        echo "no (Cannot run wget against \"$target\")"
-        exit 0
+    # if $target contains more than one url
+    if ! wget -q -O /dev/null $target; then
+
+        # check if urls respond
+        #
+        for uri in $urls
+        do
+            wget --spider $uri $wget_opt
+            if [ "$?" != "0" ]; then
+                echo "no (Cannot run wget against \"$uri\")"
+                exit 0
+            fi
+        done
     fi
     echo yes
     exit 0
@@ -60,9 +82,15 @@ if [ "$1" = "config" ]; then
     echo "graph_args --base 1000 -l 0"
     echo "graph_vlabel Load time in seconds"
     echo "graph_category network"
-    echo "graph_info This graph shows load time in seconds of $target"
-    echo "loadtime.label loadtime"
-    echo "loadtime.info Load time"
+    echo "graph_info This graph shows the load time in seconds"
+    for uri in $urls
+    do
+        uri_short=`echo ${uri:0:30}`
+        if [ "$uri_short" != "$uri" ]; then uri_short=$uri_short"..."; fi
+        esc_uri="$(clean_fieldname "$uri")"
+        echo $esc_uri".label $uri_short"
+        echo $esc_uri".info page load time"
+    done
     exit 0
 fi
 
@@ -71,7 +99,13 @@ TEMPO_DIR=$(mktemp -dt munin_http_loadtime.XXXXXX) || exit 1
 trap "rm -rf $TEMPO_DIR" EXIT
 
 cd $TEMPO_DIR || exit 1
-loadtime=`$time_bin --quiet -f "%e" wget $wget_opt $target 2>&1`
-cd -
 
-echo "loadtime.value $loadtime"
+for uri in $urls
+do
+    loadtime=`$time_bin -f "%e" wget $wget_opt --header='Accept-Encoding: gzip,deflate' $uri 2>&1`
+
+    esc_uri="$(clean_fieldname "$uri")"
+    echo $esc_uri".value $loadtime"
+done
+
+exit 0


### PR DESCRIPTION
The http_loadtime is not working in 2.0. It has a syntax error. This
commit backports the changes from development in stable-2.0 so the next
2.0 release will have a working http_loadtime plugin.