### PR TITLE
Busted limits again

### DIFF
--- a/master/lib/Munin/Master/LimitsOld.pm
+++ b/master/lib/Munin/Master/LimitsOld.pm
@@ -555,8 +555,8 @@ sub get_limits {
     my $hash = shift || return;
 
     # This hash will have values that we can look up such as these:
-    my @critical = (undef, undef);
-    my @warning  = (undef, undef);
+    my $critical = undef;
+    my $warning  = undef;
     my $crit          = munin_get($hash, "critical",      undef);
     my $warn          = munin_get($hash, "warning",       undef);
     my $unknown_limit = munin_get($hash, "unknown_limit", 3);
@@ -564,37 +564,38 @@ sub get_limits {
     my $name = munin_get_node_name($hash);
 
     if (defined $crit and $crit =~ /^\s*([-+\d.]*):([-+\d.]*)\s*$/) {
-        $critical[0] = $1 if length $1;
-        $critical[1] = $2 if length $2;
+        $critical = [undef, undef];
+        ${$critical}[0] = $1 if length $1;
+        ${$critical}[1] = $2 if length $2;
     }
     elsif (defined $crit and $crit =~ /^\s*([-+\d.]+)\s*$/) {
-        $critical[1] = $1;
+        $critical = [undef, $1];
     }
     elsif (defined $crit) {
-        @critical = (0, 0);
+        $critical = [0, 0];
     }
     if(defined $crit) {
         DEBUG "[DEBUG] processing critical: $name -> "
-                . (defined $critical[0]? $critical[0] : "")
+                . (defined ${$critical}[0]? ${$critical}[0] : "")
                 .  " : "
-                . (defined $critical[1]? $critical[1] : "");
-    }   
+                . (defined ${$critical}[1]? ${$critical}[1] : "");
+    }
 
     if (defined $warn and $warn =~ /^\s*([-+\d.]*):([-+\d.]*)\s*$/) {
-        $warning[0] = $1 if length $1;
-        $warning[1] = $2 if length $2;
+        ${$warning}[0] = $1 if length $1;
+        ${$warning}[1] = $2 if length $2;
     }
     elsif (defined $warn and $warn =~ /^\s*([-+\d.]+)\s*$/) {
-        $warning[1] = $1;
+        $warning = [undef, $1];
     }
     elsif (defined $warn) {
-        @warning = (0, 0);
+        $warning = [0, 0];
     }
     if(defined $warn) {
         DEBUG "[DEBUG] processing warning: $name -> "
-                . (defined $warning[0]? $warning[0] : "")
+                . (defined ${$warning}[0]? ${$warning}[0] : "")
                 .  " : "
-                . (defined $warning[1]? $warning[1] : "");
+                . (defined ${$warning}[1]? ${$warning}[1] : "");
     }
 
     if ($unknown_limit =~ /^\s*(\d+)\s*$/) {
@@ -608,7 +609,7 @@ sub get_limits {
         DEBUG "[DEBUG] processing unknown_limit: $name -> $unknown_limit";
     }
 
-    return (\@warning, \@critical, $unknown_limit);
+    return ($warning, $critical, $unknown_limit);
 }
 
 sub generate_service_message {


### PR DESCRIPTION
I had some issues I've fixed in Limits.

- Inheritance of warning/critical now works correctly and does not break subsequent limits
If you had say, mongo_lag graph, and you set warning/critical as follows to apply them to all fields in the graph, it would not work and limits would be ignored:
mongo_lag.warning :43200
mongo_lag.critical :86400
Additionally, in the DEBUG output I could see it corrupted all limits checks afterwards. It would actually add the "host" node as a service to check, which would populate graph_title into the "host" node. This would then corrupt every limit check for that host afterwards because it would mean other checks, when called get_host_node, would end up grabbing the root node.

- Aliased graph fields now obey limits assigned to them
The jmx_threads check has aliased fields. In the limits check it does not process this correctly and does not pass the correct path to munin_get_rrd_filename - thus it cannot grab the current value to check limits.

One thing that might need factoring in here is the field_order duplicates. I can see GraphOld.pm handles these duplicates itself but maybe it could do with abstracting into the munin_get_field_order...

By the way - I'm not sure how much of this is legacy and due to be replaced... I can see lots of work in devel branch and of course the filename is, after all, LimitsOld.pm. Though there's no new Limits.pm in the devel branch. I'm just wondering what the plan is - rewrite ground up? Or just fixup?