### PR TITLE
Feature/more robust async

### DIFF
--- a/lib/Munin/Common/Utils.pm
+++ b/lib/Munin/Common/Utils.pm
@@ -1,0 +1,59 @@
+package Munin::Common::Utils;
+
+use strict;
+use warnings;
+
+use Exporter ();
+our @ISA = qw/Exporter/;
+our @EXPORT_OK = qw( is_valid_hostname );
+
+use Params::Validate qw( :all );
+use List::Util qw( all any );
+
+### Set operations #############################################################
+
+sub is_valid_hostname {
+    my ($hostname) = validate_pos(@_, { type => SCALAR } );
+
+    # anything?
+    return unless $hostname;
+
+    # total length
+    return if length($hostname) > 255;
+
+    # each part
+    my @parts = (split(/[.]/, $hostname));
+    return if any { length > 63 } @parts;
+    return if any { ! /^[a-z0-9\-]+$/ } @parts;
+
+    return $hostname;
+
+}
+
+
+1;
+
+__END__
+
+
+=head1 NAME
+
+Munin::Common::Utils - Various utility functions
+
+
+=head1 SYNOPSIS
+
+  use Munin::Common::Utils qw( ... );
+
+
+=head1 SUBROUTINES
+
+=over
+
+=item B<is_valid_hostname($hostname)>
+
+Returns $hostname if it is syntactically valid, or an undef if not.
+
+=back
+
+=cut

--- a/lib/Munin/Node/SpoolReader.pm
+++ b/lib/Munin/Node/SpoolReader.pm
@@ -13,25 +13,34 @@ use Munin::Common::Defaults;
 use Munin::Common::SyncDictFile;
 use Munin::Common::Logger;
 
+use Params::Validate qw(:all);
+
 use Munin::Node::Config;
 my $config = Munin::Node::Config->instance;
 
 
-sub new
-{
-    my ($class, %args) = @_;
+sub new {
+    my $class = shift;
+    my $validated = validate (
+        @_, {
+            spooldir => {
+                type    => SCALAR,
+                default => $Munin::Common::Defaults::MUNIN_SPOOLDIR
+            },
+        }
+    );
+    my $self = bless {}, $class;
 
-    $args{spooldir} or croak "no spooldir provided";
+    $self->{spooldir} = $validated->{'spooldir'};
 
-    opendir $args{spooldirhandle}, $args{spooldir}
-        or croak "Could not open spooldir '$args{spooldir}': $!";
+    my $spooldirhandle;
+    opendir $spooldirhandle, $self->{spooldir}
+      or croak "Could not open spooldir '$self->{spooldir}': $!";
+    $self->{spooldirhandle} = $spooldirhandle;
 
-    $args{metadata} = _init_metadata($args{spooldir});
+    $self->{metadata} = _init_metadata($self->{spooldir});
 
-    # TODO: paranoia check?  except dir doesn't (currently) have to be
-    # root-owned.
-
-    return bless \%args, $class;
+    return $self;
 }
 
 

--- a/lib/Munin/Node/SpoolWriter.pm
+++ b/lib/Munin/Node/SpoolWriter.pm
@@ -12,7 +12,7 @@ use Fcntl qw(:DEFAULT :flock);
 use Munin::Common::Defaults;
 use Munin::Common::SyncDictFile;
 use Munin::Common::Logger;
-use Munin::Common::Utils;
+use Munin::Common::Utils qw( is_valid_hostname );
 
 use Params::Validate qw( :all );
 use List::Util qw( first );
@@ -59,7 +59,7 @@ sub new {
         MAXIMUM_AGE,
     );
 
-    $self->{hostname} = first { defined($_) and _is_valid_hostname($_) } (
+    $self->{hostname} = first { defined($_) and is_valid_hostname($_) } (
         $validated->{hostname},
         $self->{metadata}->{hostname},
         DEFAULT_HOSTNAME,

--- a/script/munin-async
+++ b/script/munin-async
@@ -29,6 +29,7 @@ use Munin::Node::SpoolReader;
 use Munin::Node::SpoolWriter;
 use Munin::Common::Defaults;
 use Munin::Common::Logger;
+use Munin::Common::Utils qw( is_valid_hostname );
 
 # Disable buffering
 $| = 1;
@@ -69,6 +70,13 @@ if ($help) {
 if ($cleanupandexit) {
 	cleanup();
 	exit;
+}
+
+if ($overridehost) {
+    if (! is_valid_hostname($overridehost)) {
+        CRITICAL(sprintf("invalid hostname: %s\n", $overridehost));
+        exit(65);
+    }
 }
 
 if ( $verbose || $debug || $screen ) {

--- a/script/munin-async
+++ b/script/munin-async
@@ -73,9 +73,9 @@ if ($cleanupandexit) {
 
 if ( $verbose || $debug || $screen ) {
     my %log;
-    $log{output} = 'screen'  if $screen;
-    $log{level}  = 'verbose' if $verbose;
-    $log{level}  = 'debug'   if $debug;
+    $log{output} = 'screen' if $screen;
+    $log{level}  = 'info'   if $verbose;
+    $log{level}  = 'debug'  if $debug;
     Munin::Common::Logger::configure(%log);
 }
 

--- a/script/munin-async
+++ b/script/munin-async
@@ -28,6 +28,7 @@ use Pod::Usage;
 use Munin::Node::SpoolReader;
 use Munin::Node::SpoolWriter;
 use Munin::Common::Defaults;
+use Munin::Common::Logger;
 
 # Disable buffering
 $| = 1;
@@ -57,6 +58,7 @@ GetOptions(
         "help|h" => \$help,
         "verbose|v" => \$verbose,
         "debug" => \$debug,
+        "screen" => \$screen,
 ) or pod2usage(1);
 if ($help) {
         pod2usage(1);
@@ -68,6 +70,13 @@ if ($cleanupandexit) {
 	exit;
 }
 
+if ( $verbose || $debug || $screen ) {
+    my %log;
+    $log{output} = 'screen'  if $screen;
+    $log{level}  = 'verbose' if $verbose;
+    $log{level}  = 'debug'   if $debug;
+    Munin::Common::Logger::configure(%log);
+}
 
 # Use STDIN/STDOUT, in order to be : 
 # 1. secure over internet (SSH), munin-node needs only 
@@ -82,7 +91,9 @@ $hostname = $spoolreader->get_metadata("hostname") || hostname();
 $hostname = $overridehost if $overridehost;
 chomp($hostname);
 
-die "spooldir [$SPOOLDIR] not found" unless -d $SPOOLDIR;
+LOGCROAK("spooldir [$SPOOLDIR] not found") unless -d $SPOOLDIR;
+
+INFO("Starting");
 
 print "# munin node at $hostname\n";
 
@@ -154,5 +165,8 @@ munin-async [options]
                                   Note that without this flag, the "fetch" 
 				  command is disabled.
 
+     --screen                   Log to screen instead of syslog
+     --debug                    Log debug messages
      -v --verbose               Be verbose
      -h --help                  View this message	
+

--- a/script/munin-async
+++ b/script/munin-async
@@ -44,6 +44,7 @@ my $cleanupandexit;
 
 my $verbose;
 my $debug;
+my $screen;
 my $help;
 
 GetOptions(

--- a/script/munin-async
+++ b/script/munin-async
@@ -92,8 +92,6 @@ $hostname = $spoolreader->get_metadata("hostname") || hostname();
 $hostname = $overridehost if $overridehost;
 chomp($hostname);
 
-LOGCROAK("spooldir [$SPOOLDIR] not found") unless -d $SPOOLDIR;
-
 INFO("Starting");
 
 print "# munin node at $hostname\n";

--- a/script/munin-asyncd
+++ b/script/munin-asyncd
@@ -30,6 +30,7 @@ use List::Util qw(min max);
 
 use Munin::Node::SpoolWriter;
 use Munin::Common::Defaults;
+use Munin::Common::Logger;
 
 my $host = "localhost:4949";
 my $metahostname;
@@ -62,9 +63,18 @@ GetOptions(
 	"verbose|v" => \$verbose,
 	"nocleanup|n" => \$nocleanup,
 	"debug" => \$debug,
+        "screen" => \$screen,
 ) or pod2usage(1);
 if ($help) {
 	pod2usage(1);
+}
+
+if ( $verbose || $debug || $screen ) {
+    my %log;
+    $log{output} = 'screen'  if $screen;
+    $log{level}  = 'verbose' if $verbose;
+    $log{level}  = 'debug'   if $debug;
+    Munin::Common::Logger::configure(%log);
 }
 
 # $minrate defaults to $update_rate.
@@ -73,10 +83,15 @@ $minrate = $update_rate if ! defined $minrate;
 # Debug implies Verbose
 $verbose = 1 if $debug;
 
+unless (-d $SPOOLDIR) {
+	mkpath($SPOOLDIR, { verbose => $verbose, } ) 
+		or LOGCROAK("Cannot create '$SPOOLDIR': $!");
+}
+
 my $sock = new IO::Socket::INET(
 	PeerAddr        => "$host",
 	Proto   => 'tcp'
-) || die "Error creating socket: $!";
+) || LOGCROAK("Error creating socket: $!");
 my $nodeheader = <$sock>;
 print STDERR "[sock][>] nodes\n" if $debug;
 print $sock "nodes\n";
@@ -113,14 +128,14 @@ my $process_name = "main";
 
 my $plugins = {};
 {
-	print STDERR "[$$][$process_name] Reading config from $host\n" if $verbose;
+	INFO("[$$][$process_name] Reading config from $host");
 	my $sock = new IO::Socket::INET( 
 		PeerAddr	=> "$host", 
 		Proto	=> 'tcp'
 	) || die "Error creating socket: $!"; 
 
 	local $0 = "munin-asyncd [$metahostname] [list]";
-	print STDERR "[sock][>] cap multigraph\n" if $debug;
+	DEBUG("[sock][>] cap multigraph");
 	print $sock "cap multigraph\n";
 	<$sock>; # Read the first header comment line
 	<$sock>; # Read the multigraph response line
@@ -236,10 +251,10 @@ MAIN: while($keepgoing) {
 	my $sleep_sec = $when_next - time;
 
 	if ($sleep_sec > 0) {
-		print STDERR "[$$][$process_name] Sleeping $sleep_sec sec\n" if $verbose;
+		INFO("[$$][$process_name] Sleeping $sleep_sec sec");
 		sleep $sleep_sec;
 	} else {
-		print STDERR "[$$][$process_name] Already late : should sleep $sleep_sec sec\n" if $verbose;
+		INFO("[$$][$process_name] Already late : should sleep $sleep_sec sec\n");
 	}
 }
 
@@ -284,13 +299,13 @@ sub fetch_data
 			push @$output_rows, "update_rate $update_rate";
 		}
 
-		print STDERR "[$$][$process_name][>][$plugin] asking for data\n" if $verbose;
-		print STDERR "[$$][$process_name][>][$plugin][sock] fetch $plugin\n" if $debug;
+		INFO("[$$][$process_name][>][$plugin] asking for data\n");
+                DEBUG("[sock][>][$plugin] fetch $plugin\n");
 		print $sock "fetch $plugin\n";
 
 		while(my $line = <$sock>) {
 			chomp($line);
-			print STDERR "[$$][$process_name][<][$plugin][sock] $line\n" if $debug;
+			DEBUG("[sock][<][$plugin] $line");
 
 			if ($line =~ m/^\./) {
 				# Starting with . => end
@@ -327,5 +342,7 @@ munin-asyncd [options]
      -n --nocleanup             Disable automated spool dir cleanup
 
         --fork                  Do fork
+        --screen                Log to screen instead of syslog
+        --debug                 Log debug messages
      -v --verbose               Be verbose
      -h --help                  View this message	

--- a/script/munin-asyncd
+++ b/script/munin-asyncd
@@ -72,9 +72,9 @@ if ($help) {
 
 if ( $verbose || $debug || $screen ) {
     my %log;
-    $log{output} = 'screen'  if $screen;
-    $log{level}  = 'verbose' if $verbose;
-    $log{level}  = 'debug'   if $debug;
+    $log{output} = 'screen' if $screen;
+    $log{level}  = 'info'   if $verbose;
+    $log{level}  = 'debug'  if $debug;
     Munin::Common::Logger::configure(%log);
 }
 

--- a/script/munin-asyncd
+++ b/script/munin-asyncd
@@ -43,6 +43,7 @@ my $nocleanup;
 my $do_fork;
 my $verbose;
 my $debug;
+my $screen;
 my $help;
 my $update_rate = 300;
 my @nodes;

--- a/t/munin_common_utils.t
+++ b/t/munin_common_utils.t
@@ -1,0 +1,36 @@
+use warnings;
+use strict;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use Test::More tests => 2;
+
+use_ok('Munin::Common::Utils');
+
+use Data::Dumper;
+
+subtest 'is_valid_hostname' => sub {
+    plan tests => 5;
+
+    my $valid_hostname = 'munin.example.com';
+    ok(Munin::Common::Utils::is_valid_hostname($valid_hostname) eq $valid_hostname,
+       'valid hostname should return itself');
+
+    my $empty_hostname = '';
+    ok(! defined(Munin::Common::Utils::is_valid_hostname($empty_hostname)),
+       'fail on empty hostname');
+
+    my $hostname_with_invalid_chars='foo/bar.example.com';
+    ok(! defined(Munin::Common::Utils::is_valid_hostname($hostname_with_invalid_chars)),
+       'fail on hostname with invalid characters');
+
+    my $long_component_hostname = 'a' x 64 . '.example.com';
+    ok(! defined(Munin::Common::Utils::is_valid_hostname($long_component_hostname)),
+       'fail on hostname component length > 63');
+
+    my $long_hostname = join ('.', 'a' x 63, 'b' x 63, 'c' x 63, 'd' x 63 ) . '.example.com';
+    ok(! defined(Munin::Common::Utils::is_valid_hostname($long_hostname)),
+       sprintf('fail on hostname length > 255 (test is %s)', length($long_hostname) ));
+
+};


### PR DESCRIPTION
Replace the constructors of Munin::Node::SpoolReader and Munin::Node::SpoolWriter. All data used is validated, although validation could be stricter.
 
Adds Munin::Common::Utils, with an is_valid_hostname function, used by async modules.