### PR TITLE
Fix several bugs in the RRD tuning

### DIFF
--- a/lib/Munin/Master/UpdateWorker.pm
+++ b/lib/Munin/Master/UpdateWorker.pm
@@ -554,23 +554,38 @@ sub _ensure_filename {
 
 
 sub _ensure_tuning {
-    my ($self, $service, $data_source, $ds_config) = @_;
+    my ( $self, $service, $data_source, $ds_config ) = @_;
+    my $fqn = sprintf( "%s:%s", $self->{ID}, $service );
+
     my $success = 1;
 
-    my $rrd_file =
-        $self->_get_rrd_file_name($service, $data_source,
-                                  $ds_config);
+    my $rrd_file
+        = $self->_get_rrd_file_name( $service, $data_source, $ds_config );
 
     $ds_config = $self->_get_rrd_data_source_with_defaults($ds_config);
-    for my $rrd_prop (keys %$rrd_tune_flags) {
-        INFO "[INFO]: Config update, ensuring $rrd_prop of"
-	    . " '$rrd_file' is '$ds_config->{$rrd_prop}'.\n";
-        RRDs::tune($rrd_file, $rrd_tune_flags->{$rrd_prop},
-                   "42:$ds_config->{$rrd_prop}");
-        if (my $tune_error = RRDs::error()) {
-            ERROR "[ERROR] Tuning $rrd_prop of '$rrd_file' to"
-		. " '$ds_config->{$rrd_prop}' failed.\n";
-            $success = '';
+
+    for my $rrd_prop ( keys %$rrd_tune_flags ) {
+        RRDs::tune( $rrd_file, $rrd_tune_flags->{$rrd_prop},
+            "42:$ds_config->{$rrd_prop}" );
+        if ( RRDs::error() ) {
+            $success = 0;
+            ERROR(
+                sprintf(
+                    "fqn=%s, ds=%s, Tuning %s to %s failed: %s\n",
+                    $fqn,      $data_source,
+                    $rrd_prop, $ds_config->{$rrd_prop},
+                    RRDs::error()
+                )
+            );
+        }
+        else {
+            INFO(
+                sprintf(
+                    "fqn=%s, ds=%s, Tuning %s to %s\n",
+                    $fqn,      $data_source,
+                    $rrd_prop, $ds_config->{$rrd_prop}
+                )
+            );
         }
     }
 

--- a/lib/Munin/Master/UpdateWorker.pm
+++ b/lib/Munin/Master/UpdateWorker.pm
@@ -562,6 +562,8 @@ sub _ensure_tuning {
     my $rrd_file
         = $self->_get_rrd_file_name( $service, $data_source, $ds_config );
 
+    return unless -f $rrd_file;
+
     $ds_config = $self->_get_rrd_data_source_with_defaults($ds_config);
 
     for my $rrd_prop ( keys %$rrd_tune_flags ) {


### PR DESCRIPTION
Bugfix: Make Munin skip nonexistent RRD files when tuning.  Munin-update logged one error message per missing RRD file per new plugin/node when tuning.  This should make less noise in the logs.

Logging: Get the error message from RRD when tuning, and ensure it ends up in the log.
