### PR TITLE
munin-httpd: Add mime type for .gif

### DIFF
--- a/lib/Munin/Master/HTML.pm
+++ b/lib/Munin/Master/HTML.pm
@@ -38,6 +38,7 @@ sub handle_request
 			js => "application/javascript",
 			svg => "image/svg+xml",
 			svgz => "image/svg+xml",
+			gif => "image/gif",
 		);
 
 		my $filename = get_param("staticdir"). "/$page";


### PR DESCRIPTION
Gif images are served as plain text files, just as svg files were before ssm's commit