### PR TITLE
p/pgsql: Detect "lts" and "ltsX" postgresql versions

### DIFF
--- a/lib/Munin/Plugin/Pgsql.pm
+++ b/lib/Munin/Plugin/Pgsql.pm
@@ -514,7 +514,7 @@ sub get_version {
     my $r = $self->runquery("SELECT version()");
     my $v = $r->[0]->[0];
     die "Unable to detect PostgreSQL version\n"
-        unless ($v =~ /^PostgreSQL (\d+)\.(\d+)(\.\d+|devel|beta\d+|rc\d+)\b/);
+        unless ($v =~ /^PostgreSQL (\d+)\.(\d+)(\.\d+(lts\d*)*|devel|beta\d+|rc\d+)\b/);
     $self->{detected_version} = "$1.$2";
 }
 


### PR DESCRIPTION
like 8.4.22lts and 8.4.22lts1 on Debian

```
select version();
                                                  version                                                  
-----------------------------------------------------------------------------------------------------------
 PostgreSQL 8.4.22lts1 on x86_64-pc-linux-gnu, compiled by GCC gcc-4.4.real (Debian 4.4.5-8) 4.4.5, 64-bit
```