### PR TITLE
fix issues:426 (Numbers are crazy in diskstats plugin after reboot)

### DIFF
--- a/plugins/node.d.linux/diskstats.in
+++ b/plugins/node.d.linux/diskstats.in
@@ -34,6 +34,9 @@ do_autoconf() if ( $ARGV[0] && $ARGV[0] eq 'autoconf' );
 # Fetch current counter values
 my %cur_diskstats = fetch_device_counters();
 
+# Fetch uptime to detect system reboot
+my ($uptime) = fetch_uptime();
+
 # Weed out unwanted devices
 filter_device_list( \%cur_diskstats );
 
@@ -66,6 +69,20 @@ exit 0;
 ########
 # SUBS #
 ########
+
+# fetch_uptime
+#
+# read /proc/uptime and return it
+
+sub fetch_uptime {
+    open my $FH, "<", '/proc/uptime' or return undef;
+    my $line = <$FH>;
+    chomp($line);
+    my @row = split(/\s+/, $line);
+    close $FH;
+
+    return @row;
+}
 
 # generate_multigraph_data
 #
@@ -180,6 +197,17 @@ sub calculate_values {
     my $bytes_per_sector = 512;
 
     my $interval = time() - $prev_time;
+
+    if ($uptime < $interval) {
+        # system has rebooted
+
+        $interval = $uptime;
+
+        # all values will be zero at system reboot
+        for my $entry ( keys %$prev_stats ) {
+            $prev_stats->{$entry} = 0;
+        }
+    }
 
     my $read_ios  = subtract_wrapping_numbers($cur_stats->{'rd_ios'}, $prev_stats->{'rd_ios'});
     my $write_ios = subtract_wrapping_numbers($cur_stats->{'wr_ios'}, $prev_stats->{'wr_ios'});


### PR DESCRIPTION
diskstats ver 2.0.22 and later gives weird numbers on some entries after system reboot

 - how I fix
  - check /proc/uptime to detect system reboot
  - use uptime second instead of interval if uptime < interval
  - reset all previous status values to zero if uptime < interval
    - both "/sys/block/*/stat" and "/proc/diskstats' are reset to zero when system rebooted

 - refs
  - https://www.kernel.org/doc/Documentation/iostats.txt
  - https://www.kernel.org/doc/Documentation/block/stat.txt

fundamental solution should be as https://github.com/munin-monitoring/munin/issues/426#issuecomment-90748370
but it might be significant rewrite