### PR TITLE
First pass at fleshing out plugin documentation.

### DIFF
--- a/doc/plugin/index.rst
+++ b/doc/plugin/index.rst
@@ -32,35 +32,9 @@ All plugins must also support the argument 'config' to get metadata on the plugi
  
 Plugins may support other arguments, but the two cases described above will work for any plugin.
 
-How to use
+See Also
 ==========
 
-Learn it here :ref:`How to use Munin plugins <plugin-use>`.
-
-.. toctree::
-   :maxdepth: 2
-
-   use.rst
-
-How to write
-============
-
-Learn it here :ref:`How to write Munin plugins <plugin-writing>`.
-
-.. toctree::
-   :maxdepth: 2
-
-   writing.rst
-   writing-tips.rst
-
-Other documentation
-===================
-Tips on writing good plugins :ref:`Tips on Writing Munin Plugins <plugin-writing-tips>`.
-
-.. toctree::
-   :maxdepth: 2
-
-   env.rst
-   multigraphing.rst
-   supersampling.rst
-   snmp.rst
+:ref:`How to use Munin plugins <plugin-use>`.
+:ref:`How to write your own Munin plugins <plugin-writing>`.
+:ref:`Tips on Writing Munin Plugins <plugin-writing-tips>`.

--- a/doc/plugin/index.rst
+++ b/doc/plugin/index.rst
@@ -4,10 +4,10 @@
  The Munin plugin
 ==================
 
-Role
+Introduction
 ====
 
-A Munin plugin is a simple executable, invoked in a command line environment, whose role is to gather a
+A Munin plugin is a simple executable invoked in a command line environment whose role is to gather a
 set of facts on a host and present them in a format Munin can use. 
 
 A plugin is usually called without any arguments.  In this circumstance, the plugin returns 

--- a/doc/plugin/index.rst
+++ b/doc/plugin/index.rst
@@ -7,10 +7,10 @@
 Role
 ====
 
-A Munin plugin is a simple executable, whose role is to gather one
-set of facts on a host and present them in a format Munin can use to analyze. 
+A Munin plugin is a simple executable, invoked in a command line environment, whose role is to gather a
+set of facts on a host and present them in a format Munin can use. 
 
-A plugin is usually called without any arguments.  In this case, the plugin returns 
+A plugin is usually called without any arguments.  In this circumstance, the plugin returns 
 the data in a 'key value' format.  For 
 example, the 'load' plugin, which comes standard with Munin, will output the current
 system load::

--- a/doc/plugin/index.rst
+++ b/doc/plugin/index.rst
@@ -55,6 +55,7 @@ Learn it here :ref:`How to write Munin plugins <plugin-writing>`.
 
 Other documentation
 ===================
+Tips on writing good plugins :ref:`Tips on Writing Munin Plugins <plugin-writing-tips>`.
 
 .. toctree::
    :maxdepth: 2

--- a/doc/plugin/index.rst
+++ b/doc/plugin/index.rst
@@ -13,12 +13,12 @@ set of facts on a host and present them in a format Munin can use to analyze.
 A plugin is usually called without any arguments.  When this happens, it returns 
 the data it is configured to gather, in a 'key value' format.  For 
 example, the 'load' plugin, which comes standard with Munin, will output the current
-system load:
+system load::
 
  # munin-run load
  load.value 0.03
 
-All plugins must also support the argument 'config' to get metadata on the plugin:
+All plugins must also support the argument 'config' to get metadata on the plugin::
  # munin-run load config
  graph_title Load average
  graph_args --base 1000 -l 0

--- a/doc/plugin/index.rst
+++ b/doc/plugin/index.rst
@@ -35,6 +35,6 @@ Plugins may support other arguments, but the two cases described above will work
 See Also
 ==========
 
-:ref:`How to use Munin plugins <plugin-use>`.
-:ref:`How to write your own Munin plugins <plugin-writing>`.
-:ref:`Tips on Writing Munin Plugins <plugin-writing-tips>`.
+* :ref:`How to use Munin plugins <plugin-use>`.
+* :ref:`How to write your own Munin plugins <plugin-writing>`.
+* :ref:`Tips on Writing Munin Plugins <plugin-writing-tips>`.

--- a/doc/plugin/index.rst
+++ b/doc/plugin/index.rst
@@ -7,13 +7,29 @@
 Role
 ====
 
-The munin plugin is a simple executable, which role is to gather one
-set of facts about the local server (or fetching data from a remote machine via SNMP)
+A Munin plugin is a simple executable, whose role is to gather one
+set of facts on a host and present them in a format Munin can use to analyze. 
 
-The plugin is called with the argument "config" to get metadata, and
-with no arguments to get the values. These are mandatory arguments for each plugin.
-We have some more standard arguments, which play a role in the process of automatic configuration. 
-Read more in the docs listed below.
+A plugin is usually called without any arguments.  When this happens, it returns 
+the data it is configured to gather, in a 'key value' format.  For 
+example, the 'load' plugin, which comes standard with Munin, will output the current
+system load:
+
+ # munin-run load
+ load.value 0.03
+
+All plugins must also support the argument 'config' to get metadata on the plugin:
+ # munin-run load config
+ graph_title Load average
+ graph_args --base 1000 -l 0
+ graph_vlabel load
+ graph_scale no
+ graph_category system
+ load.label load
+ graph_info The load average of the machine describes how many processes are in the run-queue (scheduled to run "immediately").
+ load.info 5 minute load average
+ 
+Plugins may support other arguments, but the two cases described above will work for any plugin.
 
 How to use
 ==========

--- a/doc/plugin/index.rst
+++ b/doc/plugin/index.rst
@@ -10,8 +10,8 @@ Role
 A Munin plugin is a simple executable, whose role is to gather one
 set of facts on a host and present them in a format Munin can use to analyze. 
 
-A plugin is usually called without any arguments.  When this happens, it returns 
-the data it is configured to gather, in a 'key value' format.  For 
+A plugin is usually called without any arguments.  In this case, the plugin returns 
+the data in a 'key value' format.  For 
 example, the 'load' plugin, which comes standard with Munin, will output the current
 system load::
 
@@ -19,6 +19,7 @@ system load::
  load.value 0.03
 
 All plugins must also support the argument 'config' to get metadata on the plugin::
+
  # munin-run load config
  graph_title Load average
  graph_args --base 1000 -l 0

--- a/doc/plugin/use.rst
+++ b/doc/plugin/use.rst
@@ -7,34 +7,37 @@
 .. index::
    pair: plugin; installing
 
-Installing
+Default Installation
 ==========
 
 The default directory for plugin scripts is /usr/share/munin/plugins/.
-A plugin is activated when you create a symbolic link in the ``servicedir`` 
+A plugin is activated when a symbolic link is created in the ``servicedir`` 
 (usually /etc/munin/plugins/ for a package installation of Munin)
-and restart the munin-node daemon.
+and munin-node is restarted.
 
-The utility :ref:`munin-node-configure` is used by Munin installation 
+The utility :ref:`munin-node-configure` is used by the Munin installation 
 procedure to check which plugins are suitable for your node and 
-create the links automatically. You may call it everytime when you
-changed something (services, hardware  or configuration) on your
-node and want to adjust the collection of plugins accordingly. 
-If you removed software start it with option '--remove-also'.
+create the links automatically. It can be called everytime when a system
+configuration changes (services, hardware, etc) on the node and it will adjust
+the collection of plugins accordingly. 
+
+To have :ref:`munin-node-configure` remove plugins for software that may no longer
+be installed, use the option '--remove-also'.
+
+Installing Third Party Plugins
+==========
 
 To use a Munin plugin being delivered from a `3rd-Party <http://gallery.munin-monitoring.org/contrib/>`_,
-place it in directory ``/usr/local/munin/lib/plugins`` (or in another 
-directory of your choice) make it executable and create the service link. 
-It may work also, if you put the plugin in the ``servicedir`` directly, 
-but this is not recommended to support use of utility 
-``munin-node-configure`` and because it is not appropriate for
-:ref:`wildcard plugins <tutorial-plugins-wildcard>` and also
-to avoid struggle with SELinux.
+place it in directory ``/usr/local/munin/lib/plugins`` (or any other 
+directory), make it executable, and create the service link. 
+It it also possible to place the plugin directly into the ``servicedir``, but this is not recommended for the following reasons:
+* it undermines the utility ``munin-node-configure`` 
+* it is not appropriate for :ref:`wildcard plugins <tutorial-plugins-wildcard>` 
+* it interferes with SELinux 
 
-You may put 3rd-Party plugins in the *official* plugin directory
-(usually ``/usr/share/munin/plugins``), but be prepared (Backup!)
-against overwriting existing plugin scripts with newer versions
-from the distribution.
+It is also possible to put 3rd-Party plugins in the *official* plugin directory
+(usually ``/usr/share/munin/plugins``), but this runs the risk of having said
+plugins overitten by distribution updates.
 
 .. index::
    pair: plugin; configuration
@@ -44,15 +47,14 @@ from the distribution.
 Configuring
 ===========
 
-plugin-conf.d is the directory with the plugin configuration files. 
-When pre-packaged, it's usually located in /etc/munin/, while if 
-compiled from source it is often found in /etc/opt/munin/. 
+/etc/munin/plugin-conf.d (sometimes /etc/opt/munin/plugin-conf.d) is where plugin configuration files
+are stored.
 
-To make sure that you get all new plugin configurations with software updates 
-you should not change the file munin-node which is delivered with the munin package.
-Instead put your customized configuration in a file called zzz-myconf.
-As the config files are read in alphabetical order your file is read 
-at last and will override configuration found in the other files.
+To make sure that plugin configurations are updated with software updates 
+admins should not change the file munin-node which is delivered with the munin package.
+Instead place customized configuration in a file called zzz-myconf.
+As the config files are read in alphabetical order, this file is read 
+last and will override configuration data found in the other files.
 
 The file should consist of one or more sections, one section for each 
 (group of) plugin(s) that should run with different privileges 

--- a/doc/plugin/writing-tips.rst
+++ b/doc/plugin/writing-tips.rst
@@ -4,6 +4,19 @@
  Tips for  writing good munin plugins
 ======================================
 
+When developing plugins for Munin, there's some guidelines that should be observed.  
+
+Error Handling
+==============
+
+Munin plugins should handle error conditions in a fashion that make them easy to understand and debug.  Use these
+guidelines when developing a plugin:
+* Output may always contain comments.  Use # blocks within the output to give more information
+* If an error occurs in the plugin, two things should happen:
+** A non-zero exit code must be issued
+** A descriptive message should be written to STDERR.  On a deployed plugin, this message will appear in munin-node.log.  When 
+invoked via munin-run, it'll appear in the console.
+
 Handling temporary files
 ========================
 

--- a/doc/plugin/writing-tips.rst
+++ b/doc/plugin/writing-tips.rst
@@ -11,10 +11,12 @@ Error Handling
 
 Munin plugins should handle error conditions in a fashion that make them easy to understand and debug.  Use these
 guidelines when developing a plugin:
+
 * Output may always contain comments.  Use # blocks within the output to give more information
 * If an error occurs in the plugin, two things should happen:
-** A non-zero exit code must be issued
-** A descriptive message should be written to STDERR.  On a deployed plugin, this message will appear in munin-node.log.  When 
+
+ * A non-zero exit code must be issued
+ * A descriptive message should be written to STDERR.  On a deployed plugin, this message will appear in munin-node.log.  When 
 invoked via munin-run, it'll appear in the console.
 
 Handling temporary files

--- a/doc/plugin/writing-tips.rst
+++ b/doc/plugin/writing-tips.rst
@@ -16,8 +16,7 @@ guidelines when developing a plugin:
 * If an error occurs in the plugin, two things should happen:
 
  * A non-zero exit code must be issued
- * A descriptive message should be written to STDERR.  On a deployed plugin, this message will appear in munin-node.log.  When 
-invoked via munin-run, it'll appear in the console.
+ * A descriptive message should be written to STDERR.  On a deployed plugin, this message will appear in munin-node.log.  When invoked via munin-run, it'll appear in the console.
 
 Handling temporary files
 ========================

--- a/doc/plugin/writing.rst
+++ b/doc/plugin/writing.rst
@@ -104,23 +104,25 @@ Activating the plugin
 =====================
 
 Place the plugin in the /etc/munin/plugins/ directory, and make it
-executable.
+executable.  Note that most distributions place plugins in a different directory,
+and 'activate' them by symlinking htem to /etc/munin/plugins.  New module development
+should use a similar approach so that in-process development doesn't get run 
+by mistake.
 
-Then, restart the munin-node.
+Any time a new plugin is placed or symlinked into /etc/munin/plugins, munin-node should be restarted.
 
 Debugging the plugin
 ====================
 
-To see how the plugin works, as the munin node would run it, you can
-use the command "munin-run".
+Plugins are just small programs or scripts, and just like small programs, are prone to problems
+or unexpected behaviour.  When either developing a new plugin, or debugging an already existing one,
+use the following information to help track down the problem:
 
-If the plugin is called "example", you can run "munin-run example
-config" to see the plugin configuration, and "munin-run example" to
-see the data.
+* A plugin may be tested 'by hand' by using the command 'munin-run'.  Note the plugin needs to 
+have been activated before this will work (see above).
 
-If you do not get the output you expect, check if your munin plugin
-needs more privileges. Normally, it is run as the "munin" user, but
-gathering some data may need more access.
+* If an error occurs, error messages will be written to STDERR, and 
+exit status will be non-zero.
 
-If the munin plugin emits errors, they will be visible in
-/var/log/munin/munin-node.log
+* If a plugin is already activated, any errors that may happen when the 'munin-node' cron job is
+executed will be logged, via stderr, to /var/log/munin/munin-node.log

--- a/doc/plugin/writing.rst
+++ b/doc/plugin/writing.rst
@@ -118,11 +118,8 @@ Plugins are just small programs or scripts, and just like small programs, are pr
 or unexpected behaviour.  When either developing a new plugin, or debugging an already existing one,
 use the following information to help track down the problem:
 
-* A plugin may be tested 'by hand' by using the command 'munin-run'.  Note the plugin needs to 
-have been activated before this will work (see above).
+* A plugin may be tested 'by hand' by using the command 'munin-run'.  Note the plugin needs to have been activated before this will work (see above).
 
-* If an error occurs, error messages will be written to STDERR, and 
-exit status will be non-zero.
+* If an error occurs, error messages will be written to STDERR, and exit status will be non-zero.
 
-* If a plugin is already activated, any errors that may happen when the 'munin-node' cron job is
-executed will be logged, via stderr, to /var/log/munin/munin-node.log
+* If a plugin is already activated, any errors that may happen when the 'munin-node' cron job is executed will be logged, via stderr, to /var/log/munin/munin-node.log


### PR DESCRIPTION
Per the meeting on Freenode today, I was tasked with updating the plugin documentation to show guidelines and clarify error conditions and other helpful hints for writing plugins.  I also reworked some of the existing docs to make them more 'doc like' (not written in second person, etc).  The index page now has sub references to the secondary pages, and is a little more complete.