### PR TITLE
mysql: add graph binlog_groupcommit

### DIFF
--- a/plugins/node.d/mysql_
+++ b/plugins/node.d/mysql_
@@ -15,6 +15,7 @@ Any MySQL platform, tested by the authors on:
 * MySQL 5.0.51
 * MariaDB 5.5.39
 * MariaDB-5.5.39(galera).
+* MariaDB 10.0.18
 
 Plugins:
 * MariaDB-10 Query Response Time: https://mariadb.com/kb/en/mariadb/query_response_time-plugin/
@@ -604,6 +605,26 @@ $graphs{bin_relay_log} = {
 	{name => 'Binlog_stmt_cache_use',      label => 'Binlog Statement Cache Use'},
 	{name => 'ma_binlog_size',        label => 'Binary Log Space'},
 	{name => 'relay_log_space',       label => 'Relay Log Space'},
+    ],
+};
+
+#-------------------------
+$graphs{binlog_groupcommit} = {
+    config => {
+       global_attrs => {
+           title  => 'Binary Log Group Commits',
+           vlabel => 'Commits/Groups',
+       },
+       data_source_attrs => {
+           draw  => 'LINE1',
+       },
+    },
+    data_sources => [
+       {name => 'Binlog_commits', label => 'Binlog commits'},
+       {name => 'Binlog_group_commits',      label => 'Binlog Group Commits'},
+       {name => 'Binlog_group_commit_trigger_count', label => 'Binlog Groups because of binlog_commit_wait_count'},
+       {name => 'Binlog_group_commit_trigger_timeout', label => 'Binlog Groups because of binlog_commit_wait_usec'},
+       {name => 'Binlog_group_commit_trigger_lock_wait', label => 'Binlog Groups because of transactions'},
     ],
 };
 


### PR DESCRIPTION
This adds a graph binlog_groupcommit. MariaDB-5.3 has had commit grouping.
MariaDB-10 added mechanisms to group a number of commits by count/usec
giving the user more control.

With control came the need to monitor. When 10.0.18 comes out there will
be status variables that break the reason for the group commit out into
their reasons. Yay for being ahead of the game :-)