### PR TITLE
Add queries for PostgreSQL 9.4

### DIFF
--- a/plugins/node.d/postgres_connections_
+++ b/plugins/node.d/postgres_connections_
@@ -84,6 +84,17 @@ my $pg = Munin::Plugin::Pgsql->new(
                 ON tmp.mstate=tmp2.mstate
                 ORDER BY 1;
 		",
+            [ 9.4, "SELECT tmp.state,COALESCE(count,0) FROM
+                 (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(state)
+                LEFT JOIN
+                 (SELECT CASE WHEN waiting THEN 'waiting' WHEN query='<IDLE>' THEN 'idle' WHEN query='<IDLE> in transaction' THEN 'idletransaction' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END AS state,
+                 count(*) AS count
+                 FROM pg_stat_activity WHERE pid != pg_backend_pid() %%FILTER%%
+                 GROUP BY CASE WHEN waiting THEN 'waiting' WHEN query='<IDLE>' THEN 'idle' WHEN query='<IDLE> in transaction' THEN 'idletransaction' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END
+                 ) AS tmp2
+                ON tmp.state=tmp2.state
+                ORDER BY 1
+                " ],
             [ 9.1, "SELECT tmp.state,COALESCE(count,0) FROM
                  (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(state)
 	        LEFT JOIN

--- a/plugins/node.d/postgres_connections_db
+++ b/plugins/node.d/postgres_connections_db
@@ -72,8 +72,10 @@ my $pg = Munin::Plugin::Pgsql->new(
     vlabel => 'Connections',
     basequery => [
         "SELECT pg_database.datname,COALESCE(count,0) AS count FROM pg_database LEFT JOIN (SELECT datname,count(*) FROM pg_stat_activity WHERE pid != pg_backend_pid() GROUP BY datname) AS tmp ON pg_database.datname=tmp.datname WHERE datallowconn ORDER BY 1",
-        [
-            9.1,
+        [ 9.4,
+            "SELECT pg_database.datname,COALESCE(count,0) AS count FROM pg_database LEFT JOIN (SELECT datname,count(*) FROM pg_stat_activity WHERE pid != pg_backend_pid() GROUP BY datname) AS tmp ON pg_database.datname=tmp.datname WHERE datallowconn ORDER BY 1",
+        ],
+        [ 9.1,
             "SELECT pg_database.datname,COALESCE(count,0) AS count FROM pg_database LEFT JOIN (SELECT datname,count(*) FROM pg_stat_activity WHERE procpid != pg_backend_pid() GROUP BY datname) AS tmp ON pg_database.datname=tmp.datname WHERE datallowconn ORDER BY 1",
         ]
     ],

--- a/plugins/node.d/postgres_querylength_
+++ b/plugins/node.d/postgres_querylength_
@@ -78,6 +78,12 @@ my $pg = Munin::Plugin::Pgsql->new(
                     SELECT 'transaction',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-xact_start)),0) FROM pg_stat_activity WHERE 1=1 %%FILTER%%",
         [
             9.1,
+            "SELECT 'query',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-query_start)),0) FROM pg_stat_activity WHERE query NOT LIKE '<IDLE%' %%FILTER%%
+                     UNION ALL
+                    SELECT 'transaction',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-xact_start)),0) FROM pg_stat_activity WHERE 1=1 %%FILTER%%",
+        ],
+        [
+            9.1,
             "SELECT 'query',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-query_start)),0) FROM pg_stat_activity WHERE current_query NOT LIKE '<IDLE%' %%FILTER%%
                      UNION ALL
                     SELECT 'transaction',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-xact_start)),0) FROM pg_stat_activity WHERE 1=1 %%FILTER%%",

--- a/plugins/node.d/postgres_users
+++ b/plugins/node.d/postgres_users
@@ -71,8 +71,10 @@ my $pg = Munin::Plugin::Pgsql->new(
     vlabel => 'Connections',
     basequery => [
         "SELECT usename,count(*) FROM pg_stat_activity WHERE pid != pg_backend_pid() GROUP BY usename ORDER BY 1",
-        [
-            9.1,
+        [ 9.4,
+            "SELECT usename,count(*) FROM pg_stat_activity WHERE pid != pg_backend_pid() GROUP BY usename ORDER BY 1",
+        ],
+        [ 9.1,
             "SELECT usename,count(*) FROM pg_stat_activity WHERE procpid != pg_backend_pid() GROUP BY usename ORDER BY 1",
         ]
     ],


### PR DESCRIPTION
In PostgreSQL 9.4 some monitoring related columns were renamed, so old queries don't work anymore.
Changelog: http://www.postgresql.org/docs/9.4/static/release-9-2.html
