### PR TITLE
reduce number of forked processes

### DIFF
--- a/plugins/node.d.linux/proc
+++ b/plugins/node.d.linux/proc
@@ -138,7 +138,6 @@ my @procuser = split(/\|/, $ENV{'procuser'});
 my @procaspect = exists $ENV{'procaspect'} ? split(/\|/, $ENV{'procaspect'}) : ('cpu', 'memory', 'ctxt_switches', 'threads', 'processes', 'io');
 my @proctitlec;
 my @procuniq;
-my %useruid = ();
 
 #my $procname = exists $ENV{'procname'} ? $ENV{'procname'} : "init";
 
@@ -312,6 +311,16 @@ my %ASPECTS = (
     }
 );
 
+# Open file and return contents.  If called in scalar context, return
+# as one string.  If called in list context, return array of lines.
+sub slurp {
+    my $file = shift;
+    open(my $fh, "<", $file) or return;
+    my @content = <$fh>;
+    close($fh);
+    return wantarray ? @content : join("", @content);
+}
+
 # Populate %procstats with values.
 sub populate_stats
 {
@@ -339,51 +348,36 @@ sub populate_stats
         $procstats{$procuniq[$i]}{"read_bytes"} = 0;
         $procstats{$procuniq[$i]}{"write_bytes"} = 0;
         $procstats{$procuniq[$i]}{"cancelled_write_bytes"} = 0;
+        my $procuid = getpwnam($procuser[$i]); # may return undef
 
     STATLINE:
-        foreach my $line(`grep -h \\\($procname[$i]\\\) /proc/[0-9]*/stat`) {
+        foreach my $line(`fgrep -h '($procname[$i])' /proc/[0-9]*/stat`) {
             my ($pid) = $line =~ /^(\d+)/;
 
-            open( my $fh_cmdline, "<", "/proc/$pid/cmdline" ) or next STATLINE;
-            my $cmdline = do { local $/; <$fh_cmdline> };
-            close($fh_cmdline);
-
-            open( my $fh_status, "<", "/proc/$pid/status" ) or next STATLINE;
-            my $cmduid = do { local $/; <$fh_status> };
-            close($fh_status);
-
+            my $cmdline = slurp("/proc/$pid/cmdline") or next STATLINE;
             $cmdline =~ tr{\0}{ };
 
-            ($cmduid) = $cmduid =~ m{
-                                        ^Uid:    # We want the line starting with Uid:
-                                        \s+      # skip whitespace
-                                        (\d+)    # capture the first number on that line
-                                }smx;
+            my $cmduid = (lstat("/proc/$pid"))[4];
 
             next STATLINE if $procargs[$i] and $cmdline !~ /$procargs[$i]/;
+            next STATLINE if defined $procuid and $cmduid != $procuid;
 
-            if ( length($procuser[$i]) > 0 ) {
-                if ( $cmduid ne $useruid{$procuser[$i]} ) {
-                    next STATLINE;
-                }
-            }
-
-            if ($line =~ /^(\d+) \((.*)\) (.) \-?\d+ \-?\d+ \-?\d+ \-?\d+ \-?\d+ \d+ \d+ \d+ \d+ \d+ (\d+) (\d+) \d+ \d+ \-?\d+ \d+ (\d+) \-?\d+ \d+ (\d+) (\d+)/) {
-                $procstats{$procuniq[$i]}{"utime"} += $4;
-                $procstats{$procuniq[$i]}{"stime"} += $5;
-                $procstats{$procuniq[$i]}{"threads"} += $6;
-                $procstats{$procuniq[$i]}{"vsize"} += $7;
-                $procstats{$procuniq[$i]}{"rss"} += $8;
+            if ($line =~ /^\d+ \(.*\) . \-?\d+ \-?\d+ \-?\d+ \-?\d+ \-?\d+ \d+ \d+ \d+ \d+ \d+ (\d+) (\d+) \d+ \d+ \-?\d+ \d+ (\d+) \-?\d+ \d+ (\d+) (\d+)/) {
+                $procstats{$procuniq[$i]}{"utime"} += $1;
+                $procstats{$procuniq[$i]}{"stime"} += $2;
+                $procstats{$procuniq[$i]}{"threads"} += $3;
+                $procstats{$procuniq[$i]}{"vsize"} += $4;
+                $procstats{$procuniq[$i]}{"rss"} += $5;
                 $procstats{$procuniq[$i]}{"processes"} += 1;
-                foreach my $line(`cat /proc/$1/status`){
-                    if ($line =~ /^Vm(.*):\s+(\d+) kB$/){
-                        $procstats{$procuniq[$i]}{"Vm$1"} += ($2*1024);
+                foreach my $line (slurp("/proc/$pid/status")){
+                    if ($line =~ /^(Vm.*):\s+(\d+) kB$/){
+                        $procstats{$procuniq[$i]}{$1} += ($2*1024);
                     }
-                    if ($line =~ /^(.*)_ctxt_switches:\s+(\d+)$/){
-                        $procstats{$procuniq[$i]}{"$1_ctxt_switches"} += $2;
+                    if ($line =~ /^(.*_ctxt_switches):\s+(\d+)$/){
+                        $procstats{$procuniq[$i]}{$1} += $2;
                     }
                 }
-                foreach my $line(`cat /proc/$1/io`){
+                foreach my $line (slurp("/proc/$pid/io")){
                     if ( $line =~ /^(.*):\s+(\d+)$/ ) {
                         $procstats{$procuniq[$i]}{$1} += $2;
                     }
@@ -571,8 +565,6 @@ sub set_run
         if (length($procuser[$i]) > 0 ) {
             $proctitlec[$i] = "$proctitlec[$i] by $procuser[$i]";
             $procuniq[$i] = $procuniq[$i]."___".clean_fieldname($procuser[$i]);
-            $useruid{$procuser[$i]} = `getent passwd $procuser[$i] | cut -d : -f 3`;
-            chomp($useruid{$procuser[$i]});
         }
         $procuniq[$i] = clean_fieldname($procuniq[$i]);
         $i++;


### PR DESCRIPTION
by reducing the number of cat processes, run-time on the (arbitrarily selected) system I tested on was reduced to about a fourth.
