### PR TITLE
munin-node-configure: allow setting SNMP domain

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -111,6 +111,7 @@ my $build = Module::Build->new(
         'HTTP::Server::Simple::CGI'    => '0',
         'IO::Socket::INET6'      => '2.69',
         'LWP::UserAgent'         => '6.06',
+        'List::Util'             => '0',
         'List::MoreUtils'        => '0.33',
         'Log::Dispatch'          => '2.41',
         'Net::SNMP'              => 'v6.0.1',

--- a/lib/Munin/Node/SNMPConfig.pm
+++ b/lib/Munin/Node/SNMPConfig.pm
@@ -22,6 +22,7 @@ sub new
 
     my $version  = $opts{version} || '2c';
     my $port     = $opts{port}    || 161;
+    my $domain   = $opts{domain}  || 'udp';
 
     if ($version eq '3') {
         # Privacy
@@ -57,6 +58,7 @@ sub new
         hosts     => $hosts,
         port      => $port,
         version   => $version,
+        domain    => $domain,
         sec_args  => \%sec_args,
     );
 
@@ -87,6 +89,7 @@ sub _probe_single_host
 		-hostname  => $host,
         -port      => $self->{port},
         -version   => $self->{version},
+        -domain    => $self->{domain},
 
         %{$self->{sec_args}},
 
@@ -293,6 +296,12 @@ The SNMP version to use.  Default is '2c'.
 =item community
 
 The community string to use for SNMP version 1 or 2c.  Default is 'public'.
+
+=item domain
+
+The Transport Domain to use for exchanging SNMP messages. The default
+is UDP/IPv4. Possible values: 'udp', 'udp4', 'udp/ipv4'; 'udp6',
+'udp/ipv6'; 'tcp', 'tcp4', 'tcp/ipv4'; 'tcp6', 'tcp/ipv6'.
 
 =item username
 

--- a/script/munin-node-configure
+++ b/script/munin-node-configure
@@ -85,7 +85,7 @@ sub parse_args
 	my ($suggest, $shell, $removes, $newer);
 	my $exit_not_error = 1;
 	my @families;
-	my (@snmp_hosts, $snmpver, $snmpcomm, $snmpport);
+	my (@snmp_hosts, $snmpver, $snmpcomm, $snmpport, $snmpdomain);
     my ($snmp3username, $snmp3authpass, $snmp3authproto, $snmp3privpass, $snmp3privproto);
 
     print_usage_and_exit() unless GetOptions(
@@ -113,6 +113,7 @@ sub parse_args
         'snmp=s'          => \@snmp_hosts,
         'snmpversion=s'   => \$snmpver,
         'snmpport=i'      => \$snmpport,
+        'snmpdomain=s'    => \$snmpdomain,
         # SNMPv1/2c
         'snmpcommunity=s' => \$snmpcomm,
         # SNMPv3
@@ -141,6 +142,7 @@ sub parse_args
         hosts        => \@snmp_hosts,
         version      => $snmpver,
         port         => $snmpport,
+        domain       => $snmpdomain,
 
         community    => $snmpcomm,
 
@@ -582,6 +584,12 @@ The SNMP version (1, 2c or 3) to use. ['2c']
 =item B<< --snmpport <port> >>
 
 The SNMP port to use [161]
+
+=item B<< --snmpdomain <domain> >>
+
+The Transport Domain to use for exchanging SNMP messages. The default
+is UDP/IPv4. Possible values: 'udp', 'udp4', 'udp/ipv4'; 'udp6',
+'udp/ipv6'; 'tcp', 'tcp4', 'tcp/ipv4'; 'tcp6', 'tcp/ipv6'.
 
 =item B<SNMP 1/2c authentication>
 

--- a/t/munin_node_snmpconfig.t
+++ b/t/munin_node_snmpconfig.t
@@ -23,6 +23,7 @@ use_ok 'Munin::Node::SNMPConfig';
 			hosts     => \@hosts,
 			port      => '161',
 			version   => '2c',
+			domain    => 'udp',
 			sec_args  => {
 				-community => 'public',
 			},
@@ -36,12 +37,13 @@ use_ok 'Munin::Node::SNMPConfig';
 			hosts      => \@hosts,
 			version    => '1',
 			port       => '162',
-
+			domain     => 'udp',
 			community  => 'fnord',
 		),
 		{
 			hosts     => \@hosts,
 			port      => '162',
+			domain    => 'udp',
 			version   => '1',
 			sec_args  => {
 				-community => 'fnord',
@@ -56,12 +58,13 @@ use_ok 'Munin::Node::SNMPConfig';
 			hosts      => \@hosts,
 			version    => '2c',
 			port       => '161',
-
+			domain     => 'udp',
 			community  => 'fnord',
 		),
 		{
 			hosts     => \@hosts,
 			port      => '161',
+			domain    => 'udp',
 			version   => '2c',
 			sec_args  => {
 				-community => 'fnord',
@@ -76,12 +79,13 @@ use_ok 'Munin::Node::SNMPConfig';
 			hosts      => \@hosts,
 			version    => '3',
 			port       => '162',
-
+			domain     => 'udp',
 			username   => 'jeff',
 		),
 		{
 			hosts     => \@hosts,
 			port      => '162',
+			domain    => 'udp',
 			version   => '3',
 			sec_args  => {
 				-username => 'jeff',
@@ -96,13 +100,14 @@ use_ok 'Munin::Node::SNMPConfig';
 			hosts      => \@hosts,
 			version    => '3',
 			port       => '162',
-
+			domain     => 'udp',
 			username   => 'jeff',
 			authpassword => 'swordfish',
 		),
 		{
 			hosts     => \@hosts,
 			port      => '162',
+			domain    => 'udp',
 			version   => '3',
 			sec_args  => {
 				-username => 'jeff',
@@ -117,7 +122,7 @@ use_ok 'Munin::Node::SNMPConfig';
 			hosts      => \@hosts,
 			version    => '3',
 			port       => '162',
-
+			domain     => 'udp',
 			username   => 'jeff',
 			authpassword => 'swordfish',
 			authprotocol => 'sha',
@@ -125,6 +130,7 @@ use_ok 'Munin::Node::SNMPConfig';
 		{
 			hosts     => \@hosts,
 			port      => '162',
+			domain    => 'udp',
 			version   => '3',
 			sec_args  => {
 				-username => 'jeff',
@@ -141,12 +147,14 @@ use_ok 'Munin::Node::SNMPConfig';
 			hosts      => \@hosts,
 			version    => '3',
 			port       => '162',
+			domain     => 'udp',
 			username   => 'jeff',
 			privpassword => 'swordfish',
 		),
 		{
 			hosts     => \@hosts,
 			port      => '162',
+			domain    => 'udp',
 			version   => '3',
 			sec_args  => {
 				-username => 'jeff',
@@ -165,6 +173,7 @@ use_ok 'Munin::Node::SNMPConfig';
 			hosts      => \@hosts,
 			version    => '3',
 			port       => '162',
+			domain     => 'udp',
 			username   => 'jeff',
 			authpassword => 'swordfish',
 			privpassword => 'hedgerows',
@@ -173,6 +182,7 @@ use_ok 'Munin::Node::SNMPConfig';
 		{
 			hosts     => \@hosts,
 			port      => '162',
+			domain    => 'udp',
 			version   => '3',
 			sec_args  => {
 				-username => 'jeff',


### PR DESCRIPTION
This allows the user to probe SNMP hosts using any of the transport domains supported by Net::SNMP, by specifying the --snmpdomain option to munin-node-configure.