### PR TITLE
Prevent -week graph from showing if there's not enough room to display it

### DIFF
--- a/web/static/css/_responsive.scss
+++ b/web/static/css/_responsive.scss
@@ -12,8 +12,6 @@
 		border-radius: 0;
 		padding: 5px;
 
-		.singleLine { margin-top: 0; }
-
 		.filter {
 			float: none;
 			display: inline-block;
@@ -139,6 +137,11 @@
 		display: block;
 		width: 100%;
 	}
+}
+
+/* Hide second graph in nodeview when there's not enough horizontal space to show both */
+@media (max-width: 1260px) {
+	.hide-if-overflows { display: none!important; }
 }
 
 /* Medium devices */

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -1355,9 +1355,6 @@ footer p.tagline:hover {
     border-radius: 0;
     padding: 5px;
   }
-  header .singleLine {
-    margin-top: 0;
-  }
   header .filter {
     float: none;
     display: inline-block;
@@ -1480,6 +1477,12 @@ footer p.tagline:hover {
   .dzForm #dynaForm .half {
     display: block;
     width: 100%;
+  }
+}
+/* Hide second graph in nodeview when there's not enough horizontal space to show both */
+@media (max-width: 1260px) {
+  .hide-if-overflows {
+    display: none !important;
   }
 }
 /* Medium devices */

--- a/web/templates/munin-nodeview.tmpl
+++ b/web/templates/munin-nodeview.tmpl
@@ -16,7 +16,7 @@
 					<li class="last">year</li>
 				</ul>
 			</div>
-			<div class="timeRangeSwitch hide-mobile">
+			<div class="timeRangeSwitch hide-if-overflows">
 				<ul>
 					<li>hour</li>
 					<li>day</li>
@@ -64,7 +64,7 @@
 							  data-col="0" />
 						</TMPL_UNLESS>
 					</a>
-					<a href="<TMPL_VAR URLX>" class="graphLink hide-mobile i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
+					<a href="<TMPL_VAR URLX>" class="graphLink hide-if-overflows i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
 						<TMPL_UNLESS DYN_IMAGES>
 							<img class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
 							  src="<TMPL_VAR IMGWEEK>"


### PR DESCRIPTION
Previously, the -week graph was shown under the -day one if there wasn't
enough horizontal space to show both. It is now hidden.

If the browser window width (or more specifically the body width) is lower than 1260px, the second graph will be hidden. For history, here's the calculation:

 - nav width: 200px
 - content border+padding: 1+30px
 - graph width+right margin (x2): 502+4px

This sums up as 1243px. We set the trigger width value to 1260 to have some margin if we slightly change a margin/padding/width value in the future.