### PR TITLE
split cache into cache + shmem in linux memory plugin

### DIFF
--- a/plugins/node.d.linux/memory
+++ b/plugins/node.d.linux/memory
@@ -87,6 +87,8 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
 
     print "slab " if exists $mems{'Slab'};
 
+    print "shmem " if exists $mems{'Shmem'};
+
     print "cached ",
       "buffers ",
 	"free ",
@@ -110,6 +112,11 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
     print "free.draw STACK\n";
     print "free.info Wasted memory. Memory that is not ",
       "used for anything at all.\n";
+    if (exists $mems{'Shmem'}) {
+	print "shmem.label shmem\n";
+	print "shmem.draw STACK\n";
+	print "shmem.info Shared Memory (SYSV SHM segments, tmpfs).\n";
+    }
     if (exists $mems{'Slab'}) {
 	print "slab.label slab_cache\n";
 	print "slab.draw STACK\n";
@@ -185,7 +192,7 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
 	print "inact_clean.draw LINE1\n";
 	print "inact_clean.info Memory not currently used.\n";
     }
-    for my $field (qw(apps buffers swap cached free slab swap_cache page_tables vmalloc_used committed mapped active active_anon active_cache inactive inact_dirty inact_laundry inact_clean)) {
+    for my $field (qw(apps buffers swap cached free slab swap_cache page_tables vmalloc_used committed mapped active active_anon active_cache inactive inact_dirty inact_laundry inact_clean shmem)) {
     	my ($warning, $critical) = get_thresholds($field);
 	my $total = $mems{MemTotal};
 	$total = $mems{SwapTotal} if($field eq "swap");
@@ -247,8 +254,11 @@ print "apps.value ", $mems{'MemTotal'}
 
 print "free.value ", $mems{'MemFree'}, "\n";
 print "buffers.value ", $mems{'Buffers'}, "\n";
-print "cached.value ", $mems{'Cached'}, "\n";
+print "cached.value ", $mems{'Cached'} - (defined($mems{'Shmem'}) ? $mems{'Shmem'} : 0), "\n";
 print "swap.value ", $mems{'SwapTotal'} - $mems{'SwapFree'}, "\n";
+
+print "shmem.value ", $mems{'Shmem'}, "\n"
+  if exists $mems{'Shmem'};
 
 print "committed.value ", $mems{'Committed_AS'}, "\n"
   if exists $mems{'Committed_AS'};


### PR DESCRIPTION

In its current form, the standard munin "memory" plugin on linux will generate very misleading graphs on many machines.
That is because it doesn't use the `Shmem` information from `/proc/meminfo`. All `shmem` will just be drawn as `cache`.
There is however a major difference between `shmem` (which includes the space used by tmpfs and SysV SHM segments) and filesystem cache: The FScache can be freed when the memory is needed for other things, the shmem cannot.

Therefore, the generated graphs are very misleading for machines where a lot of shmem is used, like certain database servers or servers using large tmpfs ramdisks: They suggest that the machine is not low on memory, because the memory is just used by `cache`, which one assumes to be freeable when needed, when in fact that memory is permanently bound in `shmem` and unfreeable.

This patch modifies the plugin to use `shmem` information (if available in `/proc/meminfo`).
Note that this patch tries to be minimal, really only adding the shmem info and doing nothing else - it even keeps the coding style and formatting of the original plugin. Much more could be improved on this plugin, as it seems it was last updated in early 2.6-kernel times, and since then a lot more useful information became available in `/proc/meminfo`.

Here is an example before / after pic:
![munin-memory-day-after](https://cloud.githubusercontent.com/assets/10994264/9520571/99c49614-4cc8-11e5-8048-9217b887478c.png)
