### PR TITLE
Fix $verbose typo in munin-update

### DIFF
--- a/script/munin-update
+++ b/script/munin-update
@@ -32,7 +32,7 @@ sub main {
     if ( $config->{debug} || $config->{screen} || $config->{verbose} ) {
         my %log;
         $log{output} = 'screen' if $config->{screen};
-        $log{level}  = 'info'   if $config->{$verbose};
+        $log{level}  = 'info'   if $config->{verbose};
         $log{level}  = 'debug'  if $config->{debug};
         Munin::Common::Logger::configure(%log);
     }


### PR DESCRIPTION
According to context in munin-update and error when running it, "$verbose" should be "verbose".
Error was
Global symbol "$verbose" requires explicit package name at /home/munin/munin/sandbox/bin/munin-update line 38.
Execution of /home/munin/munin/sandbox/bin/munin-update aborted due to compilation errors.