### PR TITLE
Remove unneeded forks in plugin.sh

### DIFF
--- a/plugins/plugin.sh
+++ b/plugins/plugin.sh
@@ -23,13 +23,13 @@ clean_fieldname () {
 get_warning () {
     # Skip $2 if it isn't defined
     if [ -n "$2" ]; then
-        local warntmp=$(eval "echo \$$2")
+        eval "local warntmp=\$$2"
         if [ -n "$warntmp" ]; then
             echo "${warntmp}"
             return
         fi
     fi
-    local warntmp=$(eval "echo \$${1}_warning")
+    eval "local warntmp=\$${1}_warning"
     if [ -n "$warntmp" ]; then
         echo "${warntmp}"
         return
@@ -58,13 +58,13 @@ print_warning () {
 get_critical () {
     # Skip $2 if it isn't defined
     if [ -n "$2" ]; then
-        local crittmp=$(eval "echo \$$2")
+        eval "local crittmp=\$$2"
         if [ -n "$crittmp" ]; then
             echo "${crittmp}"
             return
         fi
     fi
-    local crittmp=$(eval "echo \$${1}_critical")
+    eval "local crittmp=\$${1}_critical"
     if [ -n "$crittmp" ]; then
         echo "${crittmp}"
         return


### PR DESCRIPTION
sh creates subshell to process commands in $( ... ).
Forking new shell is rather expensive operation.
Assigning new value inside `eval` allows to avoid unneded fork.

Here is a performance comparison on pretty fast system:
```
$ warning=800; foo_critical=1300
$ 
$ #Measuring original version performance
$ source <(curl -s https://raw.githubusercontent.com/munin-monitoring/munin/ff4b7c1cef1c6edac52fe7bdfd57ae2bfe63af03/plugins/plugin.sh)
$ time for i in {1..500}; do print_thresholds foo; done >/dev/null

real    0m0.620s
user    0m0.040s
sys     0m0.087s
$ 
$ #Measuring patched version performance
$ source <(curl -s https://raw.githubusercontent.com/Self-Perfection/munin/patch-1/plugins/plugin.sh)
$ time for i in {1..500}; do print_thresholds foo; done >/dev/null

real    0m0.334s
user    0m0.030s
sys     0m0.080s
$ 
$ #Checking that behavious has not changed
$ print_thresholds foo
foo.warning 800
foo.critical 1300
```