### PR TITLE
Toolbar CSS fixes

### DIFF
--- a/web/static/css/_responsive.scss
+++ b/web/static/css/_responsive.scss
@@ -12,22 +12,38 @@
 		border-radius: 0;
 		padding: 5px;
 
-		.filter {
-			float: none;
-			display: inline-block;
+		.left .logo {
 			margin-top: 0;
-			width: 250px;
+			@include opacity(1);
+		}
 
-			/* Don't expand on focus */
-			input[type=text]:focus {
-				width: 250px;
+		.right {
+			.filter {
+				display: inline-block;
+				margin-top: 0;
+				width: 200px;
+
+				/* Don't expand on focus */
+				input[type=text] {
+					width: 200px;
+
+					&:focus {
+						width: 200px;
+					}
+				}
 			}
 		}
-		.logo {
-			width: 30px;
-			margin-top: 0;
+
+		.pageTitle {
+			h1 {
+				padding-top: 10px;
+			}
 		}
-		h1 { margin: 10px 0; }
+
+		.pageTitle {
+			display: block;
+			clear: both;
+		}
 	}
 
 	/* Different nav */

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -236,9 +236,11 @@ header h1 {
   cursor: default;
   font-size: 15px;
 }
-header .logo {
-  display: inline-block;
+header .left {
   float: left;
+}
+header .left .logo {
+  display: inline-block;
   width: 118px;
   height: 34px;
   margin-top: 5px;
@@ -255,7 +257,7 @@ header .logo {
   opacity: 0.8;
   filter: alpha(opacity=80);
 }
-header .logo:hover {
+header .left .logo:hover {
   opacity: 1;
   filter: alpha(opacity=100);
 }
@@ -296,6 +298,12 @@ header .pageTitle a:hover, header .pageTitle div.switchable:hover {
   color: #fff;
   background-color: rgba(0, 0, 0, 0.15);
   text-decoration: none;
+}
+header .right {
+  float: right;
+}
+header .right .actions {
+  display: inline-block;
 }
 
 /* Main */
@@ -678,13 +686,14 @@ footer p.tagline:hover {
   color: #F14122;
 }
 
-/* Filer input */
+/* Filter input */
 .filter {
   width: 300px;
-  float: right;
   margin-top: 5px;
   position: relative;
   text-align: right;
+  display: inline-block;
+  vertical-align: top;
 }
 .filter input[type=text] {
   width: 250px;
@@ -993,6 +1002,7 @@ footer p.tagline:hover {
 }
 
 #eventRulerToggle {
+  display: inline-block;
   width: 31px;
   height: 31px;
   overflow: hidden;
@@ -1367,22 +1377,29 @@ footer p.tagline:hover {
     border-radius: 0;
     padding: 5px;
   }
-  header .filter {
-    float: none;
+  header .left .logo {
+    margin-top: 0;
+    opacity: 1;
+    filter: alpha(opacity=100);
+  }
+  header .right .filter {
     display: inline-block;
     margin-top: 0;
-    width: 250px;
+    width: 200px;
     /* Don't expand on focus */
   }
-  header .filter input[type=text]:focus {
-    width: 250px;
+  header .right .filter input[type=text] {
+    width: 200px;
   }
-  header .logo {
-    width: 30px;
-    margin-top: 0;
+  header .right .filter input[type=text]:focus {
+    width: 200px;
   }
-  header h1 {
-    margin: 10px 0;
+  header .pageTitle h1 {
+    padding-top: 10px;
+  }
+  header .pageTitle {
+    display: block;
+    clear: both;
   }
 
   /* Different nav */

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -261,7 +261,7 @@ header .logo:hover {
 }
 header .pageTitle {
   font-weight: 100;
-  margin-top: 9px;
+  margin-top: 7px;
   min-height: 24px;
   font-size: 16px;
   color: #eee;
@@ -274,9 +274,10 @@ header .pageTitle {
 }
 header .pageTitle h1 {
   vertical-align: middle;
-  display: inline-block;
+  padding-top: 4px;
 }
 header .pageTitle a, header .pageTitle div.switchable {
+  display: inline-block;
   color: #fff;
   -webkit-transition-duration: 200ms;
   -moz-transition-duration: 200ms;
@@ -288,6 +289,8 @@ header .pageTitle a, header .pageTitle div.switchable {
   -ms-border-radius: 2px;
   border-radius: 2px;
   border: 1px solid transparent;
+  white-space: nowrap;
+  margin: -4px 0 4px 0;
 }
 header .pageTitle a:hover, header .pageTitle div.switchable:hover {
   color: #fff;

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -262,25 +262,27 @@ header {
 		font-size: 15px;
 	}
 
-	.logo {
-		display: inline-block;
+	.left {
 		float: left;
-		width: 118px;
-		height: 34px;
-		margin-top: 5px;
-		@include transition-duration(200ms);
-		background-repeat: no-repeat;
-		background-position: 4px 2px;
-		/* SVG logo: fallback to png */
-		background-image: url('../img/logo-h-neg.png');
-		background-image:
-		linear-gradient(transparent, transparent),
-		url('../img/logo-h-neg.svg');
-		background-size: 115px 30px;
-		@include opacity(0.8);
 
-		&:hover {
-			@include opacity(1);
+		.logo {
+			display: inline-block;
+			width: 118px;
+			height: 34px;
+			margin-top: 5px;
+			@include transition-duration(200ms);
+			background-repeat: no-repeat;
+			background-position: 4px 2px;
+			/* SVG logo: fallback to png */
+			background-image: url('../img/logo-h-neg.png');
+			background-image: linear-gradient(transparent, transparent),
+			url('../img/logo-h-neg.svg');
+			background-size: 115px 30px;
+			@include opacity(0.8);
+
+			&:hover {
+				@include opacity(1);
+			}
 		}
 	}
 
@@ -315,6 +317,14 @@ header {
 				background-color: rgba(0, 0, 0, 0.15);
 				text-decoration: none;
 			}
+		}
+	}
+
+	.right {
+		float: right;
+
+		.actions {
+			display: inline-block;
 		}
 	}
 }
@@ -661,13 +671,14 @@ footer {
 	}
 }
 
-/* Filer input */
+/* Filter input */
 .filter {
 	width: 300px;
-	float: right;
 	margin-top: 5px;
 	position: relative;
 	text-align: right;
+	display: inline-block;
+	vertical-align: top;
 
 	input[type=text] {
 		width: 250px;
@@ -927,6 +938,7 @@ footer {
 }
 
 #eventRulerToggle {
+	display: inline-block;
 	width: 31px;
 	height: 31px;
 	overflow: hidden;

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -286,7 +286,7 @@ header {
 
 	.pageTitle {
 		font-weight: 100;
-		margin-top: 9px;
+		margin-top: 7px;
 		min-height: 24px;
 		font-size: 16px;
 		color: #eee;
@@ -297,15 +297,18 @@ header {
 
 		h1 {
 			vertical-align: middle;
-			display: inline-block;
+			padding-top: 4px;
 		}
 
 		a, div.switchable {
+			display: inline-block;
 			color: #fff;
 			@include transition-duration(200ms);
 			padding: 2px 6px;
 			@include border-radius(2px);
 			border: 1px solid transparent;
+			white-space: nowrap;
+			margin: -4px 0 4px 0;
 
 			&:hover {
 				color: #fff;

--- a/web/static/js/component-eventruler.js
+++ b/web/static/js/component-eventruler.js
@@ -47,8 +47,8 @@ $(document).ready(function() {
 	});
 
 	// Add toggle in header
-	$('header').find('.logo')
-		.after('<div id="eventRulerToggle" class="eventRulerToggle" data-shown="false">' +
+	$('header').find('.actions')
+		.append('<div id="eventRulerToggle" class="eventRulerToggle" data-shown="false">' +
 					'<i class="mdi mdi-drag-vertical"></i></div>');
 	var eventRulerToggle = $('#eventRulerToggle');
 	eventRulerToggle.click(function(e) {

--- a/web/templates/munin-overview.tmpl
+++ b/web/templates/munin-overview.tmpl
@@ -7,11 +7,15 @@
 	</div>
 <![endif]-->
 <header>
-	<a href="/" class="logo"></a>
-	<div class="filter">
-		<i class="mdi mdi-magnify"></i>
-		<input type="text" id="filter" />
-		<i id="cancelFilter" class="mdi mdi-window-close" style="display:none;"></i>
+	<div class="left">
+		<a href="/" class="logo"></a>
+	</div>
+	<div class="right">
+		<div class="filter">
+			<i class="mdi mdi-magnify"></i>
+			<input type="text" id="filter" />
+			<i id="cancelFilter" class="mdi mdi-window-close" style="display:none;"></i>
+		</div>
 	</div>
 	<div class="pageTitle"><h1>Overview</h1></div>
 	<div class="clear"></div>

--- a/web/templates/partial/logo_navigation.tmpl
+++ b/web/templates/partial/logo_navigation.tmpl
@@ -1,9 +1,14 @@
 <header>
-	<a href="/" class="logo"></a>
-	<div class="filter">
-		<i class="mdi mdi-magnify"></i>
-		<input type="text" id="filter" />
-		<i id="cancelFilter" class="mdi mdi-window-close" style="display:none;"></i>
+	<div class="left">
+		<a href="/" class="logo"></a>
+	</div>
+	<div class="right">
+		<div class="filter">
+			<i class="mdi mdi-magnify"></i>
+			<input type="text" id="filter" />
+			<i id="cancelFilter" class="mdi mdi-window-close" style="display:none;"></i>
+		</div>
+		<div class="actions"></div>
 	</div>
 	<div class="pageTitle">
 		<h1>

--- a/web/templates/partial/logo_navigation_comparison.tmpl
+++ b/web/templates/partial/logo_navigation_comparison.tmpl
@@ -1,9 +1,14 @@
 <header>
-	<a href="/" class="logo"></a>
-	<div class="filter">
-		<i class="mdi mdi-magnify"></i>
-		<input type="text" id="filter" />
-		<i id="cancelFilter" class="mdi mdi-window-close" style="display:none;"></i>
+	<div class="left">
+		<a href="/" class="logo"></a>
+	</div>
+	<div class="right">
+		<div class="filter">
+			<i class="mdi mdi-magnify"></i>
+			<input type="text" id="filter" />
+			<i id="cancelFilter" class="mdi mdi-window-close" style="display:none;"></i>
+		</div>
+		<div class="actions"></div>
 	</div>
 	<div class="pageTitle">
 		<h1>

--- a/web/templates/partial/logo_navigation_problem.tmpl
+++ b/web/templates/partial/logo_navigation_problem.tmpl
@@ -1,5 +1,10 @@
 <header>
-	<a href="/" class="logo"></a>
+	<div class="left">
+		<a href="/" class="logo"></a>
+	</div>
+	<div class="right">
+		<div class="actions"></div>
+	</div>
 	<div class="pageTitle">
 		<h1>
 			<a href="/">Overview</a>


### PR DESCRIPTION
This PR's aim is to simplify toolbar's (green header) layout.
It contains now three main parts:

- `.left` (logo)
- `.right` (filter and action buttons)
- `.pageTitle` (breadcrumb)

This allows us to efficiently apply CSS rules for lower resolution devices.