### PR TITLE
Adjust graphs width dynamically

### DIFF
--- a/lib/Munin/Node/Config.pm
+++ b/lib/Munin/Node/Config.pm
@@ -266,7 +266,9 @@ sub _parse_plugin_line {
         return (group => [split /[\s,]+/, $var_value]);
     }
     elsif ($var_name eq 'command') {
-        return (command => [split /\s+/, $var_value]);
+    	# Don't split on escaped whitespace. Also support escaping the escape character.
+    	# Better implementations welcome :).
+        return (command => [reverse map {s/\\(.)/$1/g; scalar reverse} split /\s+(?=(?:\\\\)*(?!\\))/, reverse $var_value]);
     }
     elsif ($var_name eq 'host_name') {
         return (host_name => $var_value);

--- a/lib/Munin/Node/Service.pm
+++ b/lib/Munin/Node/Service.pm
@@ -275,11 +275,15 @@ sub _service_command
 
     if ($sconf->{$service}{command}) {
         for my $t (@{ $sconf->{$service}{command} }) {
-            if ($t eq '%c') {
-                push @run, ("$dir/$service", $argument);
-            } else {
-                push @run, ($t);
-            }
+            # Unfortunately, every occurence of %c will be expanded,
+            # even if we want to pass it unmodified to the target command,
+            # because we parse the original string during the config
+            # parsing step, at which we do not yet know the
+            # replacement value for %c. It is probably a minor inconvenience,
+            # though, since who will ever need to pass "%c" in a place
+            # like that?
+            $t =~ s/%c/$dir\/$service/g;
+            push @run, $t;
         }
     }
     else {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -128,7 +128,7 @@ img {
   width: 49%;
   vertical-align: top;
   position: relative;
-  margin: 4px 4px 4px 0;
+  margin: 4px 0.5% 4px 0;
   font-size: 0;
 }
 .graphLink:hover {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -125,7 +125,7 @@ img {
 
 .graphLink {
   display: inline-block;
-  max-width: 500px;
+  width: 49%;
   vertical-align: top;
   position: relative;
   margin: 4px 4px 4px 0;
@@ -142,7 +142,7 @@ img {
 }
 
 .graph {
-  max-width: 100%;
+  width: 100%;
   height: auto;
   /* Colors are overridden by "color" property */
   border: 1px solid;

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -180,7 +180,7 @@ img { border: 0; }
 
 .graphLink {
 	display: inline-block;
-	max-width: 500px;
+	width: 49%;
 	vertical-align: top;
 	position: relative;
 	margin: 4px 4px 4px 0;
@@ -192,7 +192,7 @@ img { border: 0; }
 }
 
 .graph {
-	max-width: 100%;
+	width: 100%;
 	height: auto;
 	/* Colors are overridden by "color" property */
 	border: 1px solid;

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -183,7 +183,7 @@ img { border: 0; }
 	width: 49%;
 	vertical-align: top;
 	position: relative;
-	margin: 4px 4px 4px 0;
+	margin: 4px 0.5% 4px 0;
 	font-size: 0;
 
 	&:hover { text-decoration: none }


### PR DESCRIPTION
This change is intended to allow the graphs to stretch and occupy all available horizontal space. This way their dimensions adjust themselves dynamically according to the actual browser window size.

The original 500px fixed width doesn't work well with high-DPI screens.

Further thoughts:

- this is good for SVG, but what about PNG? We will probably need separate CSS classes for them (which will require support on the munin-httpd part) with dynamic width for SVG and static for PNG.

- I don't exactly like the "49%" thing. I only found experimentally that it works for me (in seamonkey and chromium, fwiw). Any less, and some horizontal space is wasted. Any more, and the side by side graph display breaks and the right-hand graph goes to the next line.
(the above is probably not relevant now that the margins are set in percents as well.)

- some min-width setting may or may not be desirable. If present, it will cause the right-hand graph to wrap onto the next line when the browser window is too narrow. If absent, the graphs will shrink indefinitely, but still stay two in each row.