### PR TITLE
Make navigation panel togglable, closes #636

### DIFF
--- a/web/static/css/_responsive.scss
+++ b/web/static/css/_responsive.scss
@@ -12,10 +12,16 @@
 		border-radius: 0;
 		padding: 5px;
 
-		.left .logo {
-			margin-top: 0;
-			width: 30px;
-			@include opacity(1);
+		.left {
+			&, .action-icon {
+				margin-left: 0;
+			}
+
+			.logo {
+				margin-top: 0;
+				width: 30px;
+				@include opacity(1);
+			}
 		}
 
 		.right {
@@ -57,56 +63,21 @@
 	}
 	nav {
 		display: block;
-		width: 100%;
+		position: fixed;
+		z-index: 10;
+		top: 0;
+		left: 0;
+		width: 0;
+		height: 100%;
 		max-width: 500px;
-		margin: auto;
+		background-color: #fff;
+		@include box-shadow(1px 0px 3px -1px rgba(0, 0, 0, 0.3));
+		overflow-y: auto;
 
 		#nav {
-			display: none;
-			border-right: 0;
 			padding: 0;
-			margin-top: -4px;
 
-			h2 {
-				text-align: center;
-				padding-left: 0;
-			}
-			ul li {
-				text-align: center;
-				padding-right: 0;
-			}
-			.timerangesList { opacity: 1; }
-		}
-
-		#navToggle,
-		#nav {
-			-moz-box-shadow: 0 0 2px 0 #777777;
-			-webkit-box-shadow: 0 0 2px 0 #777777;
-			-o-box-shadow: 0 0 2px 0 #777777;
-			box-shadow: 0 0 2px 0 #777777;
-			filter: progid:DXImageTransform.Microsoft.Shadow(color=#777777, Direction=NaN, Strength=2);
-		}
-
-		#navToggle {
-			display: block;
-			padding: 10px 15px;
-			background-color: rgba(0, 0, 0, 0.05);
-			font-weight: bold;
-			cursor: pointer;
-			font-family: sans-serif;
-
-			&:after {
-				content: "+";
-				float: right;
-				font-size: 18px;
-				font-weight: normal;
-				margin-top: -2px;
-				color: #797979;
-			}
-			&.expanded:after {
-				content: "-";
-				margin-top: -4px;
-			}
+			.timerangesList { @include opacity(1); }
 		}
 	}
 

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -221,7 +221,7 @@ header {
   color: #fff;
   min-height: 45px;
   margin: 0 auto;
-  padding: 1px 12px 1px 37px;
+  padding: 1px 12px 1px 0;
   text-align: center;
   background-color: #097D03;
   position: relative;
@@ -308,11 +308,12 @@ header .pageTitle a:hover, header .pageTitle div.switchable:hover {
 header .right {
   float: right;
 }
-header .right .actions {
+header .actions {
   display: inline-block;
   margin-left: 5px;
+  vertical-align: top;
 }
-header .right .actions .action-icon {
+header .action-icon {
   display: inline-block;
   width: 31px;
   height: 31px;
@@ -327,20 +328,30 @@ header .right .actions .action-icon {
   -moz-border-radius: 2px;
   -ms-border-radius: 2px;
   border-radius: 2px;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
-header .right .actions .action-icon i {
+header .action-icon i {
   font-size: 19px;
   padding: 6px;
 }
-header .right .actions .action-icon:hover {
+header .action-icon:hover {
   background-color: rgba(0, 0, 0, 0.15);
 }
-header .right .actions .action-icon.pressed {
+header .action-icon.pressed {
   -webkit-box-shadow: inset 1px 1px 0 rgba(0, 0, 0, 0.05);
   -moz-box-shadow: inset 1px 1px 0 rgba(0, 0, 0, 0.05);
   -o-box-shadow: inset 1px 1px 0 rgba(0, 0, 0, 0.05);
   box-shadow: inset 1px 1px 0 rgba(0, 0, 0, 0.05);
   background-color: rgba(0, 0, 0, 0.2);
+}
+header .action-icon#navigation-toggle i {
+  font-size: 20px;
+  padding-top: 5px;
+  padding-bottom: 7px;
 }
 
 /* Main */
@@ -361,14 +372,21 @@ nav {
   display: table-cell;
   vertical-align: top;
   width: 200px;
-  overflow: hidden;
-  /* Shown on tablets */
+  overflow-x: hidden;
 }
 nav #nav {
   width: 200px;
 }
-nav #navToggle {
+
+.navigation-mask {
   display: none;
+  position: fixed;
+  z-index: 9;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.3);
 }
 
 #nav > hr {
@@ -1397,6 +1415,9 @@ footer p.tagline:hover {
     border-radius: 0;
     padding: 5px;
   }
+  header .left, header .left .action-icon {
+    margin-left: 0;
+  }
   header .left .logo {
     margin-top: 0;
     width: 30px;
@@ -1434,54 +1455,26 @@ footer p.tagline:hover {
 
   nav {
     display: block;
-    width: 100%;
+    position: fixed;
+    z-index: 10;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 100%;
     max-width: 500px;
-    margin: auto;
+    background-color: #fff;
+    -webkit-box-shadow: 1px 0px 3px -1px rgba(0, 0, 0, 0.3);
+    -moz-box-shadow: 1px 0px 3px -1px rgba(0, 0, 0, 0.3);
+    -o-box-shadow: 1px 0px 3px -1px rgba(0, 0, 0, 0.3);
+    box-shadow: 1px 0px 3px -1px rgba(0, 0, 0, 0.3);
+    overflow-y: auto;
   }
   nav #nav {
-    display: none;
-    border-right: 0;
     padding: 0;
-    margin-top: -4px;
-  }
-  nav #nav h2 {
-    text-align: center;
-    padding-left: 0;
-  }
-  nav #nav ul li {
-    text-align: center;
-    padding-right: 0;
   }
   nav #nav .timerangesList {
     opacity: 1;
-  }
-  nav #navToggle,
-  nav #nav {
-    -moz-box-shadow: 0 0 2px 0 #777777;
-    -webkit-box-shadow: 0 0 2px 0 #777777;
-    -o-box-shadow: 0 0 2px 0 #777777;
-    box-shadow: 0 0 2px 0 #777777;
-    filter: progid:DXImageTransform.Microsoft.Shadow(color=#777777, Direction=NaN, Strength=2);
-  }
-  nav #navToggle {
-    display: block;
-    padding: 10px 15px;
-    background-color: rgba(0, 0, 0, 0.05);
-    font-weight: bold;
-    cursor: pointer;
-    font-family: sans-serif;
-  }
-  nav #navToggle:after {
-    content: "+";
-    float: right;
-    font-size: 18px;
-    font-weight: normal;
-    margin-top: -2px;
-    color: #797979;
-  }
-  nav #navToggle.expanded:after {
-    content: "-";
-    margin-top: -4px;
+    filter: alpha(opacity=100);
   }
 
   #content {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -348,6 +348,7 @@ header .right .actions .action-icon.pressed {
   width: 100%;
   margin-left: auto;
   display: table;
+  table-layout: fixed;
   min-height: 600px;
 }
 
@@ -360,7 +361,11 @@ nav {
   display: table-cell;
   vertical-align: top;
   width: 200px;
+  overflow: hidden;
   /* Shown on tablets */
+}
+nav #nav {
+  width: 200px;
 }
 nav #navToggle {
   display: none;

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -364,6 +364,7 @@ header {
 	width: 100%;
 	margin-left: auto;
 	display: table;
+	table-layout: fixed;
 	min-height: 600px;
 }
 .clear { clear: both; }
@@ -373,6 +374,12 @@ nav {
 	display: table-cell;
 	vertical-align: top;
 	width: 200px;
+	overflow: hidden;
+
+
+	#nav {
+		width: 200px;
+	}
 
 	/* Shown on tablets */
 	#navToggle { display: none; }

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -249,7 +249,7 @@ header {
 	color: #fff;
 	min-height: 45px;
 	margin: 0 auto;
-	padding: 1px 12px 1px 37px;
+	padding: 1px 12px 1px 0;
 	text-align: center;
 	background-color: $primary-color;
 	position: relative;
@@ -326,35 +326,44 @@ header {
 
 	.right {
 		float: right;
+	}
 
-		.actions {
-			display: inline-block;
-			margin-left: 5px;
+	.actions {
+		display: inline-block;
+		margin-left: 5px;
+		vertical-align: top;
+	}
 
-			.action-icon {
-				display: inline-block;
-				width: 31px;
-				height: 31px;
-				overflow: hidden;
-				cursor: pointer;
-				margin: 5px 0 0 7px;
-				@include transition-duration(150ms);
-				@include border-radius(2px);
+	.action-icon {
+		display: inline-block;
+		width: 31px;
+		height: 31px;
+		overflow: hidden;
+		cursor: pointer;
+		margin: 5px 0 0 7px;
+		@include transition-duration(150ms);
+		@include border-radius(2px);
+		@include user-select(none);
 
-				i {
-					font-size: 19px;
-					padding: 6px;
-				}
+		i {
+			font-size: 19px;
+			padding: 6px;
+		}
 
-				&:hover {
-					background-color: rgba(0, 0, 0, 0.15);
-				}
+		&:hover {
+			background-color: rgba(0, 0, 0, 0.15);
+		}
 
-				&.pressed {
-					@include box-shadow(inset 1px 1px 0 rgba(0,0,0,0.05));
-					background-color: rgba(0, 0, 0, 0.2);
-				}
-			}
+		&.pressed {
+			@include box-shadow(inset 1px 1px 0 rgba(0,0,0,0.05));
+			background-color: rgba(0, 0, 0, 0.2);
+		}
+
+		// Adjustments for single items
+		&#navigation-toggle i {
+			font-size: 20px;
+			padding-top: 5px;
+			padding-bottom: 7px;
 		}
 	}
 }
@@ -374,15 +383,21 @@ nav {
 	display: table-cell;
 	vertical-align: top;
 	width: 200px;
-	overflow: hidden;
-
+	overflow-x: hidden;
 
 	#nav {
 		width: 200px;
 	}
-
-	/* Shown on tablets */
-	#navToggle { display: none; }
+}
+.navigation-mask {
+	display: none;
+	position: fixed;
+	z-index: 9;
+	width: 100%;
+	height: 100%;
+	top: 0;
+	left: 0;
+	background-color: rgba(0, 0, 0, 0.3);
 }
 #nav {
 	> hr {

--- a/web/static/js/component-eventruler.js
+++ b/web/static/js/component-eventruler.js
@@ -72,7 +72,7 @@
 				.append(
 					$('<i>').addClass('mdi').addClass('mdi-drag-vertical')
 				)
-				.prependTo($('header').find('.actions'));
+				.prependTo($('header').find('.right').find('.actions'));
 
 			// Add listener
 			eventRulerToggle.click(function(e) {

--- a/web/static/js/component-toolbar.js
+++ b/web/static/js/component-toolbar.js
@@ -3,24 +3,32 @@
  */
 (function($) {
 	var Toolbar = function(elem, options) {
-		this.elem = elem;
-		this.$elem = $(elem);
+		this.elem = $(elem);
 		this.options = options;
-		this.metadata = this.$elem.data('toolbar-options');
+		this.metadata = this.elem.data('toolbar-options');
 	};
 
 	Toolbar.prototype = {
 		defaults: {
-
+			mobileTriggerWidth: 768
 		},
 
 		init: function() {
+			var that = this;
 			this.settings = $.extend({}, this.defaults, this.options, this.metadata);
 
 			// Init component
 			this.filterWrap = this.elem.find('.filter');
-
+			this.actions = this.elem.find('.right').find('.actions');
 			this.navigation = $('nav');
+			this.navigationMask = $('.navigation-mask').click(function() {
+				that.toggleNavigation(false, true);
+			});
+
+			this.elem.find('#navigation-toggle').click(function() {
+				var makeVisible = that.navigation.width() <= 0;
+				that.toggleNavigation(makeVisible, true);
+			});
 
 			return this;
 		},
@@ -127,7 +135,7 @@
 
 			if (overflow) {
 				// Add overflow button if it doesn't exist yet
-				if (!this.$elem.find('.overflow').length) {
+				if (!this.elem.find('.overflow').length) {
 					// Create overflow button
 					var overflowButton = $('<div />')
 						.addClass('action-icon overflow')
@@ -135,7 +143,7 @@
 						.append(
 							$('<i />').addClass('mdi mdi-dots-vertical')
 						)
-						.appendTo(this.$elem.find('.actions'));
+						.appendTo(this.actions);
 
 					// Create list
 					var list = overflowButton.list('overflow');
@@ -150,7 +158,7 @@
 					.append(
 						$('<i />').addClass('mdi ' + icon)
 					)
-					.prependTo(this.$elem.find('.actions'));
+					.prependTo(this.actions);
 
 				// Tooltip for text
 				button.tooltip(text, {
@@ -168,6 +176,14 @@
 				}, 200);
 			} else {
 				this.navigation.css('width', destWidth);
+			}
+
+			// Toggle navigation mask if necessary
+			if ($(document).width() < this.settings.mobileTriggerWidth) {
+				if (visible)
+					this.navigationMask.fadeIn(150);
+				else
+					this.navigationMask.fadeOut(150);
 			}
 		}
 	};

--- a/web/static/js/component-toolbar.js
+++ b/web/static/js/component-toolbar.js
@@ -1,5 +1,5 @@
 /**
- * Toolbar jQuery component
+ * Toolbar & navigation panel jQuery component
  */
 (function($) {
 	var Toolbar = function(elem, options) {
@@ -19,6 +19,8 @@
 
 			// Init component
 			this.filterWrap = this.elem.find('.filter');
+
+			this.navigation = $('nav');
 
 			return this;
 		},
@@ -154,6 +156,18 @@
 				button.tooltip(text, {
 					singleLine: true
 				});
+			}
+		},
+
+		toggleNavigation: function(visible, animate) {
+			var destWidth = visible ? 200 : 0;
+
+			if (animate) {
+				this.navigation.animate({
+					width: destWidth + 'px'
+				}, 200);
+			} else {
+				this.navigation.css('width', destWidth);
 			}
 		}
 	};

--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -4,19 +4,6 @@
  */
 
 $(document).ready(function() {
-	// Navigation toggle on tablets
-	$('#navToggle').click(function() {
-		var nav = $('#nav');
-
-		if ($(this).hasClass('expanded')) {
-			$(this).removeClass('expanded');
-			nav.hide();
-		} else {
-			$(this).addClass('expanded');
-			nav.show();
-		}
-	});
-
 	// Init toolbar component
 	window.toolbar = $('header').toolbar();
 });

--- a/web/templates/munin-nodeview.tmpl
+++ b/web/templates/munin-nodeview.tmpl
@@ -64,6 +64,7 @@
 <TMPL_INCLUDE NAME="partial/footer.tmpl">
 <script src="/static/js/component-absolute.js"></script>
 <script src="/static/js/component-toolbar.js"></script>
+<script src="/static/js/component-graph.js"></script>
 <script src="/static/js/component-autorefresh.js"></script>
 <script src="/static/js/munin-nodeview.js"></script>
 <script src="/static/js/munin-nodeview-timerangeswitch.js"></script>

--- a/web/templates/munin-overview.tmpl
+++ b/web/templates/munin-overview.tmpl
@@ -8,6 +8,11 @@
 <![endif]-->
 <header>
 	<div class="left">
+		<div class="actions">
+			<div id="navigation-toggle" class="action-icon">
+				<i class="mdi mdi-menu"></i>
+			</div>
+		</div>
 		<a href="/" class="logo"></a>
 	</div>
 	<div class="right">
@@ -141,6 +146,7 @@
 <TMPL_INCLUDE NAME="partial/footer.tmpl">
 <script src="/static/js/component-absolute.js"></script>
 <script src="/static/js/component-toolbar.js"></script>
+<script src="/static/js/component-graph.js"></script>
 <script src="/static/js/component-autorefresh.js"></script>
 <script src="/static/js/munin-overview.js"></script>
 <!--[if lt IE 9]>

--- a/web/templates/partial/logo_navigation.tmpl
+++ b/web/templates/partial/logo_navigation.tmpl
@@ -1,5 +1,10 @@
 <header>
 	<div class="left">
+		<div class="actions">
+			<div id="navigation-toggle" class="action-icon">
+				<i class="mdi mdi-menu"></i>
+			</div>
+		</div>
 		<a href="/" class="logo"></a>
 	</div>
 	<div class="right">

--- a/web/templates/partial/logo_navigation_comparison.tmpl
+++ b/web/templates/partial/logo_navigation_comparison.tmpl
@@ -1,5 +1,10 @@
 <header>
 	<div class="left">
+		<div class="actions">
+			<div id="navigation-toggle" class="action-icon">
+				<i class="mdi mdi-menu"></i>
+			</div>
+		</div>
 		<a href="/" class="logo"></a>
 	</div>
 	<div class="right">

--- a/web/templates/partial/logo_navigation_problem.tmpl
+++ b/web/templates/partial/logo_navigation_problem.tmpl
@@ -1,5 +1,10 @@
 <header>
 	<div class="left">
+		<div class="actions">
+			<div id="navigation-toggle" class="action-icon">
+				<i class="mdi mdi-menu"></i>
+			</div>
+		</div>
 		<a href="/" class="logo"></a>
 	</div>
 	<div class="right">

--- a/web/templates/partial/navigation.tmpl
+++ b/web/templates/partial/navigation.tmpl
@@ -1,5 +1,4 @@
 <nav>
-	<div id="navToggle">Toggle navigation menu</div>
 	<div id="nav">
 		<h2>Problems</h2>
 		<ul>
@@ -31,3 +30,4 @@
 		</ul>
 	</div>
 </nav>
+<div class="navigation-mask"></div>


### PR DESCRIPTION
This PR introduces a toggle button at the left of the logo. On click, the navigation panel with hide to let more space to the content.

On mobiles, the navigation panel is hidden by default and will slide over the content. The previous behavior (sliding behavior at the top of the content) has been removed.

An upcoming change will make the toolbar visible when scrolling up ([like this](https://jsfiddle.net/dXQbk/)), so the toggle will be available from anywhere on the page.