### PR TITLE
Plugins' command parameter: don't split on escaped whitespace.

### DIFF
--- a/lib/Munin/Node/Config.pm
+++ b/lib/Munin/Node/Config.pm
@@ -266,7 +266,9 @@ sub _parse_plugin_line {
         return (group => [split /[\s,]+/, $var_value]);
     }
     elsif ($var_name eq 'command') {
-        return (command => [split /\s+/, $var_value]);
+    	# Don't split on escaped whitespace. Also support escaping the escape character.
+    	# Better implementations welcome :).
+        return (command => [reverse map {s/\\(.)/$1/g; scalar reverse} split /\s+(?=(?:\\\\)*(?!\\))/, reverse $var_value]);
     }
     elsif ($var_name eq 'host_name') {
         return (host_name => $var_value);

--- a/lib/Munin/Node/Service.pm
+++ b/lib/Munin/Node/Service.pm
@@ -282,8 +282,11 @@ sub _service_command
             # replacement value for %c. It is probably a minor inconvenience,
             # though, since who will ever need to pass "%c" in a place
             # like that?
-            $t =~ s/%c/$dir\/$service/g;
-            push @run, ($t);
+            if ($t =~ s/%c/$dir\/$service/g) {
+                push @run, ($t, $argument);
+            } else {
+                push @run, ($t);
+            }
         }
     }
     else {

--- a/lib/Munin/Node/Service.pm
+++ b/lib/Munin/Node/Service.pm
@@ -275,11 +275,15 @@ sub _service_command
 
     if ($sconf->{$service}{command}) {
         for my $t (@{ $sconf->{$service}{command} }) {
-            if ($t eq '%c') {
-                push @run, ("$dir/$service", $argument);
-            } else {
-                push @run, ($t);
-            }
+            # Unfortunately, every occurence of %c will be expanded,
+            # even if we want to pass it unmodified to the target command,
+            # because we parse the original string during the config
+            # parsing step, at which we do not yet know the
+            # replacement value for %c. It is probably a minor inconvenience,
+            # though, since who will ever need to pass "%c" in a place
+            # like that?
+            $t =~ s/%c/$dir\/$service/g;
+            push @run, ($t);
         }
     }
     else {


### PR DESCRIPTION
This allows to pass arguments containing whitespaces as single strings.