### PR TITLE
Allow graphs to stretch infinitely

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -125,10 +125,10 @@ img {
 
 .graphLink {
   display: inline-block;
-  max-width: 500px;
+  width: 49%;
   vertical-align: top;
   position: relative;
-  margin: 4px 4px 4px 0;
+  margin: 4px 0.5% 4px 0;
   font-size: 0;
 }
 .graphLink:hover {
@@ -142,7 +142,7 @@ img {
 }
 
 .graph {
-  max-width: 100%;
+  width: 100%;
   height: auto;
   /* Colors are overridden by "color" property */
   border: 1px solid;
@@ -519,7 +519,13 @@ nav .navigation-wrapper .navigation .badge {
 /* Content: comparison / categoryview */
 .categoryview .node, .comparison .node {
   display: inline-block;
-  width: 500px;
+  width: 48%;
+  padding: 0 1% 0 0;
+  margin: 0 0 1% 0;
+}
+
+.categoryview .node .graphLink {
+  width: 100%;
 }
 
 /* Content: service view */

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -180,10 +180,10 @@ img { border: 0; }
 
 .graphLink {
 	display: inline-block;
-	max-width: 500px;
+	width: 49%;
 	vertical-align: top;
 	position: relative;
-	margin: 4px 4px 4px 0;
+	margin: 4px 0.5% 4px 0;
 	font-size: 0;
 
 	&:hover { text-decoration: none }
@@ -192,7 +192,7 @@ img { border: 0; }
 }
 
 .graph {
-	max-width: 100%;
+	width: 100%;
 	height: auto;
 	/* Colors are overridden by "color" property */
 	border: 1px solid;
@@ -524,8 +524,14 @@ nav {
 .categoryview, .comparison {
 	.node {
 		display: inline-block;
-		width: 500px;
+		width: 48%;
+		padding: 0 1% 0 0;
+		margin: 0 0 1% 0;
 	}
+}
+
+.categoryview .node .graphLink {
+	width: 100%;
 }
 
 /* Content: service view */


### PR DESCRIPTION
This change is intended to allow the graphs to stretch and occupy all available horizontal space. This way their dimensions adjust themselves dynamically according to the actual browser window size.

Works in both node view and category/comparison view. The latter now becomes limited to two graphs in a row. It can be fixed (which is important for very wide screens with a high width-to-height aspect ratio) by adding a max-width property to the ".categoryview .node, .comparison .node" classes with a fixed value (i.e., not in percent), but it has to be specified in at least "em" values to take the screen's DPI into account, and "px" unit is unsuitable because of that.

The original 500px fixed width doesn't work well with high-DPI screens, and fixed pixel widths should be generally considered evil these days anyway.

Further thoughts:

- this is good for SVG, but what about PNG? We will probably need separate CSS classes for them (which will require support on the munin-httpd part) with dynamic width for SVG and static for PNG.

- I don't exactly like the "48%" thing in ".categoryview .node, .comparison .node". I have no idea where the extra space comes from, but with 50% and zero margin, padding and border the next graph still wraps onto the next line. I only found experimentally that it works for me (in seamonkey and chromium, fwiw).

- some min-width setting may or may not be desirable. If present, it will cause the right-hand graph to wrap onto the next line when the browser window is too narrow. If absent, the graphs will shrink indefinitely, but still stay two in each row.

- the time-range pop-up navigation blocks are now misaligned. I failed to find a solution for them, hopefully someone who is better at CSS can solve that easily.