### PR TITLE
Misc. UI improvements

### DIFF
--- a/web/static/css/_base.scss
+++ b/web/static/css/_base.scss
@@ -130,7 +130,7 @@ a {
 	display: none;
 	margin: 0;
 	padding: 3px 0;
-	position: absolute;
+	position: fixed;
 	z-index: 10;
 	background-color: #fff;
 	width: auto;

--- a/web/static/css/_header.scss
+++ b/web/static/css/_header.scss
@@ -19,6 +19,12 @@ header {
 	position: fixed;
 	width: 100%;
 	top: 0;
+	@include transition(transform 200ms linear);
+	transform: translateY(0%);
+
+	&.toolbar-hide {
+		transform: translateY(-100%);
+	}
 
 	h1 {
 		color: #fff;

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -1156,6 +1156,10 @@ p.graph_info {
   margin: 1px 5px 1px 0;
   position: relative;
 }
+.groupview .overview-sparkline .sparkline {
+  width: 90px;
+  height: 28px;
+}
 .groupview .compare {
   border-bottom: 1px solid #ccc;
   background-color: rgba(0, 0, 0, 0.06);

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -114,7 +114,7 @@ a:hover {
 
 .tooltip {
   display: none;
-  position: absolute;
+  position: fixed;
   z-index: 10;
   max-width: 400px;
   -webkit-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3);
@@ -166,7 +166,7 @@ a:hover {
   display: none;
   margin: 0;
   padding: 3px 0;
-  position: absolute;
+  position: fixed;
   z-index: 10;
   background-color: #fff;
   width: auto;

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -457,6 +457,13 @@ header {
   position: fixed;
   width: 100%;
   top: 0;
+  -webkit-transition: transform 200ms linear;
+  -moz-transition: transform 200ms linear;
+  transition: transform 200ms linear;
+  transform: translateY(0%);
+}
+header.toolbar-hide {
+  transform: translateY(-100%);
 }
 header h1 {
   color: #fff;
@@ -1500,11 +1507,7 @@ ul.timeRangeSwitch li.selected, ul.timeRangeSwitch li.selected:hover, ul.timeRan
 
 .settingsModal dl {
   padding: 4px 0;
-  border-bottom: 1px solid #999;
   font-size: 0;
-}
-.settingsModal dl:last-child {
-  border-bottom: 0;
 }
 .settingsModal dl dt, .settingsModal dl dd {
   display: inline-block;

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -470,13 +470,8 @@ ul.timeRangeSwitch {
 .settingsModal {
 	dl {
 		padding: 4px 0;
-		border-bottom: 1px solid #999;
 		// Remove white spaces preventing side-by-side
 		font-size: 0;
-
-		&:last-child {
-			border-bottom: 0;
-		}
 
 		dt, dd {
 			display: inline-block;

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -172,6 +172,11 @@ p.graph_info {
 		display: block;
 		margin: 1px 5px 1px 0;
 		position: relative;
+
+		.sparkline {
+			width: 90px;
+			height: 28px;
+		}
 	}
 
 	.compare {

--- a/web/static/js/component-absolute.js
+++ b/web/static/js/component-absolute.js
@@ -14,7 +14,7 @@
 		/**
 		 * Shows the absolute element. Its position is computed from trigger element
 		 */
-		showElement: function(trigger, animate) {
+		showElement: function(trigger, positionReference, animate) {
 			var that = this;
 
 			if (this.element.is(':visible')) {
@@ -23,10 +23,10 @@
 			}
 
 			// Generate left & top element position
-			var triggerBottom = trigger.position().top + trigger.outerHeight(true);
+			var triggerBottom = positionReference.position().top + positionReference.outerHeight(true);
 			this.element.css('top', triggerBottom);
 
-			var left = trigger.position().left + trigger.outerHeight() / 2;
+			var left = positionReference.position().left + positionReference.outerHeight() / 2;
 			this.element.css('left', left);
 
 			// Check if element is out of view
@@ -68,11 +68,10 @@
 	// Define Tooltip
 	var Tooltip = function(elem, message, options) {
 		Absolute.call(this);
-		this.trigger = elem;
-		this.$trigger = $(elem);
+		this.trigger = $(elem);
 		this.message = message;
 		this.options = options;
-		this.metadata = this.$trigger.data('tooltip-options');
+		this.metadata = this.trigger.data('tooltip-options');
 	};
 
 	Tooltip.prototype = new Absolute();
@@ -104,16 +103,16 @@
 
 		// Append <sup>?</sup> to trigger
 		if (this.settings.appendQuestionMark)
-			this.$trigger.html(this.$trigger.text() + '<sup>?</sup>');
+			this.trigger.html(this.trigger.text() + '<sup>?</sup>');
 
 		// Register mouseenter event
-		this.$trigger.mouseenter(function() {
-			that.showElement(that.$trigger, true);
+		this.trigger.mouseenter(function() {
+			that.showElement(that.trigger, that.trigger, true);
 		});
 
 		// Register mouseleave event
-		this.$trigger.mouseleave(function() {
-			that.hideElement(that.$trigger, true);
+		this.trigger.mouseleave(function() {
+			that.hideElement(true);
 		});
 
 		return this;
@@ -134,11 +133,10 @@
 	 */
 	var List = function(elem, name, options) {
 		Absolute.call(this);
-		this.trigger = elem;
-		this.$trigger = $(elem);
+		this.trigger = $(elem);
 		this.name = name;
 		this.options = options;
-		this.metadata = this.$trigger.data('list-options');
+		this.metadata = this.trigger.data('list-options');
 	};
 
 	List.prototype = new Absolute();
@@ -147,6 +145,7 @@
 	// Extend Absolute's prototype
 	List.prototype.defaults = {
 		width: 'auto',
+		positionReference: null,
 
 		// If null, will be created
 		list: null,
@@ -161,7 +160,9 @@
 		var that = this;
 		this.settings = $.extend({}, this.defaults, this.options, this.metadata);
 
-		var trigger = this.$trigger;
+		var trigger = this.trigger;
+		if (this.settings.positionReference == null)
+			this.settings.positionReference = trigger;
 
 		// List
 		if (this.settings.list == null) {
@@ -190,7 +191,7 @@
 
 		// Register event
 		trigger.click(function() {
-			that.showElement(trigger, false);
+			that.showElement(trigger, that.settings.positionReference, false);
 		});
 
 		return this;

--- a/web/static/js/component-autorefresh.js
+++ b/web/static/js/component-autorefresh.js
@@ -14,13 +14,30 @@
 		init: function() {
 			this.settings = $.extend({}, this.defaults, this.options, this.metadata);
 
-			// Start timer
-			var that = this;
-			setInterval(function() {
-				that.refreshAll.call(that);
-			}, 5*60*1000);
+			if (getCookie('graph_autoRefresh', true))
+				this.start();
 
 			return this;
+		},
+
+		start: function() {
+			if (this.intervalId !== undefined)
+				return;
+
+			var that = this;
+
+			// Start timer
+			this.intervalId = setInterval(function() {
+				that.refreshAll.call(that);
+			}, 5*60*1000);
+		},
+
+		stop: function() {
+			if (this.intervalId === undefined)
+				return;
+
+			clearInterval(this.intervalId);
+			this.intervalId = undefined;
 		},
 
 		refreshAll: function() {

--- a/web/static/js/component-modal.js
+++ b/web/static/js/component-modal.js
@@ -14,7 +14,8 @@
 
 	Modal.prototype = {
 		defaults: {
-			size: 'medium'
+			size: 'medium',
+			title: null
 		},
 
 		prepare: function() {
@@ -30,9 +31,8 @@
 				.append(
 					$('<div />')
 						.addClass('title')
-						.css('display', 'none')
 						.append(
-							$('<span />')
+							$('<span />').text(this.settings.title != null ? this.settings.title : '')
 						)
 						.append(
 							$('<a />')
@@ -81,12 +81,16 @@
 			var titleBar = this.modal.find('.title');
 			titleBar.find('span').text(title);
 			titleBar.show();
+
+			return this;
 		},
 
 		setOpenTarget: function(target) {
 			var icon = this.modal.find('.open');
 			icon.attr('href', target);
 			icon.show();
+
+			return this;
 		},
 
 		show: function() {
@@ -104,6 +108,8 @@
 				if (e.keyCode == 27)
 					that.hide();
 			});
+
+			return this;
 		},
 
 		hide: function() {
@@ -113,6 +119,8 @@
 
 			// Unregister ESC keypress event
 			$(document).off('keyup.modal');
+
+			return this;
 		},
 
 		/**
@@ -124,6 +132,8 @@
 
 			this.modal.css('width', Math.min(modalMaxWidth, $(window).width()));
 			this.modal.css('height', Math.min(modalMaxHeight), $(window).height());
+
+			return this;
 		},
 
 		getView: function() {

--- a/web/static/js/component-tabs.js
+++ b/web/static/js/component-tabs.js
@@ -4,13 +4,6 @@
  */
 
 (function($, window) {
-	var tabsEnabled,
-		content,
-		tabsContainer,
-		tabs,
-		activeTab,
-		categoryTitles;
-
 	var Tabs = function(elem, options) {
 		this.elem = elem;
 		this.$elem = $(elem);
@@ -64,27 +57,12 @@
 
 			this.activeTab.addClass('active');
 
-			// Register tab click listener
-			this.tabs.click(function() {
-				that.activeTab.removeClass('active');
-				that.activeTab = $(this);
-				that.activeTab.addClass('active');
-
-				// Hide all categories
-				if ($(this).index() != 0) {
-					$('[data-category]').hide();
-					// Show the right one
-					$('[data-category="' + that.activeTab.text() + '"]').show();
-
-					that.categoryTitles.hide();
-				}
-				else { // ALL
-					$('[data-category]').show();
-					that.categoryTitles.show();
-				}
-
-				// Save state in URL
-				saveState('cat', that.activeTab.text());
+			// Register tab click/enter listener
+			this.tabs.click(function() { // click
+				that.goTo($(this));
+			}).keyup(function(e) { // <Enter>
+				if (e.keyCode === 13)
+					that.goTo($(this));
 			});
 
 			// Hide graphs that aren't in the activeTab category
@@ -109,6 +87,32 @@
 				this.showTabs();
 
 			return this;
+		},
+
+		/**
+		 * Switchs to a specific tab
+		 * @param tab DOM element
+		 */
+		goTo: function(tab) {
+			this.activeTab.removeClass('active');
+			this.activeTab = tab;
+			this.activeTab.addClass('active');
+
+			// Hide all categories
+			if (tab.index() != 0) {
+				$('[data-category]').hide();
+				// Show the right one
+				$('[data-category="' + this.activeTab.text() + '"]').show();
+
+				this.categoryTitles.hide();
+			}
+			else { // ALL
+				$('[data-category]').show();
+				this.categoryTitles.show();
+			}
+
+			// Save state in URL
+			saveState('cat', this.activeTab.text());
 		},
 
 		/**

--- a/web/static/js/component-timerangeSwitch.js
+++ b/web/static/js/component-timerangeSwitch.js
@@ -7,6 +7,7 @@ $(document).ready(function() {
 	var actionIcon = window.toolbar.addActionIcon('mdi-clock', 'Change time range', false, null);
 	actionIcon.list('timeRangeSwitches', {
 		list: $('#switchable_timeRange'),
+		positionReference: $('header').find('.overflow'),
 		width: '270px'
 	});
 

--- a/web/static/js/component-toolbar.js
+++ b/web/static/js/component-toolbar.js
@@ -69,7 +69,7 @@
 		},
 
 		/**
-		 * Updates content's padding-top property to exactly fit toolbar height
+		 * Updates content's margin-top property to exactly fit toolbar height
 		 */
 		pushBackContent: function() {
 			$('#main').css('margin-top', this.elem.height() + 'px');

--- a/web/static/js/component-toolbar.js
+++ b/web/static/js/component-toolbar.js
@@ -48,17 +48,17 @@
 					var scrollPosition = $(this).scrollTop();
 
 					// Scrolling down
-					if (scrollPosition > lastScrollPosition) {
+					if (scrollPosition > lastScrollPosition && scrollPosition > $('header').height()) {
 						// If the header is currently showing
-						if (that.elem.is(':visible'))
-							that.elem.hide();
+						if (!that.elem.is('.toolbar-hide'))
+							that.elem.addClass('toolbar-hide');
 					}
 
 					// Scrolling up
 					else {
 						// If the header is currently hidden
-						if (!that.elem.is(':visible'))
-							that.elem.show();
+						if (that.elem.is('.toolbar-hide'))
+							that.elem.removeClass('toolbar-hide');
 					}
 
 					lastScrollPosition = scrollPosition;

--- a/web/static/js/munin-categoryview.js
+++ b/web/static/js/munin-categoryview.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
 	var services = $('.service');
 
 	// Instantiate auto-refresh & dynazoom modal links components
-	var autoRefresh = graphs.autoRefresh();
+	var autoRefresh = window.autoRefresh = graphs.autoRefresh();
 	graphs.dynazoomModal();
 	graphs.graph();
 

--- a/web/static/js/munin-categoryview.js
+++ b/web/static/js/munin-categoryview.js
@@ -68,4 +68,9 @@ $(document).ready(function() {
 
 	// Init eventruler
 	$(this).eventRuler();
+
+	// Assign tab-indexes to elements
+	graphs.each(function(index) {
+		$(this).attr('tabindex', index+1);
+	});
 });

--- a/web/static/js/munin-categoryview.js
+++ b/web/static/js/munin-categoryview.js
@@ -70,7 +70,8 @@ $(document).ready(function() {
 	$(this).eventRuler();
 
 	// Assign tab-indexes to elements
-	graphs.each(function(index) {
+	$('.graphLink').each(function(index) {
 		$(this).attr('tabindex', index+1);
 	});
+	removeTabIndexOutline();
 });

--- a/web/static/js/munin-comparison.js
+++ b/web/static/js/munin-comparison.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
 	var trs = $('tr');
 
 	// Instantiate auto-refresh & dynazoom modal links components
-	var autoRefresh = graphs.autoRefresh();
+	var autoRefresh = window.autoRefresh = graphs.autoRefresh();
 	graphs.dynazoomModal();
 	graphs.graph();
 

--- a/web/static/js/munin-comparison.js
+++ b/web/static/js/munin-comparison.js
@@ -87,4 +87,10 @@ $(document).ready(function() {
 
 	// Init eventruler
 	$(this).eventRuler();
+
+	// Assign tab-indexes to elements
+	$('.tabs > li:visible, .graphLink').each(function(index) {
+		$(this).attr('tabindex', index+1);
+	});
+	removeTabIndexOutline();
 });

--- a/web/static/js/munin-domainview.js
+++ b/web/static/js/munin-domainview.js
@@ -64,4 +64,5 @@ $(document).ready(function() {
 	$('.treeview-root').find('a').each(function(index) {
 		$(this).attr('tabindex', index+1);
 	});
+	removeTabIndexOutline();
 });

--- a/web/static/js/munin-domainview.js
+++ b/web/static/js/munin-domainview.js
@@ -59,4 +59,9 @@ $(document).ready(function() {
 	$('.switchable[data-switch="header"]').list('header', {
 		list: $('.switchable_content[data-switch="header"]')
 	});
+
+	// Assign tab-indexes to elements
+	$('.treeview-root').find('a').each(function(index) {
+		$(this).attr('tabindex', index+1);
+	});
 });

--- a/web/static/js/munin-nodeview.js
+++ b/web/static/js/munin-nodeview.js
@@ -14,7 +14,7 @@ $(document).ready(function() {
 	tabs = $('.tabs').find('li');
 
 	// Instantiate auto-refresh & dynazoom modal links components
-	var autoRefresh = graphs.autoRefresh();
+	var autoRefresh = window.autoRefresh = graphs.autoRefresh();
 	graphs.dynazoomModal();
 	graphs.graph();
 

--- a/web/static/js/munin-nodeview.js
+++ b/web/static/js/munin-nodeview.js
@@ -113,7 +113,8 @@ $(document).ready(function() {
 	$(this).eventRuler();
 
 	// Assign tab-indexes to elements
-	$('.tabs > li:visible, .graph').each(function(index) {
+	$('.tabs > li:visible, .graphLink').each(function(index) {
 		$(this).attr('tabindex', index+1);
 	});
+	removeTabIndexOutline();
 });

--- a/web/static/js/munin-nodeview.js
+++ b/web/static/js/munin-nodeview.js
@@ -111,4 +111,9 @@ $(document).ready(function() {
 
 	// Init eventruler
 	$(this).eventRuler();
+
+	// Assign tab-indexes to elements
+	$('.tabs > li:visible, .graph').each(function(index) {
+		$(this).attr('tabindex', index+1);
+	});
 });

--- a/web/static/js/munin-overview.js
+++ b/web/static/js/munin-overview.js
@@ -52,6 +52,12 @@ $(document).ready(function() {
 	window.autoRefresh = sparklines.autoRefresh();
 	sparklines.graph();
 
+	// Update sparklines extension
+	// This cannot be done directly in the template because of the TMPL_VAR variable scope in a TMPL_LOOP.
+	sparklines.each(function() {
+		$(this).data('graph').setGraphExt(getCookie('graph_ext', 'png'));
+	});
+
 	// Assign tab-indexes to elements
 	$('.domain > a, .host > a').each(function(index) {
 		$(this).attr('tabindex', index+1);

--- a/web/static/js/munin-overview.js
+++ b/web/static/js/munin-overview.js
@@ -54,8 +54,9 @@ $(document).ready(function() {
 
 	// Update sparklines extension
 	// This cannot be done directly in the template because of the TMPL_VAR variable scope in a TMPL_LOOP.
+	var graphExt = getCookie('graph_ext', 'png');
 	sparklines.each(function() {
-		$(this).data('graph').setGraphExt(getCookie('graph_ext', 'png'));
+		$(this).data('graph').setGraphExt(graphExt);
 	});
 
 	// Assign tab-indexes to elements

--- a/web/static/js/munin-overview.js
+++ b/web/static/js/munin-overview.js
@@ -49,7 +49,7 @@ $(document).ready(function() {
 
 	// Sparklines auto-refresh
 	var sparklines = window.graphs = $('.sparkline');
-	sparklines.autoRefresh();
+	window.autoRefresh = sparklines.autoRefresh();
 	sparklines.graph();
 
 	// Assign tab-indexes to elements

--- a/web/static/js/munin-overview.js
+++ b/web/static/js/munin-overview.js
@@ -56,4 +56,5 @@ $(document).ready(function() {
 	$('.domain > a, .host > a').each(function(index) {
 		$(this).attr('tabindex', index+1);
 	});
+	removeTabIndexOutline();
 });

--- a/web/static/js/munin-overview.js
+++ b/web/static/js/munin-overview.js
@@ -51,4 +51,9 @@ $(document).ready(function() {
 	var sparklines = window.graphs = $('.sparkline');
 	sparklines.autoRefresh();
 	sparklines.graph();
+
+	// Assign tab-indexes to elements
+	$('.domain > a, .host > a').each(function(index) {
+		$(this).attr('tabindex', index+1);
+	});
 });

--- a/web/static/js/munin-serviceview.js
+++ b/web/static/js/munin-serviceview.js
@@ -38,4 +38,9 @@ $(document).ready(function() {
 	$('.switchable[data-switch="header"]').list('header', {
 		list: $('.switchable_content[data-switch="header"]')
 	});
+
+	// Assign tab-indexes to elements
+	graphs.each(function(index) {
+		$(this).attr('tabindex', index+1);
+	});
 });

--- a/web/static/js/munin-serviceview.js
+++ b/web/static/js/munin-serviceview.js
@@ -29,7 +29,7 @@ $(document).ready(function() {
 
 	var graphs = window.graphs = $('.graph');
 	// Graphs auto-refresh
-	var autoRefresh = graphs.autoRefresh();
+	var autoRefresh = window.autoRefresh = graphs.autoRefresh();
 	graphs.graph();
 
 	addRefreshActionIcon(autoRefresh);

--- a/web/static/js/munin-serviceview.js
+++ b/web/static/js/munin-serviceview.js
@@ -40,7 +40,8 @@ $(document).ready(function() {
 	});
 
 	// Assign tab-indexes to elements
-	graphs.each(function(index) {
+	$('.graphLink').each(function(index) {
 		$(this).attr('tabindex', index+1);
 	});
+	removeTabIndexOutline();
 });

--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -8,16 +8,6 @@ $(document).ready(function() {
 	window.toolbar = $('header').toolbar();
 
 	addSettingsActionIcon();
-
-	// Enable outline on elements only if browser DOM using <Tab> key
-	$('[tabindex]').click(function() {
-		$(this).css('outline', 'none');
-		console.log('click');
-	}).on('keyup', function (event) {
-
-		if(event.keyCode == 9)
-			$(this).css('outline', '');
-	});
 });
 
 /**
@@ -75,6 +65,16 @@ function addSettingsActionIcon() {
 
 	window.toolbar.addActionIcon('mdi-settings', 'Settings', true, function() {
 		settingsModal.show();
+	});
+}
+
+function removeTabIndexOutline() {
+	// Enable outline on elements only if browser DOM using <Tab> key
+	$('[tabindex]').focus(function() {
+		$(this).css('outline', 'none');
+	}).on('keyup', function (event) {
+		if(event.keyCode == 9)
+			$(this).css('outline', '');
 	});
 }
 

--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -8,6 +8,16 @@ $(document).ready(function() {
 	window.toolbar = $('header').toolbar();
 
 	addSettingsActionIcon();
+
+	// Enable outline on elements only if browser DOM using <Tab> key
+	$('[tabindex]').click(function() {
+		$(this).css('outline', 'none');
+		console.log('click');
+	}).on('keyup', function (event) {
+
+		if(event.keyCode == 9)
+			$(this).css('outline', '');
+	});
 });
 
 /**
@@ -29,18 +39,29 @@ function addSettingsActionIcon() {
 	var settingsModalWrap = $('#settingsModalWrap');
 
 	// Set settings values
-	var graphExtSelect = $('#graph_ext');
-	graphExtSelect.val(getCookie('graph_ext'));
+	var graphExt_input = $('#graph_ext').val(getCookie('graph_ext', 'png'));
+	var graphAutoRefresh_input = $('#graph_autoRefresh').prop('checked', getCookie('graph_autoRefresh', 'true') == 'true');
+
 	settingsModalWrap.find('#settings_save').click(function() {
 		// Save parameters
-		var graphExt = graphExtSelect.val();
+		var graphExt = graphExt_input.val();
 		setCookie('graph_ext', graphExt);
 
+		var graphAutoRefresh = graphAutoRefresh_input.prop('checked');
+		setCookie('graph_autoRefresh', graphAutoRefresh);
+
 		// Update UI
-		if (window.graphs != undefined) {
+		if (window.graphs !== undefined) {
 			$.each(window.graphs, function (index, graph) {
 				$(graph).data('graph').setGraphExt(graphExt);
 			});
+		}
+
+		if (window.autoRefresh !== undefined) {
+			if (graphAutoRefresh)
+				window.autoRefresh.start();
+			else
+				window.autoRefresh.stop();
 		}
 
 		// Close modal
@@ -48,9 +69,9 @@ function addSettingsActionIcon() {
 	});
 
 	settingsModal = new Modal('settings', settingsModalWrap, {
-		size: 'small'
+		size: 'small',
+		title: 'Settings'
 	});
-	settingsModal.setTitle('Settings');
 
 	window.toolbar.addActionIcon('mdi-settings', 'Settings', true, function() {
 		settingsModal.show();
@@ -113,7 +134,7 @@ function setCookie(cname, cvalue, exdays) {
  * Get a cookie
  * Source: http://www.w3schools.com/js/js_cookies.asp
  */
-function getCookie(cname) {
+function getCookie(cname, defaultValue) {
 	var name = cname + "=";
 	var ca = document.cookie.split(';');
 	for(var i=0; i<ca.length; i++) {
@@ -121,5 +142,6 @@ function getCookie(cname) {
 		while (c.charAt(0)==' ') c = c.substring(1);
 		if (c.indexOf(name) == 0) return c.substring(name.length,c.length);
 	}
-	return "";
+
+	return defaultValue;
 }

--- a/web/templates/partial/footer.tmpl
+++ b/web/templates/partial/footer.tmpl
@@ -11,13 +11,23 @@
 	<h2>Graphs</h2>
 	<div>
 		<dl>
-			<dt>Graphs format</dt>
+			<dt>
+				<label for="graph_ext">Graphs format</label>
+			</dt>
 			<dd>
 				<select id="graph_ext">
 					<option value="png">PNG</option>
 					<option value="pngx2">PNGx2</option>
 					<option value="svg">SVG</option>
 				</select>
+			</dd>
+		</dl>
+		<dl>
+			<dt>
+				<label for="graph_autoRefresh">Enable auto-refresh every 5 minutes</label>
+			</dt>
+			<dd>
+				<input type="checkbox" id="graph_autoRefresh" />
 			</dd>
 		</dl>
 	</div>


### PR DESCRIPTION
This PR groups small changes and fixes:

- Set tabindexes to elements so one can more efficiently use <Tab> to browse the UI
- Add animation to toolbar appearing / disappearing on scroll on mobiles
- Make all Absolute elements (switchables & tooltips) fixed so they don't scroll with the page
- Sparklines: respect graph_ext parameter instead of hardcoded .png extension
- Add ability to disable graphs auto-refresh from UI settings