### PR TITLE
UI: Introduce stretchy graphs

### DIFF
--- a/web/static/css/_base.scss
+++ b/web/static/css/_base.scss
@@ -48,6 +48,9 @@ hr {
 	@include opacity(0.8);
 	margin: -20px 0 20px 0;
 }
+h3+.subtitle {
+	margin: -16px 0 0 0;
+}
 
 a {
 	text-decoration: none;

--- a/web/static/css/_base.scss
+++ b/web/static/css/_base.scss
@@ -80,6 +80,12 @@ a {
 	margin: 0 75px;
 	padding: 10px 0 35px 0;
 	color: #999;
+
+	i {
+		display: block;
+		font-size: 45px;
+		margin-bottom: 20px;
+	}
 }
 
 .card {

--- a/web/static/css/_graphs.scss
+++ b/web/static/css/_graphs.scss
@@ -2,43 +2,19 @@
  * Graphs styling
  */
 
-a {
-	&.unkn {
-		&:link, &:visited, &:active, &:hover { color: #ffaa00; }
-	}
-	&.warn {
-		&:link, &:visited, &:active, &:hover { color: #ffd300; }
-	}
-	&.crit {
-		&:link, &:visited, &:active, &:hover { color: #ff0000; }
-	}
-}
-
-img { border: 0; }
-
-.graphLink {
-	display: inline-block;
-	max-width: 500px;
-	vertical-align: top;
-	position: relative;
-	margin: 4px 4px 4px 0;
-	font-size: 0;
-
-	&:hover { text-decoration: none }
-	&.iwarn { background-color: $problems-warning-color; }
-	&.icrit { background-color: $problems-critical-color; }
-}
-
 .graph {
-	max-width: 100%;
+	// Width is defined lower
 	height: auto;
-	/* Colors are overridden by "color" property */
+	max-width: 100%;
+	@include box-sizing(border-box);
+
+	// Colors are overridden by "color" property
 	border: 1px solid;
 	@include box-shadow(0 0 2px 0);
 
 	&.i {
 		color: #fff;
-		@include box-shadow(0 0 2px 0 #888);
+		@include box-shadow(0 0 1px 0 #888);
 	}
 	&.iwarn, &.icrit { opacity: 0.95; }
 	&.iwarn { color: $problems-warning-color; }
@@ -46,38 +22,139 @@ img { border: 0; }
 	&.iunkn { color: #ffaa00; }
 	&.iremoved { opacity: 0.6; }
 
-	&:hover+.dynazoomModalLink {
+	&:hover+.graph-dynazoomModalLink {
 		display: block;
 		@include opacity(0.5);
 	}
 }
 
-.graph_loading {
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	width: 16px;
-	height: 16px;
-	margin-left: -8px;
-	margin-top: -8px;
+.graph-link {
+	min-width: 16px;
+	min-height: 16px;
+	max-width: 100%;
+	display: inline-block;
+	position: relative;
+	margin: 4px 7px 4px 0;
+	vertical-align: top;
+	font-size: 0;
+
+	&:hover { text-decoration: none }
+
+	.graph-loading {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 16px;
+		height: 16px;
+		margin-left: -8px;
+		margin-top: -8px;
+	}
+
+	/* Dynazoom modal link */
+	.graph-dynazoomModalLink {
+		cursor: pointer;
+		position: absolute;
+		font-size: 18px!important;
+		color: #000;
+		top: 3px;
+		right: 3px;
+		border: 1px solid transparent;
+		padding: 1px 2px 2px 2px;
+		@include opacity(0);
+		@include transition-duration(150ms);
+		@include border-radius(2px);
+
+		&:hover {
+			background-color: rgba(0, 0, 0, 0.1);
+			@include opacity(1);
+		}
+
+		@media (max-width: 768px) {
+			display: none;
+		}
+
+	}
+
+	@media (max-width: 768px) {
+		margin: 4px;
+	}
+
+	// "Problems"
+	&.unkn {
+		&:link, &:visited, &:active, &:hover { color: #ffaa00; }
+	}
+	&.warn {
+		background-color: $problems-warning-color;
+		&:link, &:visited, &:active, &:hover { color: #ffd300; }
+	}
+	&.crit {
+		background-color: $problems-critical-color;
+		&:link, &:visited, &:active, &:hover { color: #ff0000; }
+	}
 }
 
-/* Dynazoom modal link */
-.dynazoomModalLink {
-	cursor: pointer;
-	position: absolute;
-	font-size: 18px!important;
-	color: #000;
-	top: 3px;
-	right: 3px;
-	border: 1px solid transparent;
-	padding: 1px 2px 2px 2px;
-	@include opacity(0);
-	@include transition-duration(150ms);
-	@include border-radius(2px);
+// Containers
+.table {
+	display: table;
+	table-layout: fixed;
+	max-width: 100%;
 
-	&:hover {
-		background-color: rgba(0, 0, 0, 0.1);
-		@include opacity(1);
+	.table-row {
+		display: table-row;
+
+		.graph-col {
+			padding-top: 15px;
+			width: auto;
+			display: table-cell;
+
+			&:only-child {
+				display: inline-block;
+			}
+		}
+	}
+
+	@media (max-width: 768px) {
+		&, & .table-row, & .table-row .graph-col {
+			display: block;
+		}
+	}
+}
+
+.row-fluid {
+	.graph-col {
+		display: inline-block;
+	}
+
+	// Simple nowrap row
+	&.row-nowrap {
+		white-space: nowrap;
+		// Remove white-space between graphs
+		font-size: 0;
+
+		.row-text {
+			font-size: 14px;
+		}
+	}
+}
+
+// Cols dimensions
+[data-graphext="pngx2"], [data-graphext="svg"] {
+	.graph-col {
+		min-width: 400px;
+		max-width: 625px;
+
+		// Overflow graph treshold is 1260px
+		@media (min-width: 1261px) {
+			width: 50%;
+		}
+
+		// Remove min-width on too small devices
+		@media (max-width: 400px) {
+			min-width: 0;
+		}
+
+		.graph {
+			width: 100%;
+		}
 	}
 }

--- a/web/static/css/_graphs.scss
+++ b/web/static/css/_graphs.scss
@@ -99,6 +99,10 @@
 	table-layout: fixed;
 	max-width: 100%;
 
+	.table-row-group {
+		display: table-row-group;
+	}
+
 	.table-row {
 		display: table-row;
 
@@ -143,7 +147,7 @@
 		min-width: 400px;
 		max-width: 625px;
 
-		// Overflow graph treshold is 1260px
+		// [1 graph] < 1260 < [2 graphs]
 		@media (min-width: 1261px) {
 			width: 50%;
 		}
@@ -155,6 +159,13 @@
 
 		.graph {
 			width: 100%;
+		}
+
+		// High-dpi devices: higher max-width
+		@media 	only screen and (-webkit-min-device-pixel-ratio: 1.3),
+				only screen and (-o-min-device-pixel-ratio: 13/10),
+				only screen and (min-resolution: 120dpi) {
+			max-width: 1060px;
 		}
 	}
 }

--- a/web/static/css/_layout.scss
+++ b/web/static/css/_layout.scss
@@ -13,6 +13,10 @@
 	display: table;
 	table-layout: fixed;
 	min-height: 600px;
+
+	&.no-toolbar {
+		margin-top: 0;
+	}
 }
 /* Navigation */
 nav {

--- a/web/static/css/_layout.scss
+++ b/web/static/css/_layout.scss
@@ -109,6 +109,10 @@ nav {
 			}
 		}
 	}
+
+	&.force-fold {
+		width: 0;
+	}
 }
 .navigation-mask {
 	display: none;

--- a/web/static/css/_responsive.scss
+++ b/web/static/css/_responsive.scss
@@ -83,23 +83,19 @@
 
 	#content {
 		display: block;
-		padding: 1em 0 1em 0;
+		padding: 1em 0;
 		width: 100%;
 
-		h2, h3 {
+		h2, h3, h4 {
 			margin-left: 20px;
 		}
-	}
 
-	/* Graphs */
-	.graph {
-		max-width: 97%;
-		display: block;
-		margin: auto;
-	}
+		.category-head, .comparison-head {
+			margin-left: 20px;
 
-	.dynazoomModalLink {
-		display: none;
+			h2 { margin-left: 0; }
+			.timeRangeSwitch { margin-left: 40px; }
+		}
 	}
 
 	/* Overview */
@@ -112,8 +108,6 @@
 			margin-left: 10px;
 		}
 	}
-
-	.timeRangeSwitchContainer { top: 0; }
 
 	.modal {
 		width: 100%;

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -103,6 +103,11 @@ a:hover {
   padding: 10px 0 35px 0;
   color: #999;
 }
+.neutralMessage i {
+  display: block;
+  font-size: 45px;
+  margin-bottom: 20px;
+}
 
 .card {
   -webkit-box-shadow: 0 2px 1px rgba(0, 0, 0, 0.12);
@@ -681,6 +686,9 @@ header .action-icon#navigation-toggle i {
   table-layout: fixed;
   min-height: 600px;
 }
+#main.no-toolbar {
+  margin-top: 0;
+}
 
 /* Navigation */
 nav {
@@ -884,42 +892,12 @@ footer p.tagline:hover {
 /**
  * Graphs styling
  */
-a.unkn:link, a.unkn:visited, a.unkn:active, a.unkn:hover {
-  color: #ffaa00;
-}
-a.warn:link, a.warn:visited, a.warn:active, a.warn:hover {
-  color: #ffd300;
-}
-a.crit:link, a.crit:visited, a.crit:active, a.crit:hover {
-  color: #ff0000;
-}
-
-img {
-  border: 0;
-}
-
-.graphLink {
-  display: inline-block;
-  max-width: 500px;
-  vertical-align: top;
-  position: relative;
-  margin: 4px 4px 4px 0;
-  font-size: 0;
-}
-.graphLink:hover {
-  text-decoration: none;
-}
-.graphLink.iwarn {
-  background-color: #ED793F;
-}
-.graphLink.icrit {
-  background-color: #F14122;
-}
-
 .graph {
-  max-width: 100%;
   height: auto;
-  /* Colors are overridden by "color" property */
+  max-width: 100%;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
   border: 1px solid;
   -webkit-box-shadow: 0 0 2px 0;
   -moz-box-shadow: 0 0 2px 0;
@@ -928,10 +906,10 @@ img {
 }
 .graph.i {
   color: #fff;
-  -webkit-box-shadow: 0 0 2px 0 #888;
-  -moz-box-shadow: 0 0 2px 0 #888;
-  -o-box-shadow: 0 0 2px 0 #888;
-  box-shadow: 0 0 2px 0 #888;
+  -webkit-box-shadow: 0 0 1px 0 #888;
+  -moz-box-shadow: 0 0 1px 0 #888;
+  -o-box-shadow: 0 0 1px 0 #888;
+  box-shadow: 0 0 1px 0 #888;
 }
 .graph.iwarn, .graph.icrit {
   opacity: 0.95;
@@ -948,13 +926,27 @@ img {
 .graph.iremoved {
   opacity: 0.6;
 }
-.graph:hover + .dynazoomModalLink {
+.graph:hover + .graph-dynazoomModalLink {
   display: block;
   opacity: 0.5;
   filter: alpha(opacity=50);
 }
 
-.graph_loading {
+.graph-link {
+  min-width: 16px;
+  min-height: 16px;
+  max-width: 100%;
+  display: inline-block;
+  position: relative;
+  margin: 4px 7px 4px 0;
+  vertical-align: top;
+  font-size: 0;
+  /* Dynazoom modal link */
+}
+.graph-link:hover {
+  text-decoration: none;
+}
+.graph-link .graph-loading {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -963,9 +955,7 @@ img {
   margin-left: -8px;
   margin-top: -8px;
 }
-
-/* Dynazoom modal link */
-.dynazoomModalLink {
+.graph-link .graph-dynazoomModalLink {
   cursor: pointer;
   position: absolute;
   font-size: 18px !important;
@@ -985,27 +975,99 @@ img {
   -ms-border-radius: 2px;
   border-radius: 2px;
 }
-.dynazoomModalLink:hover {
+.graph-link .graph-dynazoomModalLink:hover {
   background-color: rgba(0, 0, 0, 0.1);
   opacity: 1;
   filter: alpha(opacity=100);
 }
+@media (max-width: 768px) {
+  .graph-link .graph-dynazoomModalLink {
+    display: none;
+  }
+}
+@media (max-width: 768px) {
+  .graph-link {
+    margin: 4px;
+  }
+}
+.graph-link.unkn:link, .graph-link.unkn:visited, .graph-link.unkn:active, .graph-link.unkn:hover {
+  color: #ffaa00;
+}
+.graph-link.warn {
+  background-color: #ED793F;
+}
+.graph-link.warn:link, .graph-link.warn:visited, .graph-link.warn:active, .graph-link.warn:hover {
+  color: #ffd300;
+}
+.graph-link.crit {
+  background-color: #F14122;
+}
+.graph-link.crit:link, .graph-link.crit:visited, .graph-link.crit:active, .graph-link.crit:hover {
+  color: #ff0000;
+}
+
+.table {
+  display: table;
+  table-layout: fixed;
+  max-width: 100%;
+}
+.table .table-row {
+  display: table-row;
+}
+.table .table-row .graph-col {
+  padding-top: 15px;
+  width: auto;
+  display: table-cell;
+}
+.table .table-row .graph-col:only-child {
+  display: inline-block;
+}
+@media (max-width: 768px) {
+  .table, .table .table-row, .table .table-row .graph-col {
+    display: block;
+  }
+}
+
+.row-fluid .graph-col {
+  display: inline-block;
+}
+.row-fluid.row-nowrap {
+  white-space: nowrap;
+  font-size: 0;
+}
+.row-fluid.row-nowrap .row-text {
+  font-size: 14px;
+}
+
+[data-graphext="pngx2"] .graph-col, [data-graphext="svg"] .graph-col {
+  min-width: 400px;
+  max-width: 625px;
+}
+@media (min-width: 1261px) {
+  [data-graphext="pngx2"] .graph-col, [data-graphext="svg"] .graph-col {
+    width: 50%;
+  }
+}
+@media (max-width: 400px) {
+  [data-graphext="pngx2"] .graph-col, [data-graphext="svg"] .graph-col {
+    min-width: 0;
+  }
+}
+[data-graphext="pngx2"] .graph-col .graph, [data-graphext="svg"] .graph-col .graph {
+  width: 100%;
+}
+
+img {
+  border: 0;
+}
 
 /* Content: comparison / categoryview */
-.categoryview .node, .comparison .node {
-  display: inline-block;
-  width: 500px;
-}
 .categoryview .category-head > div, .categoryview .comparison-head > div, .comparison .category-head > div, .comparison .comparison-head > div {
   display: inline-block;
   vertical-align: middle;
 }
 .categoryview .category-head .timeRangeSwitch, .categoryview .comparison-head .timeRangeSwitch, .comparison .category-head .timeRangeSwitch, .comparison .comparison-head .timeRangeSwitch {
   margin-left: 100px;
-}
-.categoryview table td, .comparison table td {
-  vertical-align: top;
-  padding-top: 15px;
 }
 
 /* Content: service view */
@@ -1610,22 +1672,20 @@ ul.timeRangeSwitch li.selected, ul.timeRangeSwitch li.selected:hover, ul.timeRan
 
   #content {
     display: block;
-    padding: 1em 0 1em 0;
+    padding: 1em 0;
     width: 100%;
   }
-  #content h2, #content h3 {
+  #content h2, #content h3, #content h4 {
     margin-left: 20px;
   }
-
-  /* Graphs */
-  .graph {
-    max-width: 97%;
-    display: block;
-    margin: auto;
+  #content .category-head, #content .comparison-head {
+    margin-left: 20px;
   }
-
-  .dynazoomModalLink {
-    display: none;
+  #content .category-head h2, #content .comparison-head h2 {
+    margin-left: 0;
+  }
+  #content .category-head .timeRangeSwitch, #content .comparison-head .timeRangeSwitch {
+    margin-left: 40px;
   }
 
   /* Overview */
@@ -1636,10 +1696,6 @@ ul.timeRangeSwitch li.selected, ul.timeRangeSwitch li.selected:hover, ul.timeRan
     padding-top: 0;
     clear: both;
     margin-left: 10px;
-  }
-
-  .timeRangeSwitchContainer {
-    top: 0;
   }
 
   .modal {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -787,6 +787,9 @@ nav .navigation-wrapper .navigation .badge {
   -ms-border-radius: 10px;
   border-radius: 10px;
 }
+nav.force-fold {
+  width: 0;
+}
 
 .navigation-mask {
   display: none;
@@ -1225,6 +1228,7 @@ p.graph_info {
   border-bottom: 1px solid #ccc;
   background-color: rgba(0, 0, 0, 0.06);
   padding: 0 10px;
+  cursor: default;
   -webkit-box-shadow: inset 0 -2px 2px 0 rgba(0, 0, 0, 0.02);
   -moz-box-shadow: inset 0 -2px 2px 0 rgba(0, 0, 0, 0.02);
   -o-box-shadow: inset 0 -2px 2px 0 rgba(0, 0, 0, 0.02);

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -1014,6 +1014,9 @@ footer p.tagline:hover {
   table-layout: fixed;
   max-width: 100%;
 }
+.table .table-row-group {
+  display: table-row-group;
+}
 .table .table-row {
   display: table-row;
 }
@@ -1058,6 +1061,11 @@ footer p.tagline:hover {
 }
 [data-graphext="pngx2"] .graph-col .graph, [data-graphext="svg"] .graph-col .graph {
   width: 100%;
+}
+@media only screen and (-webkit-min-device-pixel-ratio: 1.3), only screen and (-o-min-device-pixel-ratio: 13 / 10), only screen and (min-resolution: 120dpi) {
+  [data-graphext="pngx2"] .graph-col, [data-graphext="svg"] .graph-col {
+    max-width: 1060px;
+  }
 }
 
 img {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -66,6 +66,10 @@ hr {
   margin: -20px 0 20px 0;
 }
 
+h3 + .subtitle {
+  margin: -16px 0 0 0;
+}
+
 a {
   text-decoration: none;
 }

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -21,13 +21,10 @@ $problems-critical-color: #F14122;
 @import 'graphs';
 
 
+img { border: 0; }
+
 /* Content: comparison / categoryview */
 .categoryview, .comparison {
-	.node {
-		display: inline-block;
-		width: 500px;
-	}
-
 	.category-head, .comparison-head {
 		> div {
 			display: inline-block;
@@ -36,11 +33,6 @@ $problems-critical-color: #F14122;
 		.timeRangeSwitch {
 			margin-left: 100px;
 		}
-	}
-
-	table td {
-		vertical-align: top;
-		padding-top: 15px;
 	}
 }
 

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -175,6 +175,7 @@ p.graph_info {
 		border-bottom: 1px solid #ccc;
 		background-color: rgba(0, 0, 0, 0.06);
 		padding: 0 10px;
+		cursor: default;
 		@include box-shadow(inset 0 -2px 2px 0 rgba(0, 0, 0, 0.02));
 
 		.mdi {

--- a/web/static/js/component-dynazoom-modal.js
+++ b/web/static/js/component-dynazoom-modal.js
@@ -20,7 +20,7 @@
 				return this;
 
 			// Add dynazoom modal link to each graph
-			this.elems.after($('<i />').addClass('mdi mdi-arrow-expand dynazoomModalLink'));
+			this.elems.after($('<i />').addClass('mdi mdi-arrow-expand graph-dynazoomModalLink'));
 
 			// Prepare a hidden modal
 			var iframe = $('<iframe />')
@@ -30,7 +30,7 @@
 			var dynazoomIframe = modal.getView().find('iframe');
 
 			// Bind onclick event
-			$('.dynazoomModalLink').click(function(e) {
+			$('.graph-dynazoomModalLink').click(function(e) {
 				e.preventDefault();
 
 				var img = $(this).parent().find('img.graph');

--- a/web/static/js/component-graph.js
+++ b/web/static/js/component-graph.js
@@ -1,6 +1,7 @@
 /**
  * Graph component
  */
+
 (function($, window) {
 	var TimeRanges = {
 		Hour: 'hour',
@@ -46,6 +47,10 @@
 				.addClass('graph-loading')
 				.css('display', 'none')
 				.insertBefore(this.elem);
+
+			// Immediately switch to pngx2 on Retina displays
+			if (window.forcedGraphExt)
+				this.setGraphExt(window.forcedGraphExt);
 
 			return this;
 		},
@@ -125,3 +130,13 @@
 
 	window.Graph = Graph;
 }(jQuery, window));
+
+// Check if we should change from png to pngx2 on Retina displays
+window.forcedGraphExt = null;
+if (getCookie('graph_ext', null) == null && window.isRetina) {
+	var graphExt = Graph.GraphFormats.PNGx2;
+
+	setCookie('graph_ext', graphExt);
+	$('#content').attr('data-graphext', graphExt);
+	window.forcedGraphExt = graphExt;
+}

--- a/web/static/js/component-graph.js
+++ b/web/static/js/component-graph.js
@@ -37,16 +37,13 @@
 			this.graphExt = matches[2];
 			this.params = matches.length >= 4 ? matches[3] : null;
 
-			// For refresh method, copy current attribute as backup
-			this.autorefreshSrc = this.elem.attr('src');
-
 			// Register load & error event to hide loading styles
 			this.registerLoadingEvents('load error');
 
 			// Append spinner
 			this.loadingSpinner = $('<img />')
 				.attr('src', '/static/img/loading.gif')
-				.addClass('graph_loading')
+				.addClass('graph-loading')
 				.css('display', 'none')
 				.insertBefore(this.elem);
 
@@ -74,11 +71,10 @@
 		},
 
 		refresh: function() {
-			var src = this.autorefreshSrc;
+			var src = this.elem.attr('src');
 
-			// Add new timestamp
-			var prefix = src.indexOf('?') != -1 ? '&' : '?';
-			src += prefix + new Date().getTime();
+			// Replace timestamp in URL
+			src = replaceUrlParam(src, 't', new Date().getTime());
 
 			// Since we change the src attr, we have to reattach the error event
 			this.registerLoadingEvents('error');

--- a/web/static/js/component-toolbar.js
+++ b/web/static/js/component-toolbar.js
@@ -32,7 +32,9 @@
 				var makeVisible = that.navigation.width() <= 0;
 				that.toggleNavigation(makeVisible);
 
-				setCookie('nav_panel_reduced', !makeVisible); // Save state
+				// Don't save state when force-reduced
+				if (!that.navigation.hasClass('force-fold'))
+					setCookie('nav_panel_reduced', !makeVisible); // Save state
 			});
 
 			// Fixed toolbar

--- a/web/static/js/munin-categoryview.js
+++ b/web/static/js/munin-categoryview.js
@@ -15,33 +15,14 @@ $(document).ready(function() {
 
 	// Prepare filter
 	window.toolbar.prepareFilter('Filter graphs', function(val) {
-		graphs.each(function() {
-			var pluginName = $(this).attr('alt');
-			var src = $(this).attr('src');
-			var pluginId = src.substr(src.lastIndexOf('/')+1, src.lastIndexOf('-')-src.lastIndexOf('/')-1);
-
-			if (window.toolbar.filterMatches(val, pluginName) || window.toolbar.filterMatches(val, pluginId)) {
-				$(this).parent().parent().show();
-			}
-			else {
-				$(this).parent().parent().hide();
-			}
-		});
-
-		// Hide/show categories names
-		// We can't just use the ':visible' selector since parent
-		//	may be hidden
+		// Show or hide each service
 		services.each(function() {
-			//if ($(this).children('.node:visible').length == 0)
+			var pluginInfos = $(this).attr('data-name');
 
-			services.each(function() {
-				if ($(this).children().filter(function() {
-						return $(this).css('display') == 'none';
-					}).length > 0)
-					$(this).hide();
-				else
-					$(this).show();
-			});
+			if (window.toolbar.filterMatches(val, pluginInfos))
+				$(this).show();
+			else
+				$(this).hide();
 		});
 	});
 

--- a/web/static/js/munin-comparison.js
+++ b/web/static/js/munin-comparison.js
@@ -6,7 +6,7 @@
 $(document).ready(function() {
 	var content = $('#content');
 	var graphs = window.graphs = $('.graph');
-	var trs = $('tr');
+	var services = $('.table-row');
 
 	// Instantiate auto-refresh & dynazoom modal links components
 	var autoRefresh = window.autoRefresh = graphs.autoRefresh();
@@ -25,11 +25,9 @@ $(document).ready(function() {
 		else
 			tabs.hideTabs();
 
-		trs.each(function() {
-			var serviceName = $(this).data('servicename');
-			var serviceTitle = $(this).data('servicetitle');
-
-			if (window.toolbar.filterMatches(val, serviceName) || window.toolbar.filterMatches(val, serviceTitle)) {
+		services.each(function() {
+			if (window.toolbar.filterMatches(val, $(this).data('servicename'))
+				|| window.toolbar.filterMatches(val, $(this).data('servicetitle'))) {
 				$(this).show();
 			}
 			else {
@@ -48,8 +46,8 @@ $(document).ready(function() {
 		}
 
 		// Hide unnecessary categories names
-		$('table[data-category]').each(function() {
-			if ($(this).find('tr:visible').length == 0)
+		$('.table[data-category]').each(function() {
+			if ($(this).find('.table-row:visible').length == 0)
 				$(this).prev().hide();
 			else
 				$(this).prev().show();

--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -29,7 +29,8 @@ function addSettingsActionIcon() {
 	var settingsModalWrap = $('#settingsModalWrap');
 
 	// Set settings values
-	var graphExt_input = $('#graph_ext').val(getCookie('graph_ext', 'png'));
+	var graphExt_current = getCookie('graph_ext', 'png');
+	var graphExt_input = $('#graph_ext').val(graphExt_current);
 	var graphAutoRefresh_input = $('#graph_autoRefresh').prop('checked', getCookie('graph_autoRefresh', 'true') == 'true');
 
 	settingsModalWrap.find('#settings_save').click(function() {
@@ -41,6 +42,7 @@ function addSettingsActionIcon() {
 		setCookie('graph_autoRefresh', graphAutoRefresh);
 
 		// Update UI
+		$('#content').removeClass('graphext-' + graphExt_current).addClass('graphext-' + graphExt);
 		if (window.graphs !== undefined) {
 			$.each(window.graphs, function (index, graph) {
 				$(graph).data('graph').setGraphExt(graphExt);
@@ -53,6 +55,8 @@ function addSettingsActionIcon() {
 			else
 				window.autoRefresh.stop();
 		}
+
+		graphExt_current = graphExt;
 
 		// Close modal
 		settingsModal.hide();
@@ -114,6 +118,19 @@ function getURLParams() {
 		urlParams[decode(match[1])] = decode(match[2]);
 
 	return urlParams;
+}
+
+/**
+ * Replaces a GET value in a URL
+ * 	Source: http://stackoverflow.com/questions/7171099/how-to-replace-url-parameter-with-javascript-jquery
+ */
+function replaceUrlParam(url, paramName, paramValue){
+	var pattern = new RegExp('\\b('+paramName+'=).*?(&|$)');
+
+	if (url.search(pattern) >= 0)
+		return url.replace(pattern,'$1' + paramValue + '$2');
+
+	return url + (url.indexOf('?')>0 ? '&' : '?') + paramName + '=' + paramValue
 }
 
 /**

--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -2,12 +2,19 @@
  * Main UI script
  *  This file is included in every page
  */
+window.isRetina = (
+	window.devicePixelRatio > 1 ||
+	(window.matchMedia && window.matchMedia("(-webkit-min-device-pixel-ratio: 1.5),(-moz-min-device-pixel-ratio: 1.5),(min-device-pixel-ratio: 1.5)").matches)
+);
 
 $(document).ready(function() {
-	// Init toolbar component
-	window.toolbar = $('header').toolbar();
+	// Check if toolbar has been included (it is not on dynazoom modal)
+	if (jQuery.fn.toolbar) {
+		// Init toolbar component
+		window.toolbar = $('header').toolbar();
 
-	addSettingsActionIcon();
+		addSettingsActionIcon();
+	}
 });
 
 /**
@@ -29,8 +36,7 @@ function addSettingsActionIcon() {
 	var settingsModalWrap = $('#settingsModalWrap');
 
 	// Set settings values
-	var graphExt_current = getCookie('graph_ext', 'png');
-	var graphExt_input = $('#graph_ext').val(graphExt_current);
+	var graphExt_input = $('#graph_ext').val(getCookie('graph_ext', 'png'));
 	var graphAutoRefresh_input = $('#graph_autoRefresh').prop('checked', getCookie('graph_autoRefresh', 'true') == 'true');
 
 	settingsModalWrap.find('#settings_save').click(function() {
@@ -42,7 +48,7 @@ function addSettingsActionIcon() {
 		setCookie('graph_autoRefresh', graphAutoRefresh);
 
 		// Update UI
-		$('#content').removeClass('graphext-' + graphExt_current).addClass('graphext-' + graphExt);
+		$('#content').attr('data-graphext', graphExt);
 		if (window.graphs !== undefined) {
 			$.each(window.graphs, function (index, graph) {
 				$(graph).data('graph').setGraphExt(graphExt);
@@ -55,8 +61,6 @@ function addSettingsActionIcon() {
 			else
 				window.autoRefresh.stop();
 		}
-
-		graphExt_current = graphExt;
 
 		// Close modal
 		settingsModal.hide();

--- a/web/templates/munin-categoryview.tmpl
+++ b/web/templates/munin-categoryview.tmpl
@@ -19,9 +19,10 @@
 
 		<div class="table">
 			<TMPL_LOOP SERVICES>
-				<div class="service table-row-group">
+				<div class="service table-row-group" data-name="<TMPL_VAR ESCAPE="HTML" NAME>/<TMPL_VAR ESCAPE="HTML" TITLE>">
 					<div class="table-row">
-						<h3 id="<TMPL_VAR ESCAPE="HTML" name>"><TMPL_VAR ESCAPE="HTML" NAME></h3>
+						<h3 id="<TMPL_VAR ESCAPE="HTML" name>"><TMPL_VAR ESCAPE="HTML" TITLE></h3>
+						<div class="subtitle"><TMPL_VAR ESCAPE="HTML" NAME></div>
 					</div>
 
 					<div class="table-row">

--- a/web/templates/munin-categoryview.tmpl
+++ b/web/templates/munin-categoryview.tmpl
@@ -17,55 +17,59 @@
 			</ul>
 		</div>
 
-		<TMPL_LOOP SERVICES>
-			<div class="service table">
-				<h3 id="<TMPL_VAR ESCAPE="HTML" name>"><TMPL_VAR ESCAPE="HTML" NAME></h3>
+		<div class="table">
+			<TMPL_LOOP SERVICES>
+				<div class="service table-row-group">
+					<div class="table-row">
+						<h3 id="<TMPL_VAR ESCAPE="HTML" name>"><TMPL_VAR ESCAPE="HTML" NAME></h3>
+					</div>
 
-				<div class="table-row">
-					<TMPL_LOOP GRAPHS>
-						<div class="graph-col">
-							<span class="nodetitle row-text">
-								<a href="<TMPL_VAR HOST_URL>">
-									<TMPL_VAR ESCAPE="HTML" NODENAME></a> &bull;
-									<TMPL_IF URLX>
-										<a <TMPL_IF STATE_WARNING>class="warn"</TMPL_IF>
-										  <TMPL_IF STATE_CRITICAL>class="crit"</TMPL_IF> href="<TMPL_VAR URLX>">
+					<div class="table-row">
+						<TMPL_LOOP GRAPHS>
+							<div class="graph-col">
+								<span class="nodetitle row-text">
+									<a href="<TMPL_VAR HOST_URL>">
+										<TMPL_VAR ESCAPE="HTML" NODENAME></a> &bull;
+										<TMPL_IF URLX>
+											<a <TMPL_IF STATE_WARNING>class="warn"</TMPL_IF>
+											  <TMPL_IF STATE_CRITICAL>class="crit"</TMPL_IF> href="<TMPL_VAR URLX>">
+										</TMPL_IF>
+											<TMPL_VAR ESCAPE="HTML" LABEL>
+										<TMPL_IF URLX></a></TMPL_IF>
+								</span>
+								<br />
+								<a href="<TMPL_VAR URLX>" class="graph-link i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
+									<TMPL_IF TIMEDAY>
+										<img src="<TMPL_VAR CIMGDAY>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
+										  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+										  <TMPL_IF IMGDAYWIDTH>width="<TMPL_VAR IMGDAYWIDTH>" </TMPL_IF>
+										  <TMPL_IF IMGDAYHEIGHT>height="<TMPL_VAR IMGDAYHEIGHT>"</TMPL_IF>/>
 									</TMPL_IF>
-										<TMPL_VAR ESCAPE="HTML" LABEL>
-									<TMPL_IF URLX></a></TMPL_IF>
-							</span>
-							<br />
-							<a href="<TMPL_VAR URLX>" class="graph-link i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
-								<TMPL_IF TIMEDAY>
-									<img src="<TMPL_VAR CIMGDAY>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
-									  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-									  <TMPL_IF IMGDAYWIDTH>width="<TMPL_VAR IMGDAYWIDTH>" </TMPL_IF>
-									  <TMPL_IF IMGDAYHEIGHT>height="<TMPL_VAR IMGDAYHEIGHT>"</TMPL_IF>/>
-								</TMPL_IF>
-								<TMPL_IF TIMEWEEK>
-									<img src="<TMPL_VAR CIMGWEEK>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
-									  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-									  <TMPL_IF IMGWEEKWIDTH>width="<TMPL_VAR IMGWEEKWIDTH>" </TMPL_IF>
-									  <TMPL_IF IMGWEEKHEIGHT>height="<TMPL_VAR IMGWEEKHEIGHT>"</TMPL_IF>/>
-								</TMPL_IF>
-								<TMPL_IF TIMEMONTH>
-									<img src="<TMPL_VAR CIMGMONTH>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
-									  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-									  <TMPL_IF IMGMONTHWIDTH>width="<TMPL_VAR IMGMONTHWIDTH>" </TMPL_IF>
-									  <TMPL_IF IMGMONTHHEIGHT>height="<TMPL_VAR IMGMONTHHEIGHT>"</TMPL_IF>/>
-								</TMPL_IF>
-								<TMPL_IF TIMEYEAR>
-									<img src="<TMPL_VAR CIMGYEAR>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
-									  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-									  <TMPL_IF IMGYEARWIDTH>width="<TMPL_VAR IMGYEARWIDTH>" </TMPL_IF>
-									  <TMPL_IF IMGYEARHEIGHT>height="<TMPL_VAR IMGYEARHEIGHT>"</TMPL_IF>/>
-								</TMPL_IF>
-							</a>
-						</div>
-					</TMPL_LOOP>
+									<TMPL_IF TIMEWEEK>
+										<img src="<TMPL_VAR CIMGWEEK>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
+										  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+										  <TMPL_IF IMGWEEKWIDTH>width="<TMPL_VAR IMGWEEKWIDTH>" </TMPL_IF>
+										  <TMPL_IF IMGWEEKHEIGHT>height="<TMPL_VAR IMGWEEKHEIGHT>"</TMPL_IF>/>
+									</TMPL_IF>
+									<TMPL_IF TIMEMONTH>
+										<img src="<TMPL_VAR CIMGMONTH>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
+										  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+										  <TMPL_IF IMGMONTHWIDTH>width="<TMPL_VAR IMGMONTHWIDTH>" </TMPL_IF>
+										  <TMPL_IF IMGMONTHHEIGHT>height="<TMPL_VAR IMGMONTHHEIGHT>"</TMPL_IF>/>
+									</TMPL_IF>
+									<TMPL_IF TIMEYEAR>
+										<img src="<TMPL_VAR CIMGYEAR>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
+										  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+										  <TMPL_IF IMGYEARWIDTH>width="<TMPL_VAR IMGYEARWIDTH>" </TMPL_IF>
+										  <TMPL_IF IMGYEARHEIGHT>height="<TMPL_VAR IMGYEARHEIGHT>"</TMPL_IF>/>
+									</TMPL_IF>
+								</a>
+							</div>
+						</TMPL_LOOP>
+					</div>
 				</div>
-			</div>
-		</TMPL_LOOP>
+			</TMPL_LOOP>
+		</div>
 	</div>
 </div>
 <TMPL_INCLUDE NAME="partial/footer.tmpl">

--- a/web/templates/munin-categoryview.tmpl
+++ b/web/templates/munin-categoryview.tmpl
@@ -3,7 +3,7 @@
 <TMPL_INCLUDE NAME="partial/logo_navigation.tmpl">
 <div id="main" class="categoryview">
 	<TMPL_INCLUDE NAME="partial/navigation.tmpl">
-	<div id="content">
+	<div id="content" data-graphext="<TMPL_VAR GRAPH_EXT>">
 		<div class="category-head">
 			<div>
 				<h2>Category</h2>
@@ -18,49 +18,52 @@
 		</div>
 
 		<TMPL_LOOP SERVICES>
-			<div class="service">
+			<div class="service table">
 				<h3 id="<TMPL_VAR ESCAPE="HTML" name>"><TMPL_VAR ESCAPE="HTML" NAME></h3>
-				<TMPL_LOOP GRAPHS>
-					<div class="node">
-						<span class="nodetitle">
-							<a href="<TMPL_VAR HOST_URL>">
-								<TMPL_VAR ESCAPE="HTML" NODENAME></a> &bull;
-								<TMPL_IF URLX>
-									<a <TMPL_IF STATE_WARNING>class="warn"</TMPL_IF>
-									  <TMPL_IF STATE_CRITICAL>class="crit"</TMPL_IF> href="<TMPL_VAR URLX>">
+
+				<div class="table-row">
+					<TMPL_LOOP GRAPHS>
+						<div class="graph-col">
+							<span class="nodetitle row-text">
+								<a href="<TMPL_VAR HOST_URL>">
+									<TMPL_VAR ESCAPE="HTML" NODENAME></a> &bull;
+									<TMPL_IF URLX>
+										<a <TMPL_IF STATE_WARNING>class="warn"</TMPL_IF>
+										  <TMPL_IF STATE_CRITICAL>class="crit"</TMPL_IF> href="<TMPL_VAR URLX>">
+									</TMPL_IF>
+										<TMPL_VAR ESCAPE="HTML" LABEL>
+									<TMPL_IF URLX></a></TMPL_IF>
+							</span>
+							<br />
+							<a href="<TMPL_VAR URLX>" class="graph-link i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
+								<TMPL_IF TIMEDAY>
+									<img src="<TMPL_VAR CIMGDAY>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
+									  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+									  <TMPL_IF IMGDAYWIDTH>width="<TMPL_VAR IMGDAYWIDTH>" </TMPL_IF>
+									  <TMPL_IF IMGDAYHEIGHT>height="<TMPL_VAR IMGDAYHEIGHT>"</TMPL_IF>/>
 								</TMPL_IF>
-									<TMPL_VAR ESCAPE="HTML" LABEL>
-								<TMPL_IF URLX></a></TMPL_IF>
-						</span>
-						<br />
-						<a href="<TMPL_VAR URLX>" class="graphLink i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
-							<TMPL_IF TIMEDAY>
-								<img src="<TMPL_VAR CIMGDAY>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
-								  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-								  <TMPL_IF IMGDAYWIDTH>width="<TMPL_VAR IMGDAYWIDTH>" </TMPL_IF>
-								  <TMPL_IF IMGDAYHEIGHT>height="<TMPL_VAR IMGDAYHEIGHT>"</TMPL_IF>/>
-							</TMPL_IF>
-							<TMPL_IF TIMEWEEK>
-								<img src="<TMPL_VAR CIMGWEEK>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
-								  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-								  <TMPL_IF IMGWEEKWIDTH>width="<TMPL_VAR IMGWEEKWIDTH>" </TMPL_IF>
-								  <TMPL_IF IMGWEEKHEIGHT>height="<TMPL_VAR IMGWEEKHEIGHT>"</TMPL_IF>/>
-							</TMPL_IF>
-							<TMPL_IF TIMEMONTH>
-								<img src="<TMPL_VAR CIMGMONTH>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
-								  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-								  <TMPL_IF IMGMONTHWIDTH>width="<TMPL_VAR IMGMONTHWIDTH>" </TMPL_IF>
-								  <TMPL_IF IMGMONTHHEIGHT>height="<TMPL_VAR IMGMONTHHEIGHT>"</TMPL_IF>/>
-							</TMPL_IF>
-							<TMPL_IF TIMEYEAR>
-								<img src="<TMPL_VAR CIMGYEAR>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
-								  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-								  <TMPL_IF IMGYEARWIDTH>width="<TMPL_VAR IMGYEARWIDTH>" </TMPL_IF>
-								  <TMPL_IF IMGYEARHEIGHT>height="<TMPL_VAR IMGYEARHEIGHT>"</TMPL_IF>/>
-							</TMPL_IF>
-						</a>
-					</div>
-				</TMPL_LOOP>
+								<TMPL_IF TIMEWEEK>
+									<img src="<TMPL_VAR CIMGWEEK>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
+									  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+									  <TMPL_IF IMGWEEKWIDTH>width="<TMPL_VAR IMGWEEKWIDTH>" </TMPL_IF>
+									  <TMPL_IF IMGWEEKHEIGHT>height="<TMPL_VAR IMGWEEKHEIGHT>"</TMPL_IF>/>
+								</TMPL_IF>
+								<TMPL_IF TIMEMONTH>
+									<img src="<TMPL_VAR CIMGMONTH>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
+									  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+									  <TMPL_IF IMGMONTHWIDTH>width="<TMPL_VAR IMGMONTHWIDTH>" </TMPL_IF>
+									  <TMPL_IF IMGMONTHHEIGHT>height="<TMPL_VAR IMGMONTHHEIGHT>"</TMPL_IF>/>
+								</TMPL_IF>
+								<TMPL_IF TIMEYEAR>
+									<img src="<TMPL_VAR CIMGYEAR>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
+									  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+									  <TMPL_IF IMGYEARWIDTH>width="<TMPL_VAR IMGYEARWIDTH>" </TMPL_IF>
+									  <TMPL_IF IMGYEARHEIGHT>height="<TMPL_VAR IMGYEARHEIGHT>"</TMPL_IF>/>
+								</TMPL_IF>
+							</a>
+						</div>
+					</TMPL_LOOP>
+				</div>
 			</div>
 		</TMPL_LOOP>
 	</div>

--- a/web/templates/munin-comparison.tmpl
+++ b/web/templates/munin-comparison.tmpl
@@ -3,7 +3,7 @@
 <TMPL_INCLUDE NAME="partial/logo_navigation_comparison.tmpl">
 <div id="main" class="comparison">
 	<TMPL_INCLUDE NAME="partial/navigation.tmpl">
-	<div id="content" data-tabsenabled="true" data-tabs="true">
+	<div id="content" data-tabsenabled="true" data-tabs="true" data-graphext="<TMPL_VAR GRAPH_EXT>">
 		<div class="comparison-head">
 			<div>
 				<h2>Comparison</h2>
@@ -23,11 +23,11 @@
 
 		<TMPL_LOOP CATEGORIES>
 		<h3 id="<TMPL_VAR ESCAPE="HTML" GROUPNAME>"><TMPL_VAR ESCAPE="HTML" GROUPNAME></h3>
-		<table data-category="<TMPL_VAR ESCAPE="HTML" GROUPNAME>">
+		<div class="table" data-category="<TMPL_VAR ESCAPE="HTML" GROUPNAME>">
 			<TMPL_LOOP SERVICES>
-				<tr data-servicename="<TMPL_VAR ESCAPE="HTML" SERVICENAME>" data-servicetitle="<TMPL_VAR ESCAPE="HTML" SERVICETITLE>">
+				<div class="table-row" data-servicename="<TMPL_VAR ESCAPE="HTML" SERVICENAME>" data-servicetitle="<TMPL_VAR ESCAPE="HTML" SERVICETITLE>">
 					<TMPL_LOOP NODES>
-						<td>
+						<div class="graph-col">
 							<div class="node">
 								<span class="nodetitle">
 									<a href="<TMPL_VAR ESCAPE="URL" NODENAME>/index.html"><TMPL_VAR ESCAPE="HTML" NODENAME></a> &bull;
@@ -41,7 +41,7 @@
 								</span>
 								<br />
 								<TMPL_IF CIMG>
-									<a href="/<TMPL_VAR URL>" class="graphLink i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
+									<a href="/<TMPL_VAR URL>" class="graph-link i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
 										<img src="<TMPL_VAR CIMG>" alt="<TMPL_VAR ESCAPE="HTML" LABEL>"
 										  class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
 										  <TMPL_IF IMGWIDTH>width="<TMPL_VAR IMGWIDTH>" </TMPL_IF>
@@ -49,11 +49,11 @@
 									</a>
 								</TMPL_IF>
 							</div>
-						</td>
+						</div>
 					</TMPL_LOOP>
-				</tr>
+				</div>
 			</TMPL_LOOP>
-		</table>
+		</div>
 		</TMPL_LOOP>
 	</div>
 </div>

--- a/web/templates/munin-dynazoom.tmpl
+++ b/web/templates/munin-dynazoom.tmpl
@@ -3,7 +3,7 @@
 <TMPL_UNLESS CONTENT_ONLY>
 	<TMPL_INCLUDE NAME="partial/logo_navigation.tmpl">
 </TMPL_UNLESS>
-<div id="main">
+<div id="main" <TMPL_IF CONTENT_ONLY>class="no-toolbar"</TMPL_IF>>
 	<TMPL_UNLESS CONTENT_ONLY>
 		<TMPL_INCLUDE NAME="partial/navigation.tmpl">
 	</TMPL_UNLESS>

--- a/web/templates/munin-nodeview.tmpl
+++ b/web/templates/munin-nodeview.tmpl
@@ -4,7 +4,7 @@
 <div id="main">
 	<TMPL_INCLUDE NAME="partial/navigation.tmpl">
 	<!-- Change the tabsenabled attribute to false to disable tabs -->
-	<div id="content" data-tabsenabled="true" data-tabs="true">
+	<div id="content" data-tabsenabled="true" data-tabs="true" data-graphext="<TMPL_VAR GRAPH_EXT>">
 		<!-- Node view -->
 		<h2><TMPL_VAR NAME></h2>
 
@@ -17,23 +17,29 @@
 			<div data-category="<TMPL_VAR ESCAPE="HTML" NAME>">
 				<TMPL_LOOP SERVICES>
 					<h4><TMPL_VAR ESCAPE="HTML" NAME></h4>
-					<a href="<TMPL_VAR URLX>" class="graphLink i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
-						<img class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-						  src="<TMPL_VAR IMGDAY>"
-						  alt="<TMPL_VAR ESCAPE="HTML" NAME>"
-						  <TMPL_IF IMGDAYWIDTH>width="<TMPL_VAR IMGDAYWIDTH>" </TMPL_IF>
-						  <TMPL_IF IMGDAYHEIGHT>height="<TMPL_VAR IMGDAYHEIGHT>"</TMPL_IF>
-						  data-col="0" />
-					</a>
-					<a href="<TMPL_VAR URLX>" class="graphLink hide-if-overflows i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
-						<img class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-						  src="<TMPL_VAR IMGWEEK>"
-						  alt="<TMPL_VAR ESCAPE="HTML" NAME>"
-						  <TMPL_IF IMGWEEKWIDTH>width="<TMPL_VAR IMGWEEKWIDTH>" </TMPL_IF>
-						  <TMPL_IF IMGWEEKHEIGHT>height="<TMPL_VAR IMGWEEKHEIGHT>"</TMPL_IF>
-						  data-col="1" />
-					</a>
-					<br />
+
+					<div class="row-fluid row-nowrap">
+						<div class="graph-col">
+							<a href="<TMPL_VAR URLX>" class="graph-link i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
+								<img class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+								  src="<TMPL_VAR IMGDAY>"
+								  alt="<TMPL_VAR ESCAPE="HTML" NAME>"
+								  <TMPL_IF IMGDAYWIDTH>width="<TMPL_VAR IMGDAYWIDTH>" </TMPL_IF>
+								  <TMPL_IF IMGDAYHEIGHT>height="<TMPL_VAR IMGDAYHEIGHT>"</TMPL_IF>
+								  data-col="0" />
+							</a>
+						</div>
+						<div class="graph-col hide-if-overflows">
+							<a href="<TMPL_VAR URLX>" class="graph-link i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
+								<img class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+								  src="<TMPL_VAR IMGWEEK>"
+								  alt="<TMPL_VAR ESCAPE="HTML" NAME>"
+								  <TMPL_IF IMGWEEKWIDTH>width="<TMPL_VAR IMGWEEKWIDTH>" </TMPL_IF>
+								  <TMPL_IF IMGWEEKHEIGHT>height="<TMPL_VAR IMGWEEKHEIGHT>"</TMPL_IF>
+								  data-col="1" />
+							</a>
+						</div>
+					</div>
 				</TMPL_LOOP>
 			</div>
 		</TMPL_LOOP>

--- a/web/templates/munin-problemview.tmpl
+++ b/web/templates/munin-problemview.tmpl
@@ -3,7 +3,7 @@
 <TMPL_INCLUDE NAME="partial/logo_navigation_problem.tmpl">
 <div id="main" class="categoryview">
 	<TMPL_INCLUDE NAME="partial/navigation.tmpl">
-	<div id="content">
+	<div id="content" data-graphext="<TMPL_VAR GRAPH_EXT>">
 		<h2>Problems overview</h2>
 		<TMPL_IF CRITICAL>
 			<div class="problem" id="critical">
@@ -124,16 +124,13 @@
 			</div>
 		</TMPL_IF>
 
-	<TMPL_IF CRITICAL>
-	<TMPL_ELSE>
-		<TMPL_IF WARNING>
-		<TMPL_ELSE>
-			<TMPL_IF UNKNOWN>
-			<TMPL_ELSE>
-				<p class="neutralMessage">There are neither warnings nor errors to display.</p>
-			</TMPL_IF>
-		</TMPL_IF>
-	</TMPL_IF>
+		<TMPL_UNLESS CRITICAL>
+			<TMPL_UNLESS WARNING>
+				<TMPL_UNLESS UNKNOWN>
+					<p class="neutralMessage"><i class="mdi mdi-check-all"></i> There are neither warnings nor errors to display.</p>
+				</TMPL_UNLESS>
+			</TMPL_UNLESS>
+		</TMPL_UNLESS>
 	</div>
 </div>
 <TMPL_INCLUDE NAME="partial/footer.tmpl">

--- a/web/templates/munin-serviceview.tmpl
+++ b/web/templates/munin-serviceview.tmpl
@@ -3,40 +3,52 @@
 <TMPL_INCLUDE NAME="partial/logo_navigation.tmpl">
 <div id="main">
 	<TMPL_INCLUDE NAME="partial/navigation.tmpl">
-	<div id="content">
+	<div id="content" data-graphext="<TMPL_VAR GRAPH_EXT>">
 		<TMPL_LOOP SERVICES>
 			<h2><TMPL_VAR GRAPH_TITLE></h2>
 			<div class="subtitle"><TMPL_VAR GRAPH_NAME> &bullet;
 				<a href="<TMPL_VAR NODEVIEW_PATH>/#<TMPL_VAR CATEGORY>"><TMPL_VAR CATEGORY></a></div>
-			<a href="<TMPL_VAR ZOOMDAY>" class="graphLink i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
-				<img src="<TMPL_VAR IMGDAY>"
-					alt="daily graph"
-					class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-					<TMPL_IF IMGDAYWIDTH>width="<TMPL_VAR IMGDAYWIDTH>" </TMPL_IF>
-					<TMPL_IF IMGDAYHEIGHT>height="<TMPL_VAR IMGDAYHEIGHT>"</TMPL_IF> />
-			</a>
-			<a href="<TMPL_VAR ZOOMWEEK>" class="graphLink i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
-				<img src="<TMPL_VAR IMGWEEK>"
-					alt="weekly graph"
-					class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-					<TMPL_IF IMGWEEKWIDTH>width="<TMPL_VAR IMGWEEKWIDTH>" </TMPL_IF>
-					<TMPL_IF IMGWEEKHEIGHT>height="<TMPL_VAR IMGWEEKHEIGHT>"</TMPL_IF> />
-			</a>
-			<br />
-			<a href="<TMPL_VAR ZOOMMONTH>" class="graphLink i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
-				<img src="<TMPL_VAR IMGMONTH>"
-					alt="monthly graph"
-					class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-					<TMPL_IF IMGMONTHWIDTH>width="<TMPL_VAR IMGMONTHWIDTH>" </TMPL_IF>
-					<TMPL_IF IMGMONTHHEIGHT>height="<TMPL_VAR IMGMONTHHEIGHT>"</TMPL_IF> />
-			</a>
-			<a href="<TMPL_VAR ZOOMYEAR>" class="graphLink i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
-				<img src="<TMPL_VAR IMGYEAR>"
-					alt="yearly graph"
-					class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
-					<TMPL_IF IMGYEARWIDTH>width="<TMPL_VAR IMGYEARWIDTH>" </TMPL_IF>
-					<TMPL_IF IMGYEARHEIGHT>height="<TMPL_VAR IMGYEARHEIGHT>"</TMPL_IF> />
-			</a>
+
+			<div class="row-fluid">
+				<div class="graph-col">
+					<a href="<TMPL_VAR ZOOMDAY>" class="graph-link i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
+						<img src="<TMPL_VAR IMGDAY>"
+							alt="daily graph"
+							class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+							<TMPL_IF IMGDAYWIDTH>width="<TMPL_VAR IMGDAYWIDTH>" </TMPL_IF>
+							<TMPL_IF IMGDAYHEIGHT>height="<TMPL_VAR IMGDAYHEIGHT>"</TMPL_IF> />
+					</a>
+				</div>
+				<div class="graph-col">
+					<a href="<TMPL_VAR ZOOMWEEK>" class="graph-link i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
+						<img src="<TMPL_VAR IMGWEEK>"
+							alt="weekly graph"
+							class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+							<TMPL_IF IMGWEEKWIDTH>width="<TMPL_VAR IMGWEEKWIDTH>" </TMPL_IF>
+							<TMPL_IF IMGWEEKHEIGHT>height="<TMPL_VAR IMGWEEKHEIGHT>"</TMPL_IF> />
+					</a>
+				</div>
+			</div>
+			<div class="row-fluid">
+				<div class="graph-col">
+					<a href="<TMPL_VAR ZOOMMONTH>" class="graph-link i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
+						<img src="<TMPL_VAR IMGMONTH>"
+							alt="monthly graph"
+							class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+							<TMPL_IF IMGMONTHWIDTH>width="<TMPL_VAR IMGMONTHWIDTH>" </TMPL_IF>
+							<TMPL_IF IMGMONTHHEIGHT>height="<TMPL_VAR IMGMONTHHEIGHT>"</TMPL_IF> />
+					</a>
+				</div>
+				<div class="graph-col">
+					<a href="<TMPL_VAR ZOOMYEAR>" class="graph-link i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>">
+						<img src="<TMPL_VAR IMGYEAR>"
+							alt="yearly graph"
+							class="graph i<TMPL_IF STATE_WARNING>warn</TMPL_IF><TMPL_IF STATE_CRITICAL>crit</TMPL_IF>"
+							<TMPL_IF IMGYEARWIDTH>width="<TMPL_VAR IMGYEARWIDTH>" </TMPL_IF>
+							<TMPL_IF IMGYEARHEIGHT>height="<TMPL_VAR IMGYEARHEIGHT>"</TMPL_IF> />
+					</a>
+				</div>
+			</div>
 
 			<!-- .sum graphs.  One of the least used features of munin? -->
 			<TMPL_IF IMGWEEKSUM>

--- a/web/templates/partial/navigation.tmpl
+++ b/web/templates/partial/navigation.tmpl
@@ -1,4 +1,4 @@
-<nav <TMPL_IF NAV_PANEL_REDUCED>style="width: 0px;"</TMPL_IF>>
+<nav <TMPL_IF NAV_PANEL_REDUCED>class="force-fold"</TMPL_IF>>
 	<div class="navigation-wrapper">
 		<div class="navigation">
 			<h2>Problems</h2>


### PR DESCRIPTION
@shapirus created Pull Request #641 to introduce stretchy graphs. Indeed, with SVG graphs, we may want to occupy a lot more screen space by removing graphs max dimensions.

This PR mainly adds a new graphs DOM organization: `graph-col > graph-link > graph` classes.
Each page is aware of the graphs type using the `data-graphext` attribute. Currently supported values are `png`, `svg` and `pngx2`.