### PR TITLE
ui/navigation: Fix broken link id

### DIFF
--- a/web/templates/partial/navigation.tmpl
+++ b/web/templates/partial/navigation.tmpl
@@ -9,8 +9,8 @@
 			<h2>Problems</h2>
 			<ul>
 				<li><div class="badge"><TMPL_VAR NCRITICAL></div><a href="/problems.html#critical">Critical</a></li>
-				<li><div class="badge"><TMPL_VAR NWARNING></div><a href="/problems.html#warnings">Warning</a></li>
-				<li><div class="badge"><TMPL_VAR NUNKNOWN></div><a href="/problems.html#unknowns">Unknown</a></li>
+				<li><div class="badge"><TMPL_VAR NWARNING></div><a href="/problems.html#warning">Warning</a></li>
+				<li><div class="badge"><TMPL_VAR NUNKNOWN></div><a href="/problems.html#unknown">Unknown</a></li>
 			</ul>
 			<hr />
 


### PR DESCRIPTION
*Hi, I just updated to Ubuntu 14.04 and the new munin version I got seems to have quite a few bugs. Here is a first fix :)*

Concerned version: Munin 2.0.19-3 (seems to be still present in branch *devel*).
