### PR TITLE
Fix autoconf error in slapd_bdb_cache_ plugin

### DIFF
--- a/plugins/node.d/slapd_bdb_cache_
+++ b/plugins/node.d/slapd_bdb_cache_
@@ -108,7 +108,7 @@ if ($arg && $arg eq "config") {
 } elsif ($arg && $arg eq "autoconf") {
     if (! -x $dbstat) {
 	print "no (Can't execute db_stat file '$dbstat')\n";
-    } elsif (-d $dbdir && -r $dbdir) {
+    } elsif (! -d $dbdir || ! -r $dbdir) {
 	print "no (Can't open database directory '$dbdir')";
     } else {
 	print "yes\n";


### PR DESCRIPTION
An error in the slapd_bdb_cache_ plugin fails during autoconf with
"no (Can't open database directory '$dbdir')" when the database
directory is valid (exists and is readable).

The reason is a bug in line 79 of the slabd_bdb_cache_ plugin:

[... snipp ...]
     } elsif (-d $dbdir && -r $dbdir) {
         print "no (Can't open database directory '$dbdir')";
     } else {
[... snipp ...]

This also prevents autoconf to suceed in any configuration.

The fix is trivial, see attached patch (another variant would leave the
elsif intact and return "yes" instead of "no").  This issue is also
present in the current release (2.0.24 at the time of this bugreport).

Bugfix originally submitted to https://bugs.debian.org/768553