### PR TITLE
Update installation documentation update for FreeBSD 10

### DIFF
--- a/doc/installation/install.rst
+++ b/doc/installation/install.rst
@@ -50,8 +50,8 @@ Binary packages:
 
 .. code-block:: bash
 
- pkg_add -r munin-master
- pkg_add -r munin-node
+ pkg install munin-master
+ pkg install munin-node
 
 Debian/Ubuntu
 -------------


### PR DESCRIPTION
The current documentation for installing Munin on FreeBSD uses the `pkg_add` utility. As of FreeBSD 10 (released January 20, 2014), it has been replaced by pkgng, which uses the command `pkg install`.