### PR TITLE
Add configuration for ssh master-node transport

### DIFF
--- a/doc/node/async.rst
+++ b/doc/node/async.rst
@@ -168,6 +168,9 @@ master <master-index>` configuration you need to configure a host with a
 You will need to create an SSH key for the "munin" user, and
 distribute this to all nodes running munin-asyncd.
 
+The ssh command and options can be customized in :ref:`munin.conf`
+with the ssh_command and ssh_options configuration options.
+
 On the munin node
 -----------------
 

--- a/doc/reference/munin.conf.rst
+++ b/doc/reference/munin.conf.rst
@@ -105,6 +105,37 @@ otherwise.
    Munin sends 1 email for each warning/critical. Useful when relaying messages to external processes
    that may handle a limited number of simultaneous warnings.
 
+.. option:: ssh_command <command>
+
+   The name of the secure shell command to use.  Can be fully
+   qualified or looked up in $PATH.
+
+   Defaults to "ssh".
+
+.. option:: ssh_options <options>
+
+   The options for the secure shell command.
+
+   Defaults are "-o ChallengeResponseAuthentication=no -o
+   StrictHostKeyChecking=no".  Please adjust this according to your
+   desired security level.
+
+   With the defaults, the master will accept and store the node ssh
+   host keys with the first connection. If a host ever changes its ssh
+   host keys, you will need to manually remove the old host key from
+   the ssh known hosts file. (with: ssh-keygen -R <node-hostname>, as
+   well as ssh-keygen -R <node-ip-address>)
+
+   You can remove "StrictHostKeyChecking=no" to increase security, but
+   you will have to manually manage the known hosts file.  Do so by
+   running "ssh <node-hostname>" manually as the munin user, for each
+   node, and accept the ssh host keys.
+
+   If you would like the master to accept all node host keys, even
+   when they change, use the options "-o
+   UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o
+   PreferredAuthentications=publickey".
+
 .. index::
    pair: example; munin.conf
 

--- a/lib/Munin/Common/Config.pm
+++ b/lib/Munin/Common/Config.pm
@@ -112,6 +112,8 @@ my %legal = map { $_ => 1 } qw(
 	rundir
 	service_order
 	skipdraw
+	ssh_command
+	ssh_options
 	stack
 	state
 	staticdir

--- a/lib/Munin/Master/Config.pm
+++ b/lib/Munin/Master/Config.pm
@@ -163,6 +163,8 @@ my %booleans = map {$_ => 1} qw(
 		tmpldir          => "$Munin::Common::Defaults::MUNIN_CONFDIR/templates",
 	        staticdir        => "$Munin::Common::Defaults::MUNIN_CONFDIR/static",
 	        cgitmpdir        => "$Munin::Common::Defaults::MUNIN_CGITMPDIR",
+		ssh_command      => "ssh",
+		ssh_options      => "-o ChallengeResponseAuthentication=no -o StrictHostKeyChecking=no",
 	    }, $class ),
 
 	    oldconfig => bless ( {

--- a/lib/Munin/Master/Node.pm
+++ b/lib/Munin/Master/Node.pm
@@ -94,7 +94,7 @@ sub _do_connect {
 		return 0;
 	}
     } elsif ($uri->scheme eq "ssh") {
-	    my $ssh_command = "ssh -o ChallengeResponseAuthentication=no -o StrictHostKeyChecking=no ";
+	    my $ssh_command = sprintf("%s %s", $config->{ssh_command}, $config->{ssh_options});
 	    my $user_part = ($uri->user) ? ($uri->user . "@") : "";
 	    my $remote_cmd = ($uri->path ne '/') ? $uri->path : "";
 


### PR DESCRIPTION
These configuration options can be added to munin.conf for global ssh
client configuration.

ssh_command: The name of the ssh command. May be fully qualified or
looked up in $PATH.  Default: ssh

ssh_options: Options used for the ssh command line.  Defaults as before,
"-o ChallengeResponseAuthentication=no -o StrictHostKeyChecking=no"

Fixes #694
