### PR TITLE
Add configuration for ssh master-node transport

### DIFF
--- a/common/lib/Munin/Common/Config.pm
+++ b/common/lib/Munin/Common/Config.pm
@@ -107,6 +107,8 @@ my %legal = map { $_ => 1 } qw(
 	rundir
 	service_order
 	skipdraw
+	ssh_command
+	ssh_options
 	stack
 	state
 	staticdir

--- a/doc/node/async.rst
+++ b/doc/node/async.rst
@@ -46,6 +46,9 @@ master <master-index>` configuration you need to configure a host with a
 You will need to create an SSH key for the "munin" user, and
 distribute this to all nodes running munin-asyncd.
 
+The ssh command and options can be customized in :ref:`munin.conf`
+with the ssh_command and ssh_options configuration options.
+
 On the munin node
 -----------------
 

--- a/doc/reference/munin.conf.rst
+++ b/doc/reference/munin.conf.rst
@@ -101,6 +101,37 @@ otherwise.
    html pages you must configure a web server to run
    :ref:`munin-cgi-graph` instead.
 
+.. option:: ssh_command <command>
+
+   The name of the secure shell command to use.  Can be fully
+   qualified or looked up in $PATH.
+
+   Defaults to "ssh".
+
+.. option:: ssh_options <options>
+
+   The options for the secure shell command.
+
+   Defaults are "-o ChallengeResponseAuthentication=no -o
+   StrictHostKeyChecking=no".  Please adjust this according to your
+   desired security level.
+
+   With the defaults, the master will accept and store the node ssh
+   host keys with the first connection. If a host ever changes its ssh
+   host keys, you will need to manually remove the old host key from
+   the ssh known hosts file. (with: ssh-keygen -R <node-hostname>, as
+   well as ssh-keygen -R <node-ip-address>)
+
+   You can remove "StrictHostKeyChecking=no" to increase security, but
+   you will have to manually manage the known hosts file.  Do so by
+   running "ssh <node-hostname>" manually as the munin user, for each
+   node, and accept the ssh host keys.
+
+   If you would like the master to accept all node host keys, even
+   when they change, use the options "-o
+   UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o
+   PreferredAuthentications=publickey".
+
 .. index::
    pair: example; munin.conf
 

--- a/master/doc/munin.conf.pod.in
+++ b/master/doc/munin.conf.pod.in
@@ -127,6 +127,19 @@ munin-cgi-graph jobs which we can't stop, but munin-cgi-graph will
 throttle down how many rrdgraph calls will be running at the same time
 to this number.  Affects: munin-cgi-graph and munin-fastcgi-graph.
 
+=item B<ssh_command> I<value>
+
+The name of the secure shell command to use.  Can be fully qualified,
+or looked up in $PATH.  Default: C<ssh>
+
+=item B<ssh_options> I<value>
+
+The C<ssh> command line options.  Defaults: C<-o
+ChallengeResponseAuthentication=no -o StrictHostKeyChecking=no>.
+
+If you need per-host ssh configuration, add these to
+F<~/munin/.ssh/config>
+
 =item B<tls> <value>
 
 Can have four values. C<paranoid>, C<enabled>, C<auto>, and

--- a/master/lib/Munin/Master/Config.pm
+++ b/master/lib/Munin/Master/Config.pm
@@ -162,6 +162,8 @@ my %booleans = map {$_ => 1} qw(
 		tmpldir          => "$Munin::Common::Defaults::MUNIN_CONFDIR/templates",
 	        staticdir        => "$Munin::Common::Defaults::MUNIN_CONFDIR/static",
 	        cgitmpdir        => "$Munin::Common::Defaults::MUNIN_DBDIR/cgi-tmp",
+		ssh_command      => "ssh",
+		ssh_options      => "-o ChallengeResponseAuthentication=no -o StrictHostKeyChecking=no",
 	    }, $class ),
 
 	    oldconfig => bless ( {

--- a/master/lib/Munin/Master/Node.pm
+++ b/master/lib/Munin/Master/Node.pm
@@ -94,7 +94,7 @@ sub _do_connect {
 		return 0;
 	}
     } elsif ($uri->scheme eq "ssh") {
-	    my $ssh_command = "ssh -o ChallengeResponseAuthentication=no -o StrictHostKeyChecking=no ";
+	    my $ssh_command = sprintf("%s %s", $config->{ssh_command}, $config->{ssh_options});
 	    my $user_part = ($uri->user) ? ($uri->user . "@") : "";
 	    my $remote_cmd = ($uri->path ne '/') ? $uri->path : "";
 


### PR DESCRIPTION
These configuration options can be added to munin.conf for global ssh
client configuration.

ssh_command: The name of the ssh command. May be fully qualified or
looked up in $PATH.  Default: ssh

ssh_options: Options used for the ssh command line.  Defaults as before,
"-o ChallengeResponseAuthentication=no -o StrictHostKeyChecking=no"

Fixes #694
