### PR TITLE
Replace trivial use of Netcat in the jmx_ plugin with our own gadget to test for an open port

### DIFF
--- a/plugins/javalib/org/munin/plugin/jmx/PortProbe.java
+++ b/plugins/javalib/org/munin/plugin/jmx/PortProbe.java
@@ -1,0 +1,43 @@
+package org.munin.plugin.jmx;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+
+public class PortProbe
+{
+    static public void main(String[] argv)
+	throws Exception
+    {
+	int port = -1;
+	InetAddress host = null;
+
+	switch (argv.length)
+	    {
+	    case 1: // assume the loopback address ("localhost")
+		port = Integer.valueOf(argv[0]);
+		host = InetAddress.getByName(null);
+		break;
+	    case 2: // host name or address was given
+		port = Integer.valueOf(argv[0]);
+		host = InetAddress.getByName(argv[1]);
+		break;
+	    default:
+		System.err.println("Utilities PORT [HOST]");
+		System.exit(1);
+	    }
+
+	Socket socket = new Socket();
+	SocketAddress sa = new InetSocketAddress(host, port);
+	try {
+	    socket.connect(sa, 5*1000);
+	} catch (IOException e) {
+	    System.exit(1);
+	} finally {
+	    if (!socket.isClosed())
+		socket.close();
+	}
+    }
+}

--- a/plugins/node.d.java/jmx_
+++ b/plugins/node.d.java/jmx_
@@ -96,12 +96,7 @@ if [ "x$1" = "xsuggest" ] ; then
 fi
 
 if [ "x$1" = "xautoconf" ] ; then
-    NC=`which nc 2>/dev/null`
-    if [ "x$NC" = "x" ] ; then
-      echo "no (nc not found)"
-      exit 0
-    fi
-    $NC -n -z $ip $port >/dev/null 2>&1
+    $JAVA_BIN -cp $MUNIN_JAR $JAVA_OPTS org.munin.plugin.jmx.PortProbe $port $ip
     CONNECT=$?
 
     $JAVA_BIN -? >/dev/null 2>&1


### PR DESCRIPTION
There are several flavors of Netcat out there, and at least one of them does not understand the -z option.  That can cause autoconfig to think the port is closed when in fact it has not been tested because 'nc' rejected its options.

This patch was inspired by such a failure on Gentoo Linux when installing 2.0.19.  The Gentoo package declares a dependency on Netcat, accepts either http://netcat6.sourceforge.net/ (netcat6) or http://nc110.sourceforge.net/, and seems to prefer netcat6 which lacks -z.  That would be Gentoo's problem and I've filed a bug with them.  But I thought that the way 'nc' is used in the jmx_ plugin is so trivial that one may as well remove the dependency and provide the test in the product itself.
