### PR TITLE
Fix "Use of uninitialized value in numeric eq (==)" warning

### DIFF
--- a/master/lib/Munin/Master/Utils.pm
+++ b/master/lib/Munin/Master/Utils.pm
@@ -960,7 +960,7 @@ sub munin_readconfig_part {
 		exit(1);
 	}
 	# missing ok, return last value if we have one, copy config if not
-	if (undef == $config_parts->{$what}{config}) {
+	unless (defined $config_parts->{$what}{config}) {
 		# well, not if we shouldn't include the config
 		if ($config_parts->{$what}{include_base}) {
 			$doupdate = 1;


### PR DESCRIPTION
I get tons of lines like this in my logs

2016/07/27 12:05:43 [PERL WARNING] Use of uninitialized value in numeric eq (==) at /usr/lib64/perl5/vendor_perl/5.20.2/Munin/Master/Utils.pm line 963.

It seems to have been fixed in munin-2.1 (commit 029d747bd38282463e3826226eea25562e8180cd), although in a different way which just gives a different warning for me ("Use of uninitialized value in string eq").
