### PR TITLE
change default port to "undefined"

### DIFF
--- a/doc/reference/munin.conf.rst
+++ b/doc/reference/munin.conf.rst
@@ -152,7 +152,7 @@ only to that node.
 
 .. option:: port <port number>
 
-   The port number of the node. Ignored if using alternate transport. Default is "4949".
+   The port number of the node. Ignored if using alternate transport. Undefined by default.
 
 .. option:: local_address <address>
 


### PR DESCRIPTION
change default port to "undefined", according to program behavior

I noticed, that my munin-node started on 20203 port. So it is wrong to assume 4949 port to be default.

PS: using munin 2.999.2