### PR TITLE
Fix netstat "active connection openings" string

### DIFF
--- a/plugins/node.d.linux/netstat
+++ b/plugins/node.d.linux/netstat
@@ -102,7 +102,7 @@ if [ "$1" = "config" ]; then
 fi
 
 netstat -s | awk '
-/active connections ope/  { print "active.value " $1 }
+/active connection ope/  { print "active.value " $1 }
 /passive connection ope/  { print "passive.value " $1 }
 /failed connection/       { print "failed.value " $1 }
 /connection resets/       { print "resets.value " $1 }

--- a/plugins/node.d.linux/netstat
+++ b/plugins/node.d.linux/netstat
@@ -101,8 +101,12 @@ if [ "$1" = "config" ]; then
         exit 0
 fi
 
+# Newer versions of net tools' netstat have fixed the 'active connection
+# openings' string from plural connections to singular. The match hereby is for
+# both cases.
+#
 netstat -s | awk '
-/active connection ope/  { print "active.value " $1 }
+/active connection(s)? ope/  { print "active.value " $1 }
 /passive connection ope/  { print "passive.value " $1 }
 /failed connection/       { print "failed.value " $1 }
 /connection resets/       { print "resets.value " $1 }


### PR DESCRIPTION
Netstat fixed some typos in stats strings, which breaks Munin's netstat plugin's "active connections" metric:

https://sourceforge.net/p/net-tools/code/ci/614e15d6f4e32d094288414f6bf086d9761539f8/

This patch corrects that.
