### PR TITLE
p/postgres_users ignore own connection

### DIFF
--- a/plugins/node.d/postgres_users
+++ b/plugins/node.d/postgres_users
@@ -76,7 +76,13 @@ my $pg = Munin::Plugin::Pgsql->new(
             "SELECT usename,count(*) FROM pg_stat_activity WHERE procpid != pg_backend_pid() GROUP BY usename ORDER BY 1",
         ]
     ],
-    configquery => "SELECT DISTINCT usename,usename FROM pg_stat_activity ORDER BY 1",
+    configquery => [
+        "SELECT DISTINCT usename,usename FROM pg_stat_activity WHERE pid != pg_backend_pid() ORDER BY 1",
+        [
+            9.1,
+            "SELECT DISTINCT usename,usename FROM pg_stat_activity WHERE procpid != pg_backend_pid() ORDER BY 1",
+        ]
+    ],
 );
 
 $pg->Process();


### PR DESCRIPTION
Ignore the connection from munin-node when running config as it's
ignored when fetching values.