### PR TITLE
Ignore current process when configuring labels for postgres_users plugin

### DIFF
--- a/plugins/node.d/postgres_users
+++ b/plugins/node.d/postgres_users
@@ -76,7 +76,13 @@ my $pg = Munin::Plugin::Pgsql->new(
             "SELECT usename,count(*) FROM pg_stat_activity WHERE procpid != pg_backend_pid() GROUP BY usename ORDER BY 1",
         ]
     ],
-    configquery => "SELECT DISTINCT usename,usename FROM pg_stat_activity ORDER BY 1",
+    configquery => [
+        "SELECT DISTINCT usename,usename FROM pg_stat_activity WHERE pid != pg_backend_pid() ORDER BY 1",
+        [
+            9.1,
+            "SELECT DISTINCT usename,usename FROM pg_stat_activity WHERE procpid != pg_backend_pid() ORDER BY 1",
+        ]
+    ],
 );
 
 $pg->Process();


### PR DESCRIPTION
I'm resubmitting this pull request which was originally submitted as #683, but got closed accidentally.

Original description:
> I was receiving errors that there was no data for the label 'postgres'. This label was  included in the configuration, because the current process was not excluded when configuring the labels (and this is the default database), but it was excluded from the values. This change also excludes the current process from the labels.