### PR TITLE
Update postgres_connections_ for PostgreSQL 9.6

### DIFF
--- a/plugins/node.d/postgres_connections_
+++ b/plugins/node.d/postgres_connections_
@@ -76,6 +76,17 @@ my $pg = Munin::Plugin::Pgsql->new(
         "SELECT tmp.mstate AS state,COALESCE(count,0) FROM
                  (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(mstate)
                 LEFT JOIN
+                 (SELECT CASE WHEN wait_event_type IS NOT NULL THEN 'waiting' WHEN state='idle' THEN 'idle' WHEN state LIKE 'idle in transaction%' THEN 'idletransaction' WHEN state='disabled' THEN 'unknown' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END AS mstate,
+                 count(*) AS count
+                 FROM pg_stat_activity WHERE pid != pg_backend_pid() %%FILTER%%
+                 GROUP BY CASE WHEN wait_event_type IS NOT NULL THEN 'waiting' WHEN state='idle' THEN 'idle' WHEN state LIKE 'idle in transaction%' THEN 'idletransaction' WHEN state='disabled' THEN 'unknown' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END
+                 ) AS tmp2
+                ON tmp.mstate=tmp2.mstate
+                ORDER BY 1;
+		",
+            [ 9.5, "SELECT tmp.mstate AS state,COALESCE(count,0) FROM
+                 (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(mstate)
+                LEFT JOIN
                  (SELECT CASE WHEN waiting THEN 'waiting' WHEN state='idle' THEN 'idle' WHEN state LIKE 'idle in transaction%' THEN 'idletransaction' WHEN state='disabled' THEN 'unknown' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END AS mstate,
                  count(*) AS count
                  FROM pg_stat_activity WHERE pid != pg_backend_pid() %%FILTER%%
@@ -83,7 +94,7 @@ my $pg = Munin::Plugin::Pgsql->new(
                  ) AS tmp2
                 ON tmp.mstate=tmp2.mstate
                 ORDER BY 1;
-		",
+		" ],
             [ 9.4, "SELECT tmp.state,COALESCE(count,0) FROM
                  (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(state)
                 LEFT JOIN


### PR DESCRIPTION
PostgreSQL 9.6 changed the way how waiting connections are represented.

Closes #746