### PR TITLE
Correcting mysql_queries plugin random hash ordering.

### DIFF
--- a/plugins/node.d/mysql_queries
+++ b/plugins/node.d/mysql_queries
@@ -47,9 +47,10 @@ use strict;
 my $MYSQLADMIN = $ENV{mysqladmin} || "mysqladmin";
 my $COMMAND    = "$MYSQLADMIN $ENV{mysqlopts} extended-status";
 
-my %WANTED = ( "Com_delete"  => "delete", 
-			   "Com_insert"  => "insert",
-               "Com_select"  => "select", 
+my @WANTED_ORDER = ( "Com_select", "Com_delete", "Com_insert", "Com_update", "Com_replace", "Qcache_hits" );
+my %WANTED = ( "Com_delete"  => "delete",
+               "Com_insert"  => "insert",
+               "Com_select"  => "select",
                "Com_update"  => "update",
                "Com_replace" => "replace",
                "Qcache_hits" => "cache_hits",
@@ -95,7 +96,7 @@ graph_category mysql
 graph_info Note that this is a old plugin which is no longer installed by default.  It is retained for compatibility with old installations.
 graph_total total\n");
 
-    for my $key (keys %WANTED) {
+    foreach my $key (@WANTED_ORDER){
         my $title = $WANTED{$key};
         print("$title.label ${title}\n",
               "$title.min 0\n",


### PR DESCRIPTION
Perl docs say: The keys of a hash are returned in an apparently random order. The actual random order is subject to change in future versions of Perl, but it is guaranteed to be the same order as either the values or each function produces (given that the hash has not been modified). Since Perl 5.8.1 the ordering can be different even between different runs of Perl for security reasons (see Algorithmic Complexity Attacks in perlsec).