### PR TITLE
Revert "munin_stats plugin: only graph munin-graph if graph_strategy=…

### DIFF
--- a/plugins/node.d/munin_stats.in
+++ b/plugins/node.d/munin_stats.in
@@ -27,14 +27,9 @@ use strict;
 use warnings;
 
 use Munin::Plugin;
-use Munin::Master::GraphOld;
 
-my @logs = qw/update html limits/;
+my @logs = qw/update graph html limits/;
 my $logdir = ($ENV{'logdir'} || $ENV{'MUNIN_LOGDIR'} || '@@LOGDIR@@');
-my $conffile = "$Munin::Common::Defaults::MUNIN_CONFDIR/munin.conf";
-if (! graph_check_cron() ) {
-     push  (@logs, "graph");
-}
 
 if ($ARGV[0] and $ARGV[0] eq 'autoconf') {
     my $munin_update_location = 
@@ -56,13 +51,9 @@ if ($ARGV[0] and $ARGV[0] eq 'autoconf') {
 }
 
 if ($ARGV[0] and $ARGV[0] eq "config") {
-    print "graph_title Munin processing time\n";
-    if (! graph_check_cron() ) {
-        print  "graph_info This graph shows the run time of the four different processes making up a munin-master run.  Munin-master is run from cron every 5 minutes and we want each of the programmes in munin-master to complete before the next instance starts.  Especially munin-update and munin-graph are time consuming and their run time bears watching. If munin-update uses too long time to run please see the munin-update graph to determine which host is slowing it down.  If munin-graph is running too slow you need to get clever (email the munin-users mailing list) unless you can buy a faster computer with better disks to run munin on.\n";
-    } else {
-        print  "graph_info This graph shows the run time of the three different processes making up a munin-master run.  Munin-master is run from cron every 5 minutes and we want each of the programmes in munin-master to complete before the next instance starts.  Especially munin-update is time consuming and its run time bears watching. If munin-update uses too long time to run please see the munin-update graph to determine which host is slowing it down.\n";
-    }
-    print "graph_args --base 1000 -l 0\n",
+    print "graph_title Munin processing time\n",
+          "graph_info This graph shows the run time of the four different processes making up a munin-master run.  Munin-master is run from cron every 5 minutes and we want each of the programmes in munin-master to complete before the next instance starts.  Especially munin-update and munin-graph are time consuming and their run time bears watching. If munin-update uses too long time to run please see the munin-update graph to determine which host is slowing it down.  If munin-graph is running too slow you need to get clever (email the munin-users mailing list) unless you can buy a faster computer with better disks to run munin on.\n",
+          "graph_args --base 1000 -l 0\n",
           "graph_scale yes\n",
           "graph_vlabel seconds\n",
           "graph_category munin\n";
@@ -72,10 +63,8 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
     }
     print "update.warning 240\n";
     print "update.critical 285\n";
-    if (! graph_check_cron() ) {
-        print "graph.warning 240\n";
-        print "graph.critical 285\n";
-    }
+    print "graph.warning 240\n";
+    print "graph.critical 285\n";
     exit 0;
 }
 


### PR DESCRIPTION
…cron"

SInce ec3128b, munin_stats plugin depends on Munin::Master module. So, munin-node.rpm depends on munin.rpm, and all nodes need to install the unwanted munin master package.

This reverts commit ec3128b.

Fixes #745.