### PR TITLE
Fix Java committed memory bigger than Max

### DIFF
--- a/plugins/javalib/org/munin/plugin/jmx/MemoryAllocatedTotal.java
+++ b/plugins/javalib/org/munin/plugin/jmx/MemoryAllocatedTotal.java
@@ -21,7 +21,12 @@ public class MemoryAllocatedTotal extends AbstractMemoryUsageProvider {
 		long totalInit = heap.getInit()+nonHeap.getInit();
 		long totalUsed = heap.getUsed() + nonHeap.getUsed();
 		long totalCommitted = heap.getCommitted()+nonHeap.getCommitted();
-		long totalMax = heap.getMax()+nonHeap.getMax();
+		long totalMax = heap.getMax();
+		if (nonHeap.getMax() == -1) {
+			totalMax += nonHeap.getCommitted();
+		} else {
+			totalMax += nonHeap.getMax();
+		}
 		memoryUsage = new MemoryUsage(totalInit, totalUsed, totalCommitted, totalMax);
 	}
 


### PR DESCRIPTION
IllegalArgumentException is thrown if committed is greater than
the value of max.
Max for NonHeap can be -1 (undefined).
In the case we use committed for max.