### PR TITLE
Suppress returned no data warnings on munin-update

### DIFF
--- a/lib/Munin/Master/UpdateWorker.pm
+++ b/lib/Munin/Master/UpdateWorker.pm
@@ -686,6 +686,10 @@ sub _update_rrd_files {
     my $last_timestamp = 0;
 
     for my $service (keys %{$nested_service_config->{data_source}}) {
+	my $update = get_config_for_service($nested_service_config->{global}{$service}, "update");
+	if (defined($update) and $update eq 'no') {
+	    next;
+	}
 
 	my $service_config = $nested_service_config->{data_source}{$service};
 	my $service_data   = $nested_service_data->{$service};


### PR DESCRIPTION
I see many warnings in munin-update.log with jmx plugins.

```
2016/12/21 04:07:04 [WARNING] Service jmx_alfresco_memory.pool_G1_Perm_Gen.postGC on xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:4949 returned no data for label Used
2016/12/21 04:07:04 [WARNING] Service jmx_alfresco_memory.pool_G1_Perm_Gen.postGC on xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:4949 returned no data for label Max
2016/12/21 04:07:04 [WARNING] Service jmx_alfresco_memory.pool_G1_Perm_Gen.postGC on xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:4949 returned no data for label Committed
2016/12/21 04:07:04 [WARNING] Service jmx_alfresco_memory.pool_G1_Perm_Gen.postGC on xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:4949 returned no data for label Init
```

Updating data should be skipped if service config has `update no`.