### PR TITLE
Remove --sdtout param from munin-update command

### DIFF
--- a/doc/tutorial/troubleshooting.rst
+++ b/doc/tutorial/troubleshooting.rst
@@ -205,7 +205,7 @@ Run :ref:`munin-update` as user ``munin`` on the Munin master machine.
 ::
 
   # su -s /bin/bash munin
-  $ /usr/share/munin/munin-update --debug --nofork --stdout --host foo.example.com --service df
+  $ /usr/share/munin/munin-update --debug --nofork --host foo.example.com --service df
 
 You should get a line like this:
 


### PR DESCRIPTION
I was going through the troubleshooting documentation, and one of the commands suggested is using an outdated(?) parameter that doesn't exist.

Error:

    $ /usr/share/munin/munin-update --debug --nofork --stdout --host example.com --service df

    Unknown option: stdout

Version installed: 

    $ /usr/share/munin/munin-update --version                                       

    munin version 2.0.25-2.

OS installed:

    cat /etc/centos-release
 
    CentOS release 6.8 (Final)

Disclaimer: This is the first time going through Munin in detail.

