### PR TITLE
web: remove runtime dep to fonts.googleapis.com

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -18,7 +18,7 @@ html, body {
 body {
   background: #FAFAFA;
   font-size: 90%;
-  font-family: Roboto, sans-serif;
+  font-family: "Dejavu Sans", Helvetica, Verdana, Arial, sans-serif;
   color: #666666;
 }
 

--- a/web/static/css/style.scss
+++ b/web/static/css/style.scss
@@ -89,7 +89,7 @@ html, body {
 body {
 	background: #FAFAFA;
 	font-size: 90%;
-	font-family: Roboto, sans-serif;
+	font-family: "Dejavu Sans", Helvetica, Verdana, Arial, sans-serif;
 	color: #666666;
 }
 

--- a/web/templates/partial/head.tmpl
+++ b/web/templates/partial/head.tmpl
@@ -40,5 +40,4 @@
 	<!--[if lt IE 9]>
 		<script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 	<![endif]-->
-	<link href="https://fonts.googleapis.com/css?family=Roboto:500,400" rel="stylesheet" type="text/css">
 </head>


### PR DESCRIPTION
Depending on some external ressource is bad as it makes us not self
contained anymore.

Either provide the resource locally, or find an alternative