### PR TITLE
[apt_all] Make @releases configurable

### DIFF
--- a/plugins/node.d.linux/apt_all
+++ b/plugins/node.d.linux/apt_all
@@ -13,7 +13,8 @@ graphs.
 
 =head1 CONFIGURATION
 
-No configuration needed
+[apt_all]
+env.MUNIN_APT_RELEASES = stable,testing,unstable
 
 =head1 MAGIC MARKERS
 
@@ -34,7 +35,7 @@ $ENV{'LC_ALL'}="C";
 my $aptcache = '/var/cache/apt';
 my $dpkgstatus = '/var/lib/dpkg/status';
 # Releases to monitor
-my @releases = ("stable", "testing", "unstable");
+my @releases = split(",", ($ENV{MUNIN_APT_RELEASES} || "stable,testing,unstable"));
 
 # Print the apt state, regenerating the state cache if necessary
 sub print_state() {


### PR DESCRIPTION
This avoids error messages when trying to update releases not present in
the sources. See Debian bug #715141. [0]

[0] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=715141

Signed-off-by: Olivier Mehani <shtrom@ssji.net>