### PR TITLE
Fix the check_perms_if_paranoid method

### DIFF
--- a/lib/Munin/Node/OS.pm
+++ b/lib/Munin/Node/OS.pm
@@ -68,7 +68,7 @@ sub check_perms_if_paranoid
     # Check dir as well
     if (-f $target) {
         (my $dirname = $target) =~ s{[^/]+$}{};
-        return $class->check_perms($dirname);
+        return $class->check_perms_if_paranoid($dirname);
     }
 
     return 1;


### PR DESCRIPTION
Hello,

When the `paranoia` directive is set to true, munin-node crashes with the following error message:

    Can't locate object method "check_perms" via package "Munin::Node::OS" at /usr/share/perl5/Munin/Node/OS.pm line 74.

One instance of `check_perms` was missed when the method was renamed to `check_perms_if_paranoid`.

This PR closes issue #741.