### PR TITLE
Tomcat improvements

### DIFF
--- a/plugins/node.d/tomcat_access
+++ b/plugins/node.d/tomcat_access
@@ -54,6 +54,7 @@ use strict;
 use warnings;
 
 use Munin::Plugin::HTTP;
+use URI::Escape;
 
 my $ret = undef;
 
@@ -70,7 +71,7 @@ my $PASSWORD = exists $ENV{'password'} ? $ENV{'password'} : "munin";
 my $TIMEOUT  = exists $ENV{'timeout'}  ? $ENV{'timeout'}  : 30;
 my $CONNECTOR= $ENV{'connector'};
 
-my $url = sprintf $URL, $USER, $PASSWORD, $HOST, $PORT;
+my $url = sprintf $URL, uri_escape($USER), uri_escape($PASSWORD), $HOST, $PORT;
 
 if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
     if($ret) {

--- a/plugins/node.d/tomcat_access
+++ b/plugins/node.d/tomcat_access
@@ -51,6 +51,8 @@ GPLv2
 =cut
 
 use strict;
+use warnings;
+
 use Munin::Plugin::HTTP;
 
 my $ret = undef;
@@ -65,22 +67,23 @@ my $PORT     = exists $ENV{'port'}     ? $ENV{'port'}     : exists $ENV{'ports'}
 my $HOST     = exists $ENV{'host'}     ? $ENV{'host'}     : "127.0.0.1";
 my $USER     = exists $ENV{'user'}     ? $ENV{'user'}     : "munin";
 my $PASSWORD = exists $ENV{'password'} ? $ENV{'password'} : "munin";
-my $CONNECTOR= exists $ENV{'connector'}? $ENV{'connector'}: "http-".$PORT;
+my $TIMEOUT  = exists $ENV{'timeout'}  ? $ENV{'timeout'}  : 30;
+my $CONNECTOR= $ENV{'connector'};
 
 my $url = sprintf $URL, $USER, $PASSWORD, $HOST, $PORT;
 
 if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
     if($ret) {
-	print "no ($ret)\n";
-	exit 0;
+        print "no ($ret)\n";
+        exit 0;
     }
-    my $repsonse = $UA->get($url);
-    if($repsonse->is_success and $repsonse->content =~ /<status>.*<\/status>/im) {
+    my $response = $UA->get($url);
+    if($response->is_success and $response->content =~ /<status>.*<\/status>/im) {
 	print "yes\n";
 	exit 0;
     } else {
-	print "no (no tomcat status)\n";
-	exit 0;
+        print "no (no tomcat status)\n";
+        exit 0;
     }
 }
 
@@ -101,8 +104,32 @@ my $response = $UA->get($url);
 my %options = ( KeyAttr => { connector => 'name' }, ForceArray => 1 );
 my $xml = $xs->XMLin($response->content, %options);
 
-if($xml->{'connector'}->{$CONNECTOR}->{'requestInfo'}->[0]->{'requestCount'}) {
-    print "accesses.value " . $xml->{'connector'}->{$CONNECTOR}->{'requestInfo'}->[0]->{'requestCount'} . "\n";
+my @connectors;
+if(defined $CONNECTOR) {
+    push @connectors, $CONNECTOR;
 } else {
-    print "accesses.value U\n";
+    @connectors = keys %{$xml->{'connector'}};
+}
+
+if(exists $ARGV[0] and $ARGV[0] eq "config") {
+    print "graph_title Tomcat accesses\n";
+    print "graph_args --base 1000\n";
+    print "graph_vlabel accesses / \${graph_period}\n";
+    print "graph_category tomcat\n";
+    for my $connector (@connectors) {
+        my $clean = clean_fieldname($connector);
+        print "${clean}_accesses.label $connector Accesses\n";
+        print "${clean}_accesses.type DERIVE\n";
+        print "${clean}_accesses.max 1000000\n";
+        print "${clean}_accesses.min 0\n";
+    }
+} else {
+    for my $connector (@connectors) {
+        my $clean = clean_fieldname($connector);
+        if(exists $xml->{'connector'}->{$connector}->{'requestInfo'}->[0]->{'requestCount'}) {
+            print "${clean}_accesses.value " . $xml->{'connector'}->{$connector}->{'requestInfo'}->[0]->{'requestCount'} . "\n";
+        } else {
+            print "${clean}_accesses.value U\n";
+        }
+    }
 }

--- a/plugins/node.d/tomcat_jvm
+++ b/plugins/node.d/tomcat_jvm
@@ -59,6 +59,8 @@ GPLv2
 =cut
 
 use strict;
+use warnings;
+
 use Munin::Plugin::HTTP;
 
 my $ret = undef;
@@ -81,8 +83,8 @@ if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
 	print "no ($ret)\n";
 	exit 0;
     }
-    my $repsonse = $UA->get($url);
-    if($repsonse->is_success and $repsonse->content =~ /<status>.*<\/status>/im) {
+    my $response = $UA->get($url);
+    if($response->is_success and $response->content =~ /<status>.*<\/status>/im) {
 	print "yes\n";
 	exit 0;
     } else {

--- a/plugins/node.d/tomcat_jvm
+++ b/plugins/node.d/tomcat_jvm
@@ -62,6 +62,7 @@ use strict;
 use warnings;
 
 use Munin::Plugin::HTTP;
+use URI::Escape;
 
 my $ret = undef;
 
@@ -76,7 +77,7 @@ my $HOST     = exists $ENV{'host'}     ? $ENV{'host'}     : "127.0.0.1";
 my $USER     = exists $ENV{'user'}     ? $ENV{'user'}     : "munin";
 my $PASSWORD = exists $ENV{'password'} ? $ENV{'password'} : "munin";
 
-my $url = sprintf $URL, $USER, $PASSWORD, $HOST, $PORT;
+my $url = sprintf $URL, uri_escape($USER), uri_escape($PASSWORD), $HOST, $PORT;
 
 if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
     if($ret) {

--- a/plugins/node.d/tomcat_threads
+++ b/plugins/node.d/tomcat_threads
@@ -50,6 +50,8 @@ GPLv2
 =cut
 
 use strict;
+use warnings;
+
 use Munin::Plugin::HTTP;
 
 my $ret = undef;
@@ -64,23 +66,37 @@ my $PORT     = exists $ENV{'port'}     ? $ENV{'port'}     : exists $ENV{'ports'}
 my $HOST     = exists $ENV{'host'}     ? $ENV{'host'}     : "127.0.0.1";
 my $USER     = exists $ENV{'user'}     ? $ENV{'user'}     : "munin";
 my $PASSWORD = exists $ENV{'password'} ? $ENV{'password'} : "munin";
-my $CONNECTOR= exists $ENV{'connector'}? $ENV{'connector'}: "http-".$PORT;
+my $TIMEOUT  = exists $ENV{'timeout'}  ? $ENV{'timeout'}  : 30;
+my $CONNECTOR= $ENV{'connector'};
 
 my $url = sprintf $URL, $USER, $PASSWORD, $HOST, $PORT;
 
 if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
     if($ret) {
-	print "no ($ret)\n";
-	exit 0;
+        print "no ($ret)\n";
+        exit 0;
     }
-    my $repsonse = $UA->get($url);
-    if($repsonse->is_success and $repsonse->content =~ /<status>.*<\/status>/im) {
+    my $response = $UA->get($url);
+    if($response->is_success and $response->content =~ /<status>.*<\/status>/im) {
 	print "yes\n";
 	exit 0;
     } else {
-	print "no (no tomcat status)\n";
-	exit 0;
+        print "no (no tomcat status)\n";
+        exit 0;
     }
+}
+
+my $ua = LWP::UserAgent->new(timeout => $TIMEOUT);
+my $xs = new XML::Simple;
+my $response = $ua->request(HTTP::Request->new('GET',$url));
+my %options = ( KeyAttr => { connector => 'name' }, ForceArray => 1 );
+my $xml = $xs->XMLin($response->content, %options);
+
+my @connectors;
+if(defined $CONNECTOR) {
+    push @connectors, $CONNECTOR;
+} else {
+    @connectors = keys %{$xml->{'connector'}};
 }
 
 if(exists $ARGV[0] and $ARGV[0] eq "config") {
@@ -89,28 +105,38 @@ if(exists $ARGV[0] and $ARGV[0] eq "config") {
     print "graph_vlabel threads\n";
     print "graph_category tomcat\n";
     print "graph_total total\n";
-    print "graph_order busy idle\n";
-    print "busy.label busy threads\n";
-    print "busy.draw AREA\n";
-    print "idle.label idle threads\n";
-    print "idle.draw STACK\n";
-    exit 0;
-}
+    my @idle;
+    my @busy;
+    my $first = 1;
+    for my $connector (@connectors) {
+        my $clean = clean_fieldname($connector);
+        print "${clean}_busy.label $connector busy threads\n";
+        if($first) {
+            print "${clean}_busy.draw AREA\n";
+            $first = 0;
+        } else {
+            print "${clean}_busy.draw STACK\n";
+        }
+        print "${clean}_idle.label $connector idle threads\n";
+        print "${clean}_idle.draw STACK\n";
 
-my $xs = new XML::Simple;
-my $response = $UA->get($url);
-my %options = ( KeyAttr => { connector => 'name' }, ForceArray => 1 );
-my $xml = $xs->XMLin($response->content, %options);
+        push @busy, "${clean}_busy";
+        push @idle, "${clean}_idle";
+    }
+    print "graph_order " . join(" ", @busy) . " " . join(" ", @idle) . "\n";
 
-if($xml->{'connector'}->{$CONNECTOR}->{'threadInfo'}->[0]->{'currentThreadsBusy'} =~ /\d+/ &&
-    $xml->{'connector'}->{$CONNECTOR}->{'threadInfo'}->[0]->{'currentThreadCount'} =~ /\d+/ ) {
-    print "busy.value " . $xml->{'connector'}->{$CONNECTOR}->{'threadInfo'}->[0]->{'currentThreadsBusy'} . "\n";
-    print "idle.value " .
-	  ($xml->{'connector'}->{$CONNECTOR}->{'threadInfo'}->[0]->{'currentThreadCount'} -
-	  $xml->{'connector'}->{$CONNECTOR}->{'threadInfo'}->[0]->{'currentThreadsBusy'}) . "\n";
-	print "total.value " . $xml->{'connector'}->{$CONNECTOR}->{'threadInfo'}->[0]->{'currentThreadCount'} . "\n";
 } else {
-    print "busy.value U\n";
-    print "idle.value U\n";
-    print "total.value U\n";
+    for my $connector (@connectors) {
+        my $clean = clean_fieldname($connector);
+        if(exists $xml->{'connector'}->{$connector}->{'threadInfo'}->[0]->{'currentThreadsBusy'} &&
+            exists $xml->{'connector'}->{$connector}->{'threadInfo'}->[0]->{'currentThreadCount'}) {
+            print "${clean}_busy.value " . $xml->{'connector'}->{$connector}->{'threadInfo'}->[0]->{'currentThreadsBusy'} . "\n";
+            print "${clean}_idle.value " .
+              ($xml->{'connector'}->{$connector}->{'threadInfo'}->[0]->{'currentThreadCount'} -
+              $xml->{'connector'}->{$connector}->{'threadInfo'}->[0]->{'currentThreadsBusy'}) . "\n";
+        } else {
+            print "${clean}_busy.value U\n";
+            print "${clean}_idle.value U\n";
+        }
+    }
 }

--- a/plugins/node.d/tomcat_threads
+++ b/plugins/node.d/tomcat_threads
@@ -53,6 +53,7 @@ use strict;
 use warnings;
 
 use Munin::Plugin::HTTP;
+use URI::Escape;
 
 my $ret = undef;
 
@@ -69,7 +70,7 @@ my $PASSWORD = exists $ENV{'password'} ? $ENV{'password'} : "munin";
 my $TIMEOUT  = exists $ENV{'timeout'}  ? $ENV{'timeout'}  : 30;
 my $CONNECTOR= $ENV{'connector'};
 
-my $url = sprintf $URL, $USER, $PASSWORD, $HOST, $PORT;
+my $url = sprintf $URL, uri_escape($USER), uri_escape($PASSWORD), $HOST, $PORT;
 
 if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
     if($ret) {

--- a/plugins/node.d/tomcat_volume
+++ b/plugins/node.d/tomcat_volume
@@ -68,6 +68,8 @@ tomcat-users.xml example:
 =cut
 
 use strict;
+use warnings;
+
 use Munin::Plugin::HTTP;
 
 my $ret = undef;
@@ -82,35 +84,24 @@ my $PORT     = exists $ENV{'port'}     ? $ENV{'port'}     : exists $ENV{'ports'}
 my $HOST     = exists $ENV{'host'}     ? $ENV{'host'}     : "127.0.0.1";
 my $USER     = exists $ENV{'user'}     ? $ENV{'user'}     : "munin";
 my $PASSWORD = exists $ENV{'password'} ? $ENV{'password'} : "munin";
-my $CONNECTOR= exists $ENV{'connector'}? $ENV{'connector'}: "http-".$PORT;
+my $TIMEOUT  = exists $ENV{'timeout'}  ? $ENV{'timeout'}  : 30;
+my $CONNECTOR= $ENV{'connector'};
 
 my $url = sprintf $URL, $USER, $PASSWORD, $HOST, $PORT;
 
 if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
     if($ret) {
-	print "no ($ret)\n";
-	exit 0;
+        print "no ($ret)\n";
+        exit 0;
     }
-    my $repsonse = $UA->get($url);
-    if($repsonse->is_success and $repsonse->content =~ /<status>.*<\/status>/im) {
+    my $response = $UA->get($url);
+    if($response->is_success and $response->content =~ /<status>.*<\/status>/im) {
 	print "yes\n";
 	exit 0;
     } else {
-	print "no (no tomcat status)\n";
-	exit 0;
+        print "no (no tomcat status)\n";
+        exit 0;
     }
-}
-
-if(exists $ARGV[0] and $ARGV[0] eq "config") {
-    print "graph_title Tomcat volume\n";
-    print "graph_args --base 1000\n";
-    print "graph_vlabel bytes per \${graph_period}\n";
-    print "graph_category tomcat\n";
-    print "volume.label bytes\n";
-    print "volume.type DERIVE\n";
-    print "volume.max 1000000000\n";
-    print "volume.min 0\n";
-    exit 0;
 }
 
 my $xs = new XML::Simple;
@@ -118,9 +109,32 @@ my $response = $UA->get($url);
 my %options = ( KeyAttr => { connector => 'name' }, ForceArray => 1 );
 my $xml = $xs->XMLin($response->content, %options);
 
-
-if($xml->{'connector'}->{$CONNECTOR}->{'requestInfo'}->[0]->{'bytesSent'}) {
-    print "volume.value " . $xml->{'connector'}->{$CONNECTOR}->{'requestInfo'}->[0]->{'bytesSent'} . "\n";
+my @connectors;
+if(defined $CONNECTOR) {
+    push @connectors, $CONNECTOR;
 } else {
-    print "volume.value U\n";
+    @connectors = keys %{$xml->{'connector'}};
+}
+
+if(exists $ARGV[0] and $ARGV[0] eq "config") {
+    print "graph_title Tomcat volume\n";
+    print "graph_args --base 1000\n";
+    print "graph_vlabel bytes per \${graph_period}\n";
+    print "graph_category tomcat\n";
+    for my $connector (@connectors) {
+        my $clean = clean_fieldname($connector);
+        print "${clean}_volume.label $connector bytes\n";
+        print "${clean}_volume.type DERIVE\n";
+        print "${clean}_volume.max 1000000000\n";
+        print "${clean}_volume.min 0\n";
+    }
+} else {
+    for my $connector (@connectors) {
+        my $clean = clean_fieldname($connector);
+        if(exists $xml->{'connector'}->{$connector}->{'requestInfo'}->[0]->{'bytesSent'}) {
+            print "${clean}_volume.value " . $xml->{'connector'}->{$connector}->{'requestInfo'}->[0]->{'bytesSent'} . "\n";
+        } else {
+            print "${clean}_volume.value U\n";
+        }
+    }
 }

--- a/plugins/node.d/tomcat_volume
+++ b/plugins/node.d/tomcat_volume
@@ -71,6 +71,7 @@ use strict;
 use warnings;
 
 use Munin::Plugin::HTTP;
+use URI::Escape;
 
 my $ret = undef;
 
@@ -87,7 +88,7 @@ my $PASSWORD = exists $ENV{'password'} ? $ENV{'password'} : "munin";
 my $TIMEOUT  = exists $ENV{'timeout'}  ? $ENV{'timeout'}  : 30;
 my $CONNECTOR= $ENV{'connector'};
 
-my $url = sprintf $URL, $USER, $PASSWORD, $HOST, $PORT;
+my $url = sprintf $URL, uri_escape($USER), uri_escape($PASSWORD), $HOST, $PORT;
 
 if(exists $ARGV[0] and $ARGV[0] eq "autoconf") {
     if($ret) {


### PR DESCRIPTION
Two fixes for the perl tomcat plugins.  One fixes it so the username/password to tomcat can have URI unsafe characters (which tend to appear in passwords).

The other is backwards incompatible because it changes the datafield names so that it can support collecting data from more than one collector (otherwise we can only monitor a single collector per plugin instance), as well as auto-detecting collector names so that the plugins "just work".  They should still function in the mode where the admin specifies the collector name to support existing setups.

I also have a patchset for 2.0 available if these changes sound like a good idea for that branch too.