### PR TITLE
Add support for rndc options in bind9_rndc plugin.

### DIFF
--- a/plugins/node.d/bind9_rndc
+++ b/plugins/node.d/bind9_rndc
@@ -12,6 +12,7 @@ The following environment variables are used by this plugin
 
   [bind9_rndc]
     env.rndc		/usr/sbin/rndc
+    env.rndc_options	
     env.querystats      /var/run/named.stats
 
 The user/group that runs the plugin must have read access to the stats
@@ -63,6 +64,7 @@ License not documented.
 use strict;
 
 my $rndc = defined($ENV{rndc}) ? $ENV{rndc} : '/usr/sbin/rndc';
+my $rndc_options = defined($ENV{rndc_options}) ? $ENV{rndc_options} : '';
 my $querystats = $ENV{querystats} || '/var/run/named.stats';
 my %IN;
 my %QUERIES;
@@ -70,7 +72,7 @@ my %IP;
 
 # attempt to create log file if it doesn't exist
 if ( ! -r $querystats ) {
-    system("$rndc stats");
+    system("$rndc $rndc_options stats");
 }
 
 # open the log file, and get its size
@@ -78,7 +80,7 @@ open(my $stats, '<', $querystats) or die "$0: $querystats: $!\n";
 my $size = (stat $stats)[7];
 
 # call rdnc and go directly to the correct offset
-system("$rndc stats");
+system("$rndc $rndc_options stats");
 seek($stats , $size, 0);
 
 # We want the last block like this in the file (bind 9.early)


### PR DESCRIPTION
The `bind9_rndc` plugin doesn't support options to set a different key (`-k`), config file (`-c`) or any of the other [`rndc` options](https://ftp.isc.org/isc/bind9/cur/9.11/doc/arm/man.rndc.html).

I needed these changes to monitor multiple BIND instances.