### PR TITLE
m/Utils: always use munin_read_storable()

### DIFF
--- a/master/lib/Munin/Master/Utils.pm
+++ b/master/lib/Munin/Master/Utils.pm
@@ -34,7 +34,6 @@ our (@ISA, @EXPORT);
 	   'munin_runlock',
 	   'munin_getlock',
 	   'munin_readconfig_raw',
-	   'munin_readconfig_storable',
 	   'munin_writeconfig',
 	   'munin_writeconfig_storable',
 	   'munin_read_storable',
@@ -267,22 +266,6 @@ sub munin_overwrite {
     return ($configfile);
 }
 
-sub munin_readconfig_storable {
-    my ($file) = @_;
-
-    my $part = undef;
-    $file ||= $configfile;
-
-    # try to read storable version
-    if ((-r $file) && open (my $CFG_STORABLE, '<', $file)) { 
-        DEBUG "[DEBUG] munin_readconfig: found Storable version of $file, using it";
-        $part = Storable::fd_retrieve($CFG_STORABLE); 
-        close ($CFG_STORABLE); 
-    }
-
-    return $part; 
-}
-
 sub munin_readconfig_raw {
     my ($conf, $missingok) = @_;
 
@@ -290,7 +273,7 @@ sub munin_readconfig_raw {
 
     $conf ||= $configfile;
     # try first to read storable version
-    $part = munin_readconfig_storable("$conf.storable");
+    $part = munin_read_storable("$conf.storable");
     if (!defined $part) {
         if (! -r $conf and ! $missingok) {
             WARN "munin_readconfig: cannot open '$conf'";
@@ -971,7 +954,7 @@ sub munin_readconfig_part {
 	if ($config_parts->{$what}{timestamp} < $stat[9]) {
 	    # could use _raw if we wanted to read non-storable fallback
 	    $config_parts->{$what}{config} = undef; # Unalloc RAM for old config, since it will be overriden anyway.
-	    $part = munin_readconfig_storable($filename);
+	    $part = munin_read_storable($filename);
 	    $config_parts->{$what}{timestamp} = $stat[9];
 	    $doupdate = 1;
 	}


### PR DESCRIPTION
Some legacy code used munin_readconf_storable() which was looking for a text
version if the Storable version wasn't present. The text version has been
removed completely, and the munin_readconf_storable() was modified accordingly.

But munin_readconf_storable() didn't get the enhancements of
munin_read_storable(), so this commit removes that old function and remaps the
calls to munin_read_storable()

Closes: #821