### PR TITLE
Fix alerts for unknown values not being triggered for GAUGE values

### DIFF
--- a/master/lib/Munin/Master/LimitsOld.pm
+++ b/master/lib/Munin/Master/LimitsOld.pm
@@ -369,13 +369,17 @@ sub process_service {
 		my ($previous_updated_timestamp, $previous_updated_value) = @{ $state->{value}{"$rrd_filename:42"}{previous} || [ ] };
 
 		my $heartbeat = 600; # XXX - $heartbeat is a fixed 10 min (2 runs of 5 min).
-		if (! $field->{type} || $field->{type} eq "GAUGE") {
-			$value = $current_updated_value;
-		} elsif (! defined $current_updated_value || ! defined $previous_updated_value || $current_updated_timestamp == $previous_updated_timestamp) {
-			# No derive computing possible. Report unknown.
+		if (! defined $current_updated_value) {
+			# No value yet. Report unknown.
 			$value = "U";
 		} elsif (time > $current_updated_timestamp + $heartbeat) {
-			# Current value is too old. Report unknown. 
+			# Current value is too old. Report unknown.
+			$value = "U";
+		} elsif (! $field->{type} || $field->{type} eq "GAUGE") {
+			# Non-compute up-to-date value.
+			$value = $current_updated_value;
+		} elsif (! defined $previous_updated_value || $current_updated_timestamp == $previous_updated_timestamp) {
+			# No derive computing possible. Report unknown.
 			$value = "U";
 		} elsif ($current_updated_timestamp > $previous_updated_timestamp + $heartbeat) {
 			# Old value is too old. Report unknown. 

--- a/master/lib/Munin/Master/LimitsOld.pm
+++ b/master/lib/Munin/Master/LimitsOld.pm
@@ -369,7 +369,7 @@ sub process_service {
 		my ($previous_updated_timestamp, $previous_updated_value) = @{ $state->{value}{"$rrd_filename:42"}{previous} || [ ] };
 
 		my $heartbeat = 600; # XXX - $heartbeat is a fixed 10 min (2 runs of 5 min).
-		if (! defined $current_updated_value) {
+		if (! defined $current_updated_value || $current_updated_value eq "U") {
 			# No value yet. Report unknown.
 			$value = "U";
 		} elsif (time > $current_updated_timestamp + $heartbeat) {
@@ -378,24 +378,17 @@ sub process_service {
 		} elsif (! $field->{type} || $field->{type} eq "GAUGE") {
 			# Non-compute up-to-date value.
 			$value = $current_updated_value;
-		} elsif (! defined $previous_updated_value || $current_updated_timestamp == $previous_updated_timestamp) {
+		} elsif (! defined $previous_updated_value || $previous_updated_value eq "U") {
 			# No derive computing possible. Report unknown.
 			$value = "U";
-		} elsif ($current_updated_timestamp > $previous_updated_timestamp + $heartbeat) {
-			# Old value is too old. Report unknown. 
-			$value = "U";
-		} elsif ($field->{type} eq "COUNTER" && $current_updated_value < $previous_updated_value) {
-			# COUNTER never decrease. Report unknown.
-			$value = "U";
-		} elsif ($current_updated_value eq "U") {
-			# The current value is unknown. Report unknown.
+		} elsif ($current_updated_timestamp == $previous_updated_timestamp || $current_updated_timestamp > $previous_updated_timestamp + $heartbeat) {
+			# Old value does not exist or is too old. Report unknown.
 			$value = "U";
 		} elsif ($field->{type} eq "ABSOLUTE") {
-			# The previous value is unimportant, as if ABSOLUTE, the counter is reset anytime the value is read
+			# The previous value is unimportant, as if ABSOLUTE, the counter is reset everytime the value is read
 			$value = $current_updated_value / ($current_updated_timestamp - $previous_updated_timestamp);
-		} elsif ($previous_updated_value eq "U") {
-			# The previous value is unknown.
-			# Report unknown, as we are not ABSOLUTE
+		} elsif ($field->{type} eq "COUNTER" && $current_updated_value < $previous_updated_value) {
+			# COUNTER never decrease. Report unknown.
 			$value = "U";
 		} else {
 			# Everything is ok for DERIVE/COUNTER
@@ -405,7 +398,7 @@ sub process_service {
 	}
 
         # De-taint.
-        if (!defined $value || $value eq "U") {
+        if ($value eq "U") {
             $value = "unknown";
         }
         else {


### PR DESCRIPTION
Currently, the logic in the Limits process means it only checks for "out-of-date" values if the value is a COUNTER or DERIVE type. For GAUGE types it just processes the last received value.

This means if you shutdown a server running munin-node with disk usage and if_err plugins enabled with limits set on them, the Limits process on the munin master will only report unknown for the if_err plugin (which is COUNTER I think.) There will be no alert for disk usage.

After applying this PR, you receive alerts for unknown on both disk usage and if_err.