### PR TITLE
Allow unknown_limit to be set on host level once for all services

### DIFF
--- a/master/lib/Munin/Master/LimitsOld.pm
+++ b/master/lib/Munin/Master/LimitsOld.pm
@@ -559,7 +559,12 @@ sub get_limits {
     my $warning  = undef;
     my $crit          = munin_get($hash, "critical",      undef);
     my $warn          = munin_get($hash, "warning",       undef);
-    my $unknown_limit = munin_get($hash, "unknown_limit", 3);
+    my $unknown_limit = munin_get($hash, "unknown_limit", undef);
+
+    if (not defined $unknown_limit) {
+        my $host_node = get_host_node($hash);
+        $unknown_limit = munin_get($host_node, "unknown_limit", 3);
+    }
 
     my $name = munin_get_node_name($hash);
 


### PR DESCRIPTION
Hello

This could be specific to me but creating pull request as it's a tiny change and if anyone does have similar requirements to myself it should help greatly.

At the moment, if one has a server that if powered off overnight (development environments for example) but one still wishes to monitor it through the day when it is on, one currently receives alerts for unknown values on if_err at least when it goes off, and if #837 is merged one gets alerts for all unknown values across all graphs with limits configured.

Setting unknown_limit for all graphs with limits is arduous and difficult, especially as there are many graphs where limits are pre-configured into them (if_err is one of them.)

My proposed solution is to allow the`unknown_limit` configuration to be given per-host as well as per-graph and per-service and per-field. It acts as a `fallback` for when there is nothing on the graph/service/field, thus applying to all limits, and allowing you to configure something like `144` which would allow 12 hours of downtime before alerts start to send. 