### PR TITLE
plugins/postgres: Fix connection stats for PG 9.2-9.4

### DIFF
--- a/plugins/node.d/postgres_connections_
+++ b/plugins/node.d/postgres_connections_
@@ -95,17 +95,6 @@ my $pg = Munin::Plugin::Pgsql->new(
                 ON tmp.mstate=tmp2.mstate
                 ORDER BY 1;
 		" ],
-            [ 9.4, "SELECT tmp.state,COALESCE(count,0) FROM
-                 (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(state)
-                LEFT JOIN
-                 (SELECT CASE WHEN waiting THEN 'waiting' WHEN query='<IDLE>' THEN 'idle' WHEN query='<IDLE> in transaction' THEN 'idletransaction' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END AS state,
-                 count(*) AS count
-                 FROM pg_stat_activity WHERE pid != pg_backend_pid() %%FILTER%%
-                 GROUP BY CASE WHEN waiting THEN 'waiting' WHEN query='<IDLE>' THEN 'idle' WHEN query='<IDLE> in transaction' THEN 'idletransaction' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END
-                 ) AS tmp2
-                ON tmp.state=tmp2.state
-                ORDER BY 1
-                " ],
             [ 9.1, "SELECT tmp.state,COALESCE(count,0) FROM
                  (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(state)
 	        LEFT JOIN


### PR DESCRIPTION
Commit dce46027a5fdb7d5cd44dc8cdb70ebcc425a949f introduced a query for
PG 9.4 but it counts all connections (including idle) as active.

This patch fixes the graph as described in the comments for https://github.com/munin-monitoring/munin/commit/dce46027a5fdb7d5cd44dc8cdb70ebcc425a949f

By removing the 9.4 query, the 9.5 query will be applied to PG 9.2-9.4. This has been successfully tested on live servers running PG 9.3 and on official Postgres Docker images from 9.2 to 9.4.
