### PR TITLE
Update snmp option documentation to match implementation

### DIFF
--- a/doc/reference/munin-node-configure.rst
+++ b/doc/reference/munin-node-configure.rst
@@ -172,7 +172,7 @@ For further reading on SNMP v3 security models please consult RFC3414 and the do
    Authentication password. Optional when encryption is also enabled, in which case defaults to the
    privacy password ("--snmpprivpass").
 
-.. option:: --snmpauthprotocol <protocol>
+.. option:: --snmpauthproto <protocol>
 
    Authentication protocol. One of 'md5' or 'sha' (HMAC-MD5-96, RFC1321 and SHA-1/HMAC-SHA-96, NIST
    FIPS PIB 180, RFC2264). ['md5']
@@ -186,7 +186,7 @@ For further reading on SNMP v3 security models please consult RFC3414 and the do
    are defaulted (to 'des', 'md5', and the privpassword value, respectively) and may therefore be
    left unspecified.
 
-.. option:: --snmpprivprotocol <protocol>
+.. option:: --snmpprivproto <protocol>
 
    If the privpassword is set this setting controls what kind of encryption is used to achieve
    privacy in the session. Only the very weak 'des' encryption method is supported officially.

--- a/script/munin-node-configure
+++ b/script/munin-node-configure
@@ -634,7 +634,7 @@ Username.  There is no default.
 Authentication password.  Optional when encryption is also enabled, in which
 case defaults to the privacy password (C<--snmpprivpass>).
 
-=item B<< --snmpauthprotocol <protocol> >>
+=item B<< --snmpauthproto <protocol> >>
 
 Authentication protocol.  One of 'md5' or 'sha' (HMAC-MD5-96, RFC1321 and
 SHA-1/HMAC-SHA-96, NIST FIPS PIB 180, RFC2264).  ['md5']
@@ -648,7 +648,7 @@ Privacy requires a privprotocol as well as an authprotocol and a authpassword,
 but all of these are defaulted (to 'des', 'md5', and the privpassword value,
 respectively) and may therefore be left unspecified.
 
-=item B<< --snmpprivprotocol <protocol> >>
+=item B<< --snmpprivproto <protocol> >>
 
 If the privpassword is set this setting controls what kind of encryption is
 used to achieve privacy in the session.  Only the very weak 'des' encryption


### PR DESCRIPTION
This closes #831 
The scripts use options which end in "proto", while documentation was using "protocol"