### PR TITLE
DERIVE does not need a max to avoid false spikes.

### DIFF
--- a/plugins/node.d.linux/interrupts.in
+++ b/plugins/node.d.linux/interrupts.in
@@ -63,10 +63,6 @@ if [ "$1" = "config" ]; then
 	# Specify type
 	echo 'intr.type DERIVE'
 	echo 'ctx.type DERIVE'
-	# Set max (should always be done with counters) Note: this is max
-	# per second.
-	echo 'intr.max 100000'
-	echo 'ctx.max 100000'
 	echo 'intr.min 0'
 	echo 'ctx.min 0'
 


### PR DESCRIPTION
100k interrupts/s is not unlikely on a busy system.

This mirrors the change done in 5497c8b3 for master.