### PR TITLE
Do not send empty upper and lower limit from dynazoom

### DIFF
--- a/master/static/dynazoom.html
+++ b/master/static/dynazoom.html
@@ -100,8 +100,8 @@ function refreshImg() {
 		+ "-pinpoint=" + parseInt(form.start_epoch.value) + "," + parseInt(form.stop_epoch.value)
 		+ ".png"
 		+ "?" 
-		+ "&lower_limit=" + form.lower_limit.value
-		+ "&upper_limit=" + form.upper_limit.value
+		+ (form.lower_limit.value ? "&lower_limit=" + form.lower_limit.value : "")
+		+ (form.upper_limit.value ? "&upper_limit=" + form.upper_limit.value : "")
 		+ "&size_x=" + form.size_x.value
 		+ "&size_y=" + form.size_y.value
 	;


### PR DESCRIPTION
JavaScript function refreshImg() in dynazoom.html sets upper_limit and lower_limit parameters in the image query. When there are no limits set ( during initial graph display for example ), refreshImg() sets parameters with empty values ( upper_limit=&lower_limit= ). Because of the recent fixes in processing of CGI parameters in munin-cgi-graph ( #721 ) empty values are accepted and passed to RRD, which fails with error: `Cannot convert '' to float`.

This pull request fixes the refreshImg(), so limits are used in query only if their value is present ( using ternary condition operator ).