### PR TITLE
Add support for IBM i

### DIFF
--- a/plugins/node.d/snmp__df.in
+++ b/plugins/node.d/snmp__df.in
@@ -84,6 +84,7 @@ elsif (!defined($host))
 # Partition level
 my $hrFSIndex              = "1.3.6.1.2.1.25.3.8.1.1."; # Should be more than 0
 my $hrFSMountPoint         = "1.3.6.1.2.1.25.3.8.1.2."; # Used to look up filesystem
+my $hrFSStorageIndex       = "1.3.6.1.2.1.25.3.8.1.7."; # Used to map filesystem to storage
 
 # Filesystem level
 my $hrStorageType          = "1.3.6.1.2.1.25.2.3.1.2."; # Backup for hrFS*
@@ -106,13 +107,15 @@ if (!defined ($session))
 
 my %partitions;
 
-my $parts = get_by_regex ($session, $hrFSIndex, "[1-9]");
+my $filesystems = get_by_regex ($session, $hrFSIndex, "[1-9]");
 
-foreach my $partition (keys %$parts)
+foreach my $filesys (keys %$filesystems)
 {
-    my $mp = get_single ($session, $hrFSMountPoint . $partition);
-    $partitions{$mp}{partition} = $partition;
-    print "# Added partition \"$mp\" as $partition...\n" if $Munin::Plugin::SNMP::DEBUG;
+	my $mp = get_single ($session, $hrFSMountPoint . $filesys);
+    my $st = get_single ($session, $hrFSStorageIndex . $filesys);
+	$partitions{$mp}{partition} = $filesys;
+	$partitions{$mp}{disk} = $st;
+    print "# Added mountpoint \"$mp\" as \"$filesys\" on disk \"$st\”...\n" if $Munin::Plugin::SNMP::DEBUG;
 }
 
 my $stor_id;
@@ -137,7 +140,7 @@ if ($foundpartitions == 0 or defined $partitions{""})
 		$partitions{$spart}{extinfo} = $part;
 		$stor_id->{$id} = $spart;
 	}
-} else 
+} else
 { # Get the ones we're sure are really fixed
 
 	$stor_id   = get_by_regex ($session, $hrStorageDesc, '(^'.join('$|^',keys(%partitions)).'$)');
@@ -147,10 +150,36 @@ foreach my $storage (keys %$stor_id)
 {
     $partitions{$stor_id->{$storage}}{storage} = $storage;
     $partitions{$stor_id->{$storage}}{size}    = get_single ($session, $hrStorageSize . $storage);
+    print "# found $storage with size $partitions{$stor_id->{$storage}}{size}\n" if $Munin::Plugin::SNMP::DEBUG;
+
     if ($partitions{$stor_id->{$storage}}{size} == 0) {
       delete $stor_id->{$storage} ;
     }
 }
+
+# If there are still no size definitions, use the mapping to storage
+# ($hrFSStorageIndex) to get the size. Make sure, we only add each storage
+# device only once
+my %newpartitions;
+foreach my $part (keys %partitions)
+{
+	if ( (!defined $partitions{$part}{size} or $partitions{$part}{size} == 0) and defined $partitions{$part}{disk}) {
+		my $disk = $partitions{$part}{disk};
+		my $name = get_single($session, $hrStorageDesc . $disk);
+
+		if (!defined $newpartitions{$name} ) {
+
+			$newpartitions{$name}{size} = get_single ($session, $hrStorageSize . $disk);
+			$newpartitions{$name}{storage} = $disk;
+			$newpartitions{$name}{used} = get_single ($session, $hrStorageUsed . $disk);
+
+			print "# added size \"$newpartitions{$name}{size}\" to \"$name\" for \"$part\" from disk \"$disk\"\n" if $Munin::Plugin::SNMP::DEBUG;
+		}
+	}
+}
+
+if (keys %newpartitions != 0) { %partitions = %newpartitions; }
+
 
 foreach my $part (keys %partitions)
 {

--- a/plugins/node.d/snmp__df.in
+++ b/plugins/node.d/snmp__df.in
@@ -111,10 +111,10 @@ my $filesystems = get_by_regex ($session, $hrFSIndex, "[1-9]");
 
 foreach my $filesys (keys %$filesystems)
 {
-	my $mp = get_single ($session, $hrFSMountPoint . $filesys);
+    my $mp = get_single ($session, $hrFSMountPoint . $filesys);
     my $st = get_single ($session, $hrFSStorageIndex . $filesys);
-	$partitions{$mp}{partition} = $filesys;
-	$partitions{$mp}{disk} = $st;
+    $partitions{$mp}{partition} = $filesys;
+    $partitions{$mp}{disk} = $st;
     print "# Added mountpoint \"$mp\" as \"$filesys\" on disk \"$st\”...\n" if $Munin::Plugin::SNMP::DEBUG;
 }
 


### PR DESCRIPTION
There are systems where mount points do not have size definitions for
themselves. Therefor use the mapping between filesystem and storage
(hfFSStorageIndex) to get the storage device. Make sure, the device is
only added once. This makes it possible to use the plugin for IBM i
(formerly known as AS/400)

This is actually a regression from former plugin version delivered in 2.0.6

Also I checked the plugin in the master branch, it correctly falls back to storage devices so there is no need for changes there.