### PR TITLE
Update nfs plugins: Fixing autoconf to detect if service enabled

### DIFF
--- a/plugins/node.d.linux/nfs4_client.in
+++ b/plugins/node.d.linux/nfs4_client.in
@@ -32,7 +32,12 @@ proc="read write commit open open_confirm open_noattr open_downgrade close setat
 
 if [ "$1" = "autoconf" ]; then
 	if [ -f "$NFS" ]; then
-		echo yes
+		grep -q proc4 "$NFS"
+		if [ $? = 0 ]; then
+			echo yes
+		else
+			echo "no (no proc4 in $NFS)"
+		fi
 		exit 0
 	else
 		echo "no (no $NFS)"

--- a/plugins/node.d.linux/nfs_client.in
+++ b/plugins/node.d.linux/nfs_client.in
@@ -32,7 +32,12 @@ proc="getattr setattr lookup access readlink read write create mkdir symlink mkn
 
 if [ "$1" = "autoconf" ]; then
 	if [ -f "$NFS" ]; then
-		echo yes
+		grep -q proc3 "$NFS"
+		if [ $? = 0 ]; then
+			echo yes
+		else
+			echo "no (no proc3 in $NFS)"
+		fi
 		exit 0
 	else
 		echo no

--- a/plugins/node.d.linux/nfsd.in
+++ b/plugins/node.d.linux/nfsd.in
@@ -32,7 +32,12 @@ proc="getattr setattr lookup access readlink read write create mkdir symlink mkn
 
 if [ "$1" = "autoconf" ]; then
 	if [ -f "$NFSD" ]; then
-		echo yes
+		grep -q proc3 "$NFSD"
+		if [ $? = 0 ]; then
+			echo yes
+		else
+			echo "no (no proc3 in $NFSD)"
+		fi
 		exit 0
 	else
 		echo "no (no $NFSD)"

--- a/plugins/node.d.linux/nfsd4.in
+++ b/plugins/node.d.linux/nfsd4.in
@@ -38,7 +38,12 @@ proc="access close commit create delegpurge delegreturn getattr getfh link lock 
 
 if [ "$1" = "autoconf" ]; then
 	if [ -f "$NFSD" ]; then
-		echo yes
+		grep -q proc4ops "$NFSD"
+		if [ $? = 0 ]; then
+			echo yes
+		else
+			echo "no (no proc4ops in $NFSD)"
+		fi
 		exit 0
 	else
 		echo "no (no $NFSD)"


### PR DESCRIPTION
The autoconf function of the nfs plugins do not recognize the correspondent nfs service if it is not available.