### PR TITLE
Travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: perl
 perl:
+  - "5.20"
   - "5.18"
   - "5.16"
   - "5.14"
@@ -9,27 +10,27 @@ perl:
 branches:
  only:
   - stable-2.0
-  - devel
   - master
-install: "/bin/true"
-before_install:
- - "cpanm --notest File::Copy::Recursive"
- - "cpanm --notest File::Slurp"
- - "cpanm --notest HTML::Template"
- - "cpanm --notest IO::Scalar"
- - "cpanm --notest IO::Socket::INET6"
- - "cpanm --notest Log::Log4perl"
- - "cpanm --notest Module::Build"
- - "cpanm --notest Net::SNMP"
- - "cpanm --notest Net::Server"
- - "cpanm --notest Net::SSLeay"
- - "cpanm --notest Test::Deep"
- - "cpanm --notest Test::Differences"
- - "cpanm --notest Test::LongString"
- - "cpanm --notest Test::MockModule"
- - "cpanm --notest Test::MockObject::Extends"
- - "cpanm --notest Time::HiRes"
- - sh contrib/install_rrd.sh
+  - travis-test
+addons:
+  apt:
+    packages:
+      - devscripts
+      - libpango1.0-dev
+      - libfile-copy-recursive-perl
+      - libfile-slurp-perl
+      - libhtml-template-perl
+      - libio-socket-inet6-perl
+      - liblog-dispatch-perl
+      - libmodule-build-perl
+      - libnet-server-perl
+      - libnet-snmp-perl
+      - libnet-ssleay-perl
+      - libtest-deep-perl
+      - libtest-differences-perl
+      - libtest-longstring-perl
+      - libtest-mockmodule-perl
+      - libtest-mockobject-perl
 notifications:
   email: false
   irc:
@@ -43,3 +44,15 @@ notifications:
 matrix:
   # we don't need to continue any build when 1 test is failing.
   fast_finish: true
+
+env:
+  - TEST_MEDIUM=1
+
+before_install:
+  cpanm -n Devel::Cover::Report::Coveralls
+
+script:
+  make && make test
+
+# Using the container-based infrastructure
+sudo: false

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,65 @@
+# BEWARE: this cpanfile is backported from master - it is only used for travis tests
+# In all other regards (besides being used for testing) it is probably not
+# accurate (too many dependencies, ...).
+
+requires 'Digest::MD5';
+requires 'File::Path';
+requires 'File::ReadBackwards';
+requires 'File::Temp';
+requires 'Getopt::Long';
+requires 'HTML::Template::Pro';
+requires 'HTTP::Server::Simple::CGI';
+requires 'IO::Scalar';
+requires 'IO::Socket::INET6';
+requires 'JSON';
+requires 'LWP::Simple';
+requires 'LWP::UserAgent';
+requires 'List::MoreUtils';
+requires 'List::Util';
+requires 'Log::Dispatch';
+requires 'Log::Dispatch::Screen';
+requires 'Log::Dispatch::Syslog';
+requires 'MIME::Base64';
+requires 'Module::Build';
+requires 'Net::DNS';
+requires 'Net::Domain';
+requires 'Net::IP';
+requires 'Net::SNMP';
+requires 'Net::SSLeay';
+requires 'Net::Server::Fork';
+requires 'Params::Validate';
+requires 'Parallel::ForkManager';
+requires 'Pod::Perldoc';
+requires 'Pod::Usage';
+requires 'Scalar::Util';
+requires 'Socket';
+requires 'Test::Perl::Critic';
+requires 'Text::Balanced';
+requires 'Time::HiRes';
+requires 'URI';
+requires 'URI::_server';
+requires 'XML::Dumper';
+requires 'XML::LibXML';
+requires 'XML::Parser';
+
+on test => sub {
+    requires 'Directory::Scratch';
+    requires 'File::Slurp';
+    requires 'Test::Class';
+    requires 'Test::Deep';
+    requires 'Test::Differences';
+    requires 'Test::Exception';
+    requires 'Test::LongString';
+    requires 'Test::MockModule';
+    requires 'Test::MockObject';
+    requires 'Test::MockObject::Extends';
+    requires 'Test::More';
+};
+
+on develop => sub {
+    requires 'Capture::Tiny';
+    requires 'IO::Scalar';
+    requires 'Pod::Simple::SimpleTree';
+    requires 'Test::Perl::Critic';
+    requires 'perl', 'v5.10.1';
+};

--- a/getversion
+++ b/getversion
@@ -16,16 +16,22 @@
 # * If we're still looking for a version, just fallback to "unknown".
 
 current_git_branch() {
-    # Handle this too:
-
-    # git checkout 2.0.9
-    # git branch
-    # * (no branch)
-    #   devel
-
     GB="$(git branch | awk '$1 == "*" {print $2}')"
     case $GB in
+
+	# git checkout 402c6d6
+	# git branch
+	# * (detached from 402c6d6)
+	#   devel
+	# --> This is new with git 1.8+
+	"(detached" ) echo "detached";;
+
+	# git checkout 2.0.9
+	# git branch
+	# * (no branch)
+	#   devel
 	"(no" ) echo;;
+
 	*     ) echo $GB;;
     esac
 }
@@ -33,10 +39,11 @@ current_git_branch() {
 generate_version_string() {
     branch="$(current_git_branch)"
     case "${branch}" in
-        ""|master|stable-*)
+        ""|master|devel|stable-*)
             git describe
             ;;
         *)
+            branch=$(echo $branch | sed -e 's/[^0-9A-Za-z\.\-\_]/_/g' )
             # "foo | read VAR" does *not* work
             # workaround stolen from http://www.etalabs.net/sh_tricks.html
             read VERSION COMMITS HASH <<EOF


### PR DESCRIPTION
Some pieces from `master` ported back to `stable-2.0`:
* travis recipe (using Debian packages instead of cpan for most dependencies)
* cpanfile (for remaining dependencies)
* getversion (failed with current git output)

This fixes the travis test failures (due to the broken `install_rrd` script).