### PR TITLE
Handle negative values in spooled data

### DIFF
--- a/lib/Munin/Node/SpoolReader.pm
+++ b/lib/Munin/Node/SpoolReader.pm
@@ -156,7 +156,7 @@ sub _cat_multigraph_file
                 next;
             }
 
-            if (m/^(\w+)\.value\s+(?:N:)?([0-9.]+|U)$/) {
+            if (m/^(\w+)\.value\s+(?:N:)?(-?[0-9.]+|U)$/) {
                 $_ = "$1.value $epoch:$2";
             }
 


### PR DESCRIPTION
When the value of spool data is negative the old regex would not match that line, which resulted in the code not timestamping negative values