### PR TITLE
dev_scripts: "Build" parameters in 'install' for proper lib install path

### DIFF
--- a/dev_scripts/install
+++ b/dev_scripts/install
@@ -26,8 +26,10 @@ clean_sandbox() {
 
 make_sandbox() {
 	banner BUILD
-	perl Build.PL --install_base "${BASEDIR}/sandbox" --debug
-	./Build install
+	perl Build.PL --install_base "${BASEDIR}/sandbox"
+	# Without this repetition of "--install_base", the wrong path (~/perl5/) would be written
+	# to _build/runtime_params and be used for munin module installation.
+	./Build --install_base "${BASEDIR}/sandbox" install
 
 	xargs mkdir -p -v <<EOF
 		sandbox/etc/munin-conf.d


### PR DESCRIPTION
Previously the Munin module files were partly installed outside of the
sandbox (here: ~/perl5/).

Thus Munin modules were not found when running code in the sandbox, e.g.:

 $ dev_scripts/install node
 Can't locate Munin/Node/Configure/PluginList.pm in @INC (you may need
 to install the Munin::Node::Configure::PluginList module) (@INC
 contains.
 BEGIN failed--compilation aborted at
 /home/foo/perl5/bin/munin-node-configure line 26.