### PR TITLE
Master::HTML: prevent access to static resources outside of "staticdir"

### DIFF
--- a/lib/Munin/Master/HTML.pm
+++ b/lib/Munin/Master/HTML.pm
@@ -30,6 +30,17 @@ sub handle_request
 	if ($path =~ m/static\/(.+)$/) {
 		# Emit the static page
 		my $page = $1;
+		if ($page =~ m#/\.\./#) {
+			# "/../" indicates a traversal up the path. We have to prevent this,
+			# otherwise we may get tricked into delivering arbitrary files.
+			# Since there is no readily available function for determining the
+			# canonical path, we simply refuse malformed requests.
+			# Most webservers (used for proxying) should do canonicalization on their
+			# own, but we cannot rely on this.
+			# Static resource paths should never include parent references, anyway.
+			print "HTTP/1.0 404 Not found\r\n";
+			return;
+		}
 		my ($ext) = ($page =~ m/.*\.([^.]+)$/);
 		my %mime_types = (
 			css => "text/css",


### PR DESCRIPTION
Currently it is possible to trick `munin-httpd` into delivering html files outside of the `staticdir`:
```shell
demo:~# curl -s "http://localhost:4948/static/..%2f..%2f../usr/share/apache2/icons/README.html" | md5sum
23091c19eaf031d01d86c3da50f3cfb8  -
demo:~# md5sum /usr/share/apache2/icons/README.html
23091c19eaf031d01d86c3da50f3cfb8  /usr/share/apache2/icons/README.html
```

A proxying webserver prevents this, since it canonicalizes the path before handing it over to its backend.