### PR TITLE
Simplify spooled value regex

### DIFF
--- a/lib/Munin/Node/SpoolReader.pm
+++ b/lib/Munin/Node/SpoolReader.pm
@@ -156,7 +156,7 @@ sub _cat_multigraph_file
                 next;
             }
 
-            if (m/^(\w+)\.value\s+(?:N:)?(-?[0-9.]+|U)$/) {
+            if (m/^(\w+)\.value\s+(?:N:)?(.+)$/) {
                 $_ = "$1.value $epoch:$2";
             }
 


### PR DESCRIPTION
Fix #933 (the source of the issue at least)

The regex could be further simplified (`^(\w+)\.value\s+(?:N:)?(.+)$`) since validating the value seems irrelevant at this point.