### PR TITLE
Let the server use max timestamp rather than now for non-timestamped dirtyconfig values

### DIFF
--- a/master/lib/Munin/Master/Node.pm
+++ b/master/lib/Munin/Master/Node.pm
@@ -17,6 +17,9 @@ use Log::Log4perl qw( :easy );
 use Time::HiRes qw( gettimeofday tv_interval );
 use IO::Socket::INET6;
 
+# Used as a timestamp value, this declares none was found
+use constant NO_TIMESTAMP => -1;
+
 my $config = Munin::Master::Config->instance()->{config};
 
 # Quick version, to enable "DEBUG ... if $debug" constructs
@@ -359,7 +362,7 @@ sub parse_service_config {
         } elsif ($line =~ m{\A ([^\.]+)\.value \s+ (.+?) \s* $}xms) {
 	    $correct++;
 	    # Special case for dirtyconfig
-            my ($ds_name, $value, $when) = ($1, $2, -1);
+            my ($ds_name, $value, $when) = ($1, $2, NO_TIMESTAMP);
             
 	    $ds_name = $self->_sanitise_fieldname($ds_name);
 	    if ($value =~ /^(\d+):(.+)$/) {

--- a/master/lib/Munin/Master/Node.pm
+++ b/master/lib/Munin/Master/Node.pm
@@ -312,9 +312,6 @@ sub parse_service_config {
 
     new_service($service);
 
-    # every 'N' has the same value. Should not take parsing time into the equation
-    my $now = time;
-
     for my $line (@$lines) {
 
 	DEBUG "[CONFIG from $plugin] $line" if $debug;
@@ -362,7 +359,7 @@ sub parse_service_config {
         } elsif ($line =~ m{\A ([^\.]+)\.value \s+ (.+?) \s* $}xms) {
 	    $correct++;
 	    # Special case for dirtyconfig
-            my ($ds_name, $value, $when) = ($1, $2, $now);
+            my ($ds_name, $value, $when) = ($1, $2, -1);
             
 	    $ds_name = $self->_sanitise_fieldname($ds_name);
 	    if ($value =~ /^(\d+):(.+)$/) {

--- a/master/lib/Munin/Master/UpdateWorker.pm
+++ b/master/lib/Munin/Master/UpdateWorker.pm
@@ -224,7 +224,9 @@ sub do_work {
 		    %{$service_config{global}});
 
 		my $last_updated_timestamp = $self->_update_rrd_files(\%service_config, \%service_data);
-          	$self->set_spoolfetch_timestamp($last_updated_timestamp);
+		if ($last_updated_timestamp) {
+		    $self->set_spoolfetch_timestamp($last_updated_timestamp);
+		}
 	    } # for @plugins
 
 	    # Send "quit" to node
@@ -584,9 +586,7 @@ sub _update_rrd_files {
     		} keys %{$nested_service_config->{data_source}{$svc}};
     	    } keys %{$nested_service_config->{data_source}}
     	);
-    if (not $last_timestamp > 0) {
-    	$last_timestamp = time;
-    }
+    my $last_timestamp_or_now = ($last_timestamp > 0) ? $last_timestamp : time;
 
     for my $service (keys %{$nested_service_config->{data_source}}) {
 
@@ -620,7 +620,7 @@ sub _update_rrd_files {
 	    my $rrd_file = $self->_create_rrd_file_if_needed($service, $ds_name, $ds_config, $first_epoch);
 
 	    if (defined($service_data) and defined($service_data->{$ds_name})) {
-		$self->_update_rrd_file($rrd_file, $ds_name, $service_data->{$ds_name}, $last_timestamp);
+		$self->_update_rrd_file($rrd_file, $ds_name, $service_data->{$ds_name}, $last_timestamp_or_now);
 	    }
 	    else {
 		WARN "[WARNING] Service $service on $nodedesignation returned no data for label $ds_name";
@@ -860,7 +860,7 @@ sub to_mul_nb {
 }
 
 sub _update_rrd_file {
-    my ($self, $rrd_file, $ds_name, $ds_values, $last_timestamp) = @_;
+    my ($self, $rrd_file, $ds_name, $ds_values, $max_timestamp) = @_;
 
     my $values = $ds_values->{value};
 
@@ -887,7 +887,7 @@ sub _update_rrd_file {
         my $when = $ds_values->{when}[$i];
 
 	if ($when == -1) {
-	    $when = $last_timestamp;
+	    $when = $max_timestamp;
 	}
 
 	# Ignore values that is not in monotonic increasing timestamp for the RRD.

--- a/master/lib/Munin/Master/UpdateWorker.pm
+++ b/master/lib/Munin/Master/UpdateWorker.pm
@@ -574,7 +574,19 @@ sub _update_rrd_files {
     my $nodedesignation = $self->{host}{host_name}."/".
 	$self->{host}{address}.":".$self->{host}{port};
 
-    my $last_timestamp = 0;
+    my $last_timestamp =
+    	max(0,
+    	    map {
+    		my $svc = $_;
+    		map {
+    		    my $ds = $_;
+    		    @{$nested_service_data->{$svc}->{$ds}->{when} || []};
+    		} keys %{$nested_service_config->{data_source}{$svc}};
+    	    } keys %{$nested_service_config->{data_source}}
+    	);
+    if (not $last_timestamp > 0) {
+    	$last_timestamp = time;
+    }
 
     for my $service (keys %{$nested_service_config->{data_source}}) {
 
@@ -608,7 +620,7 @@ sub _update_rrd_files {
 	    my $rrd_file = $self->_create_rrd_file_if_needed($service, $ds_name, $ds_config, $first_epoch);
 
 	    if (defined($service_data) and defined($service_data->{$ds_name})) {
-		$last_timestamp = max($last_timestamp, $self->_update_rrd_file($rrd_file, $ds_name, $service_data->{$ds_name}));
+		$self->_update_rrd_file($rrd_file, $ds_name, $service_data->{$ds_name}, $last_timestamp);
 	    }
 	    else {
 		WARN "[WARNING] Service $service on $nodedesignation returned no data for label $ds_name";
@@ -848,7 +860,7 @@ sub to_mul_nb {
 }
 
 sub _update_rrd_file {
-    my ($self, $rrd_file, $ds_name, $ds_values) = @_;
+    my ($self, $rrd_file, $ds_name, $ds_values, $last_timestamp) = @_;
 
     my $values = $ds_values->{value};
 
@@ -873,6 +885,10 @@ sub _update_rrd_file {
     for (my $i = 0; $i < scalar @$values; $i++) { 
         my $value = $values->[$i];
         my $when = $ds_values->{when}[$i];
+
+	if ($when == -1) {
+	    $when = $last_timestamp;
+	}
 
 	# Ignore values that is not in monotonic increasing timestamp for the RRD.
 	# Otherwise it will reject the whole update
@@ -926,7 +942,7 @@ sub _update_rrd_file {
     $self->{state}{value}{"$rrd_file:42"}{current} = [ $current_updated_timestamp, $current_updated_value ]; 
     $self->{state}{value}{"$rrd_file:42"}{previous} = [ $previous_updated_timestamp, $previous_updated_value ]; 
 
-    return $current_updated_timestamp;
+    return scalar @update_rrd_data;
 }
 
 sub dump_to_file

--- a/master/lib/Munin/Master/UpdateWorker.pm
+++ b/master/lib/Munin/Master/UpdateWorker.pm
@@ -886,7 +886,7 @@ sub _update_rrd_file {
         my $value = $values->[$i];
         my $when = $ds_values->{when}[$i];
 
-	if ($when == -1) {
+	if ($when == $self->{node}->NO_TIMESTAMP) {
 	    $when = $max_timestamp;
 	}
 


### PR DESCRIPTION
* Use special value `-1` rather than `$now` for `when` field in dirtyconfig output
  * Declare as a named constant
* Pre-compute `$last_timestamp`, in a separate iteration
  * Fall back to current timestamp
  * But not for spoolfetch timestamp
* If special value found in `when` field, use `$last_timestamp` instead
* `Munin::Master::UpdateWorker::_update_rrd_file` now returns number of
  RRD updates and `$last_timestamp` is an argument