### PR TITLE
Specify minimum value for tuples

### DIFF
--- a/plugins/node.d/postgres_bgwriter
+++ b/plugins/node.d/postgres_bgwriter
@@ -78,7 +78,8 @@ my $pg = Munin::Plugin::Pgsql->new(
            ('buffers_clean','Buffers cleaned', 'Buffers cleaned by background bgwriter runs'),
            ('buffers_backend', 'Buffers by backend', 'Buffers written by backends and not the bgwriter'),
            ('buffers_alloc', 'Buffers allocated', 'Buffers allocated globally')",
-    graphtype => 'DERIVE'
+    graphtype => 'DERIVE',
+    graphmin => 0
 );
 
 $pg->Process();

--- a/plugins/node.d/postgres_cache_
+++ b/plugins/node.d/postgres_cache_
@@ -85,7 +85,8 @@ my $pg = Munin::Plugin::Pgsql->new(
     ],
     suggestquery =>
         "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate AND NOT datname='postgres' UNION ALL SELECT 'ALL' ORDER BY 1 LIMIT 10",
-    graphtype => 'DERIVE'
+    graphtype => 'DERIVE',
+    graphmin  => 0
 );
 
 $pg->Process();

--- a/plugins/node.d/postgres_checkpoints
+++ b/plugins/node.d/postgres_checkpoints
@@ -77,7 +77,8 @@ my $pg = Munin::Plugin::Pgsql->new(
         "VALUES ('checkpoints_timed','Timed checkpoints','Checkpoints started by timeout'),('checkpoints_req','Requested checkpoints','Checkpoints started by request')",
     stack       => 1,
     graphtype   => 'DERIVE',
-    graphperiod => 'minute'
+    graphperiod => 'minute',
+    graphmin    => 0
 );
 
 $pg->Process();

--- a/plugins/node.d/postgres_scans_
+++ b/plugins/node.d/postgres_scans_
@@ -81,6 +81,7 @@ my $pg = Munin::Plugin::Pgsql->new(
         "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate AND NOT datname='postgres' ORDER BY 1 LIMIT 10",
     stack     => 1,
     graphtype => 'DERIVE',
+    graphmin  => 0
 );
 
 $pg->Process();

--- a/plugins/node.d/postgres_tuples_
+++ b/plugins/node.d/postgres_tuples_
@@ -100,7 +100,7 @@ my $pg = Munin::Plugin::Pgsql->new(
     ],
     suggestquery =>
         "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate AND NOT datname='postgres' ORDER BY 1 LIMIT 10",
-    graphtype => 'DERIVE',
+    graphtype => 'DERIVE', graphmin => 0,
 );
 
 $pg->Process();


### PR DESCRIPTION
As far as I remember, rrdtool graphs need minimal value set for DERIVE counter to work correctly if the counts are reset to not produce a negative peak. However that's exactly what happens with postgres_tuples_ plugin:

![image](https://user-images.githubusercontent.com/474217/38386682-14d2be1e-391e-11e8-8436-c8a61b37de0f.png)

I'm not 100% sure, but that could be because minimal values are not set by default. So set them.