### PR TITLE
[postgres plugin] Do not set database=undef when paramdatabase.

### DIFF
--- a/lib/Munin/Plugin/Pgsql.pm
+++ b/lib/Munin/Plugin/Pgsql.pm
@@ -461,7 +461,7 @@ sub _connect() {
         # variables.
         my $dbname = "template1";
         $dbname = $self->{defaultdb}           if ($self->{defaultdb});
-        $dbname = $self->wildcard_parameter(0) if ($self->{paramdatabase} && !defined($nowildcard));
+        $dbname = $self->wildcard_parameter(0) if ($self->{paramdatabase} && !defined($nowildcard) && $self->wildcard_parameter(0));
         $dbname = $ENV{"PGDATABASE"}           if ($ENV{"PGDATABASE"});
         $self->{dbh} = DBI->connect("DBI:Pg:dbname=$dbname", '', '', {pg_server_prepare => 0});
         unless ($self->{dbh}) {


### PR DESCRIPTION
From 7d58bca sudo -u munin munin-run postgres_locks_ALL now gives an error.

    host1 postgres[72156]: err [5-1] 2018-05-18 12:10:27 JST  pgsql  [local]  pgsql   3D000FATAL: database "pgsql" does not exist
    (pgsql is the default for user of freebsd ports.)

I am verifying that this will be as follows.
* postgres_locks_ALL is database=template1
* postgres_locks_mydb1 is database=mydb1

