### PR TITLE
Limits merge cleanup

### DIFF
--- a/lib/Munin/Master/LimitsOld.pm
+++ b/lib/Munin/Master/LimitsOld.pm
@@ -345,7 +345,6 @@ sub process_service {
         my $field   = munin_get_node($hash, [$fname]);
         next if (!defined $field or ref($field) ne "HASH");
         my $fpath   = munin_get_node_loc($field);
-        my $oldstate = 'ok';
 
         my ($warn, $crit, $unknown_limit) = get_limits($field);
 
@@ -362,9 +361,9 @@ sub process_service {
         $sth_state->execute($ds_id, "ds");
         my ($current_updated_timestamp, $current_updated_value,
             $previous_updated_timestamp, $previous_updated_value,
-            $old_alarm, $old_num_unknowns) = $sth_state->fetchrow_array;
+            $old_state, $old_num_unknowns) = $sth_state->fetchrow_array;
 
-        $oldstate = $old_alarm || 'ok';
+        $old_state ||= 'ok';
 
 		my $heartbeat = 600; # XXX - $heartbeat is a fixed 10 min (2 runs of 5 min).
 		if (! defined $current_updated_value || $current_updated_value eq "U") {
@@ -439,40 +438,41 @@ sub process_service {
                     : "Value is unknown.";
             my $num_unknowns;
 
-            if ( $oldstate ne "unknown") {
+            if ($old_state ne "unknown") {
+                # Assume that the state changed - see some exceptions below.
                 $hash->{'state_changed'} = 1;
             }
             else {
                 $hash->{'state_changed'} = 0;
             }
 
-            # First we'll need to check whether the user wants to ignore
-            # a few UNKNOWN values before actually changing the state to
-            # UNKNOWN.
+            # The user may want to ignore a few unknown values before
+            # they should be reported. Thus we need to track the number
+            # of recently received unknown values. And we may want to
+            # postpone a "change" notification until we reach the limit.
             if ($unknown_limit > 1) {
-                if (defined $onfield and defined $onfield->{"state"}) {
-                    if ($onfield->{"state"} ne "unknown") {
-                        if (defined $onfield->{"num_unknowns"}) {
-                            if ($onfield->{"num_unknowns"} < $unknown_limit) {
-                                # Don't change the state to UNKNOWN yet.
-                                $hash->{'state_changed'} = 0;
-                                $state = $onfield->{"state"};
-                                $extinfo = $onfield->{$state};
-
-                                # Increment the number of UNKNOWN values seen.
-                                $num_unknowns = $onfield->{"num_unknowns"} + 1;
-                            }
-                        }
-                        else {
+                if ($old_state ne "unknown") {
+                    # The last sample reported a different state.
+                    if ($old_num_unknowns) {
+                        # One or more previous values were also "unknown".
+                        if ($old_num_unknowns < $unknown_limit) {
                             # Don't change the state to UNKNOWN yet.
                             $hash->{'state_changed'} = 0;
-                            $state = $onfield->{"state"};
-                            $extinfo = $onfield->{$state};
-                            
-                            # Start counting the number of consecutive UNKNOWN
-                            # values seen.
-                            $num_unknowns = 1;
+                            $state = $old_state;
+                            $extinfo = $field->{"extinfo"};
+
+                            # Increment the number of UNKNOWN values seen.
+                            $num_unknowns = $old_num_unknowns + 1;
                         }
+                    } else {
+                        # The previous values were not reported as unknown.
+                        $hash->{'state_changed'} = 0;
+                        $state = $old_state;
+                        $extinfo = $field->{"extinfo"};
+
+                        # Start counting the number of consecutive UNKNOWN
+                        # values seen.
+                        $num_unknowns = 1;
                     }
                 }
             }
@@ -522,7 +522,7 @@ sub process_service {
                         . ") exceeded"
                 ));
 
-            if ( $oldstate ne "critical") {
+            if ($old_state ne "critical") {
                 $hash->{'state_changed'} = 1;
             }
         }
@@ -545,7 +545,7 @@ sub process_service {
                         . ") exceeded"
                 ));
 
-            if ( $oldstate ne "warning") {
+            if ($old_state ne "warning") {
                 $hash->{'state_changed'} = 1;
             }
         }
@@ -553,8 +553,8 @@ sub process_service {
             munin_set_var_loc(\%notes, [@$fpath, "state"], "ok");
             munin_set_var_loc(\%notes, [@$fpath, "ok"],    "OK");
 
-	    if ($oldstate ne 'ok') {
-                if ($oldstate eq 'unknown' && munin_get_bool($hobj, 'ignore_unknown', 'false')) {
+	    if ($old_state ne 'ok') {
+                if ($old_state eq 'unknown' && munin_get_bool($hobj, 'ignore_unknown', 'false')) {
                     DEBUG("[DEBUG] ignoring transition from UNKNOWN to OK");
                 } else {
 		    $hash->{'state_changed'} = 1;
@@ -564,7 +564,7 @@ sub process_service {
         }
 
 	# Replicate the state into the SQL DB
-	my $new_state = $onfield->{"state"};
+	my $new_state = $old_state;
 	$sth_state_upt->execute($new_state, $ds_id, "ds");
     }
     generate_service_message($hash);


### PR DESCRIPTION
The recent merge of stable into master seems to have caused at least a small problem manifesting as an undefined variable `$state` (which was removed meanwhile).

In the vicinity of this piece of code (in `LimitsOld.pm`) there were some more problematic parts, that are probably not fully migrated from state file to SQL database (to be expected - as discussed recently via IRC):
* some access to an `$onfield` hash (removed quite some time ago) - as mentioned in #914 (probably fixed now)
* the final state stored in the database (`my $new_state = $old_state;` - close to the end of `process_service`) looks wrong (`$old_state` does not change during this function and it was read from the database in the beginning)
    * should it be `$state` instead of `$old_state` (requiring some more changes)?
* there are some occurrences of `munin_set_var_loc` which are probably outdated?

In general: the code is a bit better now: it does not *always* spill the logs (and cron job mails) with warnings and probably it passes the autopkgtests of the Debian experimental packaging now. Thus I assume is it good enough to be merged.
But it probably needs a bit more work afterwards.

@steveschnepp: do you think, the limits code is worth to be incrementally improved now (by me)? Or would you rather want to rework this part of the code completely?