### PR TITLE
Style checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+# settings for the "flake8" (python code style checks)
+[flake8]
+max-line-length = 99

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ addons:
       - libtest-longstring-perl
       - libtest-mockmodule-perl
       - libtest-mockobject-perl
+      - python3-flake8
+      - shellcheck
 notifications:
   email: false
   irc:
@@ -52,7 +54,10 @@ before_install:
   cpanm -n Devel::Cover::Report::Coveralls
 
 script:
-  make && make test
+  - make
+  # the old travis environment requires an old flake8 invocation
+  - PYTHON_LINT_CALL="python3 -m flake8.main" make lint
+  - make test
 
 # Using the container-based infrastructure
 sudo: false

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ PODMAN5          := build/master/doc/munin.conf node/doc/munin-node.conf
 .PHONY: install install-pre install-master-prime install-node-prime install-node-pre install-common-prime install-doc install-man \
         build build-common-prime build-common-pre build-doc \
         source_dist \
-        test clean \
+        test lint clean \
         clean-% test-% build-% install-% \
 	tags \
 	infiles
@@ -464,6 +464,18 @@ install-%: %/Build
 
 test-%: %/Build
 	cd $* && $(PERL) Build test --verbose=0 || true
+
+lint:
+	@# SC1008: ignore our weird shebang (substituted later)
+	@# SC1090: ignore sourcing of files with variable in path
+	@# SC2009: do not complain about "ps ... | grep" calls (may be platform specific)
+	@# SC2126: tolerate "grep | wc -l" (simple and widespread) instead of "grep -c"
+	find plugins/node.d.linux/ -type f -print0 \
+		| xargs -0 grep -l --null "@@GOODSH@@" \
+			| xargs -0 shellcheck --exclude=SC1008,SC1090,SC2009,SC2126 --shell dash
+	find plugins/node.d.linux/ -type f -print0 \
+		| xargs -0 grep -l --null "@@BASH@@" \
+			| xargs -0 shellcheck --exclude=SC1008,SC1090,SC2009,SC2126 --shell bash
 
 clean-%: %/Build common/blib/lib/Munin/Common/Defaults.pm
 	cd $* && $(PERL) Build realclean

--- a/Makefile
+++ b/Makefile
@@ -470,12 +470,19 @@ lint:
 	@# SC1090: ignore sourcing of files with variable in path
 	@# SC2009: do not complain about "ps ... | grep" calls (may be platform specific)
 	@# SC2126: tolerate "grep | wc -l" (simple and widespread) instead of "grep -c"
-	find plugins/node.d.linux/ -type f -print0 \
+	# TODO: fix the remaining shellcheck issues for the missing platforms:
+	#       aix, darwin, netbsd, sunos
+	#       (these require tests with their specific shell implementations)
+	find plugins/node.d/ \
+			plugins/node.d.cygwin/ \
+			plugins/node.d.debug/ \
+			plugins/node.d.linux/ -type f -print0 \
 		| xargs -0 grep -l --null "@@GOODSH@@" \
 			| xargs -0 shellcheck --exclude=SC1008,SC1090,SC2009,SC2126 --shell dash
 	find plugins/ -type f -print0 \
 		| xargs -0 grep -l --null "@@BASH@@" \
 			| xargs -0 shellcheck --exclude=SC1008,SC1090,SC2009,SC2126 --shell bash
+	# TODO: perl plugins currently fail with perlcritic
 
 clean-%: %/Build common/blib/lib/Munin/Common/Defaults.pm
 	cd $* && $(PERL) Build realclean

--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,7 @@ lint:
 	find plugins/node.d.linux/ -type f -print0 \
 		| xargs -0 grep -l --null "@@GOODSH@@" \
 			| xargs -0 shellcheck --exclude=SC1008,SC1090,SC2009,SC2126 --shell dash
-	find plugins/node.d.linux/ -type f -print0 \
+	find plugins/ -type f -print0 \
 		| xargs -0 grep -l --null "@@BASH@@" \
 			| xargs -0 shellcheck --exclude=SC1008,SC1090,SC2009,SC2126 --shell bash
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ MANCENTER        := "Munin Documentation"
 MAN8		 := master/_bin/munin-update master/_bin/munin-limits master/_bin/munin-html master/_bin/munin-graph
 PODMAN8          := build/master/doc/munin-cron master/doc/munin master/doc/munin-check
 PODMAN5          := build/master/doc/munin.conf node/doc/munin-node.conf
+PYTHON_LINT_CALL ?= python3 -m flake8
 
 .PHONY: install install-pre install-master-prime install-node-prime install-node-pre install-common-prime install-doc install-man \
         build build-common-prime build-common-pre build-doc \
@@ -482,6 +483,9 @@ lint:
 	find plugins/ -type f -print0 \
 		| xargs -0 grep -l --null "@@BASH@@" \
 			| xargs -0 shellcheck --exclude=SC1008,SC1090,SC2009,SC2126 --shell bash
+	find plugins/ -type f -print0 \
+		| xargs -0 grep -l --null "@@PYTHON@@" \
+			| xargs -0 $(PYTHON_LINT_CALL)
 	# TODO: perl plugins currently fail with perlcritic
 
 clean-%: %/Build common/blib/lib/Munin/Common/Defaults.pm

--- a/plugins/node.d.aix/df.in
+++ b/plugins/node.d.aix/df.in
@@ -63,10 +63,10 @@ if [ "$1" = "config" ]; then
 	echo 'graph_category disk'
 	echo 'graph_scale no'
 	df -P -k | sed 1d | grep -v "//" | grep -v "nfs" | while read i; do
-		name=`echo $i | sed 's/[\/.-]/_/g'| awk '{ print $6 }'`
+		name=`echo "$i" | sed 's/[\/.-]/_/g'| awk '{ print $6 }'`
 		devName="$name.label "
-		fsLabel=`echo $i | awk '{ print $6 }'`
-                echo $devName$fsLabel
+		fsLabel=`echo "$i" | awk '{ print $6 }'`
+		echo "$devName$fsLabel"
 		echo "$name.warning ${warning:-92}"
 		echo "$name.critical ${critical:-98}"
 	done
@@ -74,7 +74,7 @@ if [ "$1" = "config" ]; then
 fi
 
 df -P -k | sed 1d | grep -v "//" | grep -v "nfs" | while read i; do
-	name=`echo $i | sed 's/[\/.-]/_/g'| awk '{ print $6 ".value " }'`
-	name2=`echo $i | awk '{ print $5 }' | cut -f1 -d%`
-        echo $name $name2
+	name=`echo "$i" | sed 's/[\/.-]/_/g'| awk '{ print $6 ".value " }'`
+	name2=`echo "$i" | awk '{ print $5 }' | cut -f1 -d%`
+        echo "$name $name2"
 done

--- a/plugins/node.d.cygwin/df.in
+++ b/plugins/node.d.cygwin/df.in
@@ -50,8 +50,8 @@ GPLv2
 
 print_values () {
     df -P -x iso9660 2>/dev/null | sed -e 1d -e '/\/\//d' -e 's/%//' |
-    while read dev size used free pct fs; do
-	echo "$(clean_fieldname $dev).value $pct"
+    while read -r dev size used free pct fs; do
+        echo "$(clean_fieldname "$dev").value $pct"
     done
 }
 
@@ -71,12 +71,13 @@ if [ "$1" = "config" ]; then
     echo 'graph_vlabel %'
     echo 'graph_scale no'
     echo 'graph_category disk'
-    df -P -x iso9660 | sed -e 1d -e '/\/\//d' -e 's/%//' | sort |
-    while read dev size used free pct fs; do
-	name=$(clean_fieldname $dev)
-	echo "$name.label $fs"
-	print_warning $name
-	print_critical $name
+    # shellcheck disable=SC2034
+    df -P -x iso9660 | sed -e 1d -e '/\/\//d' -e 's/%//' | sort \
+            | while read -r dev size used free pct fs; do
+        name=$(clean_fieldname "$dev")
+        echo "$name.label $fs"
+        print_warning "$name"
+        print_critical "$name"
     done
     exit 0
 fi

--- a/plugins/node.d.cygwin/df.in
+++ b/plugins/node.d.cygwin/df.in
@@ -46,7 +46,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 print_values () {
     df -P -x iso9660 2>/dev/null | sed -e 1d -e '/\/\//d' -e 's/%//' |

--- a/plugins/node.d.darwin/df_inode.in
+++ b/plugins/node.d.darwin/df_inode.in
@@ -20,10 +20,10 @@ print_values() {
 	/bin/df -P -i -t noprocfs,devfs,fdesc,linprocfs,nfs,nullfs,autofs | tail +2 | grep -v "//" | while read i; do
 		case $i in
 		mfs:*) name=mfs$mfs; mfs=`expr $mfs + 1`;;
-		*) name=`echo $i | awk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;
+		*) name=`echo "$i" | awk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;
 		esac
-		printf "$name.value "
-		echo $i | awk '{ print $8 }' | cut -f1 -d%
+		printf "%s.value " "$name"
+		echo "$i" | awk '{ print $8 }' | cut -f1 -d%
 	done
 }
 

--- a/plugins/node.d.darwin/if_.in
+++ b/plugins/node.d.darwin/if_.in
@@ -62,6 +62,7 @@ case $1 in
 	echo "graph_order down up"
 	echo "graph_title $INTERFACE traffic"
 	echo 'graph_args --base 1000'
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel bits in (-) / out (+) per ${graph_period}'
 	echo 'graph_category network'
 	echo "graph_info This graph shows the traffic of the $INTERFACE network interface. Please note that the traffic is shown in bits per second, not bytes. IMPORTANT: Since the data source for this plugin use 32bit counters, this plugin is really unreliable and unsuitable for most 100Mb (or faster) interfaces, where bursts are expected to exceed 50Mbps. This means that this plugin is unsuitable for most production environments."

--- a/plugins/node.d.darwin/if_err_.in
+++ b/plugins/node.d.darwin/if_err_.in
@@ -62,6 +62,7 @@ case $1 in
         echo "graph_order down up collisions"
         echo "graph_title $INTERFACE errors and collisions"
         echo 'graph_args --base 1000'
+        # shellcheck disable=SC2016
         echo 'graph_vlabel packets in (-) / out (+) per ${graph_period}'
         echo 'graph_category network'
         echo "graph_info This graph shows the amount of errors and collisions on the $INTERFACE network interface."

--- a/plugins/node.d.debug/colour_tester.in
+++ b/plugins/node.d.debug/colour_tester.in
@@ -25,13 +25,13 @@ COLOURS="00CC00 0066B3 FF8000 FFCC00 330099 990099 CCFF00 FF0000 808080
 I=1
 for C in $COLOURS; do
     col[$I]="$C"
-    I=$(($I + 1))
+    I=$((I + 1))
 done
-NUMCOL=$(($I - 1))
+NUMCOL=$((I - 1))
 
 
 do_ () { # Fetch
-   for I in $(seq 1 $NUMCOL); do
+   for I in $(seq 1 "$NUMCOL"); do
        echo "l$I.value $I"
    done
 }
@@ -39,14 +39,14 @@ do_ () { # Fetch
 do_config () {
     echo "graph_title Colour testing plugin"
     echo "graph_vlabel Colour index and colour"
-    for I in $(seq 1 $NUMCOL); do
-        echo "l$I.label "${col[$I]}
-        echo "l$I.colour "${col[$I]}
+    for I in $(seq 1 "$NUMCOL"); do
+        echo "l$I.label ${col[$I]}"
+        echo "l$I.colour ${col[$I]}"
         echo "l$I.type GAUGE"
     done
 }
 
 case $1 in
-    ''|config) eval do_$1;;
+    ''|config) eval "do_$1";;
     *) echo Error >&2; exit 1;;
 esac

--- a/plugins/node.d.debug/extinfo_tester.in
+++ b/plugins/node.d.debug/extinfo_tester.in
@@ -20,4 +20,4 @@ hold.label hold
 EOF
 }
 
-do_$1
+"do_$1"

--- a/plugins/node.d.debug/multigraph_tester.in
+++ b/plugins/node.d.debug/multigraph_tester.in
@@ -3,7 +3,7 @@
 #%# family=test
 #%# capabilities=autoconf
 
-. $MUNIN_LIBDIR/plugins/plugin.sh || exit 1
+. "$MUNIN_LIBDIR/plugins/plugin.sh" || exit 1
 
 # Handle the case where the munin node does not understand multigraph.
 is_multigraph "$@"
@@ -78,7 +78,7 @@ do_autoconf () {
 
 # Main is here
 
-do_$1 2>/dev/null || {
+"do_$1" 2>/dev/null || {
       echo "Do what now?" >&2
       exit 1
 }

--- a/plugins/node.d.debug/warning_tester.in
+++ b/plugins/node.d.debug/warning_tester.in
@@ -27,7 +27,7 @@ three.critical 0:84
 EOF
 }
 
-do_$1 2>/dev/null || {
+"do_$1" 2>/dev/null || {
     echo "Do what now?">&2
     exit 1
 }

--- a/plugins/node.d.linux/cpu.in
+++ b/plugins/node.d.linux/cpu.in
@@ -16,8 +16,13 @@ The following is default configuration
 
   [cpu]
 	env.HZ	100
+	env.scaleto100	no
 
-See "BUGS" for a explanation of this setting.
+"scaleto100" may be "yes" or "no". With "yes" all CPU-related values
+are scaled for a limit of 100.  With "no" (the default) all CPU-related
+values are scaled for a limit of n * 100 ("n" being the number of CPUs).
+
+See "BUGS" for an explanation of the "HZ" setting.
 
 =head2 EXAMPLE WARNING AND CRITICAL SETTINGS
 
@@ -111,6 +116,7 @@ if [ "$1" = "autoconf" ]; then
 fi
 
 HZ=${HZ:-100}
+scaleto100=${scaleto100:-no}
 
 extinfo=""
 

--- a/plugins/node.d.linux/cpu.in
+++ b/plugins/node.d.linux/cpu.in
@@ -77,10 +77,6 @@ about IO performance.
   #%# capabilities=autoconf
 
 
-=head1 VERSION
-
-  $Id$
-
 =head1 BUGS
 
 Some combinations of hardware and Linux (probably only 2.4 kernels)
@@ -103,7 +99,7 @@ GPLv2
 =cut
 
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if [ -r /proc/stat ]; then
@@ -120,12 +116,12 @@ scaleto100=${scaleto100:-no}
 
 extinfo=""
 
-if egrep -q '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
+if grep -qE '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
 	extinfo="iowait irq softirq"
-	if egrep -q '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
+	if grep -qE '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
 		extextinfo="steal"
 	fi
-	if egrep -q '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
+	if grep -qE '^cpu +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+ +[0-9]+' /proc/stat; then
 		extextextinfo="guest"
 	fi
 
@@ -133,14 +129,14 @@ fi
 
 if [ "$1" = "config" ]; then
 
-	NCPU=$(egrep '^cpu[0-9]+ ' /proc/stat | wc -l)
+	NCPU=$(grep -E '^cpu[0-9]+ ' /proc/stat | wc -l)
 	if [ "$scaleto100" = "yes" ]; then
 		graphlimit=100
 	else
-		graphlimit=$(($NCPU * 100))
+		graphlimit=$((NCPU * 100))
 	fi
 	echo 'graph_title CPU usage'
-	echo "graph_order system user nice idle" $extinfo
+	echo "graph_order system user nice idle $extinfo"
 	echo "graph_args --base 1000 -r --lower-limit 0 --upper-limit $graphlimit"
 	echo 'graph_vlabel %'
 	echo 'graph_scale no'
@@ -215,9 +211,7 @@ if [ "$1" = "config" ]; then
 		if [ "$scaleto100" = "yes" ]; then
 			echo "steal.cdef steal,$NCPU,/"
 		fi
-		for field in steal; do
-			print_adjusted_thresholds "$field" "$graphlimit"
-		done
+		print_adjusted_thresholds "steal" "$graphlimit"
 	fi
 
 	if [ ! -z "$extextextinfo" ]
@@ -230,9 +224,7 @@ if [ "$1" = "config" ]; then
 		if [ "$scaleto100" = "yes" ]; then
 			echo "guest.cdef guest,$NCPU,/"
 		fi
-		for field in guest; do
-			print_adjusted_thresholds "$field" "$graphlimit"
-		done
+		print_adjusted_thresholds "guest" "$graphlimit"
 	fi
 
 	exit 0
@@ -242,11 +234,11 @@ fi
 # to avoid 10e+09 and the like %.0f should do this.
 
 if [ ! -z "$extextextinfo" ]; then
-	awk -v hz=$HZ '/^cpu / { printf "user.value %.0f\nnice.value %.0f\nsystem.value %.0f\nidle.value %.0f\niowait.value %.0f\nirq.value %.0f\nsoftirq.value %.0f\nsteal.value %.0f\nguest.value %.0f\n", $2*100/hz, $3*100/hz, $4*100/hz, $5*100/hz, $6*100/hz, $7*100/hz, $8*100/hz, $9*100/hz, $10*100/hz }' < /proc/stat
+	awk -v "hz=$HZ" '/^cpu / { printf "user.value %.0f\nnice.value %.0f\nsystem.value %.0f\nidle.value %.0f\niowait.value %.0f\nirq.value %.0f\nsoftirq.value %.0f\nsteal.value %.0f\nguest.value %.0f\n", $2*100/hz, $3*100/hz, $4*100/hz, $5*100/hz, $6*100/hz, $7*100/hz, $8*100/hz, $9*100/hz, $10*100/hz }' < /proc/stat
 elif [ ! -z "$extextinfo" ]; then
-	awk -v hz=$HZ '/^cpu / { printf "user.value %.0f\nnice.value %.0f\nsystem.value %.0f\nidle.value %.0f\niowait.value %.0f\nirq.value %.0f\nsoftirq.value %.0f\nsteal.value %.0f\n", $2*100/hz, $3*100/hz, $4*100/hz, $5*100/hz, $6*100/hz, $7*100/hz, $8*100/hz, $9*100/hz }' < /proc/stat
+	awk -v "hz=$HZ" '/^cpu / { printf "user.value %.0f\nnice.value %.0f\nsystem.value %.0f\nidle.value %.0f\niowait.value %.0f\nirq.value %.0f\nsoftirq.value %.0f\nsteal.value %.0f\n", $2*100/hz, $3*100/hz, $4*100/hz, $5*100/hz, $6*100/hz, $7*100/hz, $8*100/hz, $9*100/hz }' < /proc/stat
 elif [ ! -z "$extinfo" ]; then
-	awk -v hz=$HZ '/^cpu / { printf "user.value %.0f\nnice.value %.0f\nsystem.value %.0f\nidle.value %.0f\niowait.value %.0f\nirq.value %.0f\nsoftirq.value %.0f\n", $2*100/hz, $3*100/hz, $4*100/hz, $5*100/hz, $6*100/hz, $7*100/hz, $8*100/hz }' < /proc/stat
+	awk -v "hz=$HZ" '/^cpu / { printf "user.value %.0f\nnice.value %.0f\nsystem.value %.0f\nidle.value %.0f\niowait.value %.0f\nirq.value %.0f\nsoftirq.value %.0f\n", $2*100/hz, $3*100/hz, $4*100/hz, $5*100/hz, $6*100/hz, $7*100/hz, $8*100/hz }' < /proc/stat
 else
-	awk -v hz=$HZ '/^cpu / { printf "user.value %.0f\nnice.value %.0f\nsystem.value %.0f\nidle.value %.0f\n", $2*100/hz, $3*100/hz, $4*100/hz, $5*100/hz }' < /proc/stat
+	awk -v "hz=$HZ" '/^cpu / { printf "user.value %.0f\nnice.value %.0f\nsystem.value %.0f\nidle.value %.0f\n", $2*100/hz, $3*100/hz, $4*100/hz, $5*100/hz }' < /proc/stat
 fi

--- a/plugins/node.d.linux/cpuspeed.in
+++ b/plugins/node.d.linux/cpuspeed.in
@@ -19,10 +19,11 @@ None needed by default.
 You can set one environment variable to modify the plugins behaviour:
 
   [cpuspeed]
-     env.scaleto100 1
+     env.scaleto100 yes
 
-Show the frequency as a percentage instead of absolute frequency.  If
-set the plugin sets up a CDEF to change the speed in Hz to percent.
+Show the frequency as a percentage instead of absolute frequency.
+If set the "yes" the plugin sets up a CDEF to change the speed in Hz
+to percent.
 
 If you set or unset this the whole time series will be shown in the
 same way, either as Hz or percent (as the graphs are updated).
@@ -56,6 +57,8 @@ GPLv2
 =cut
 
 . $MUNIN_LIBDIR/plugins/plugin.sh
+
+scaleto100=${scaleto100:-no}
 
 if [ "$1" = "autoconf" ]; then
     if [ -r /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state ] ; then

--- a/plugins/node.d.linux/cpuspeed.in
+++ b/plugins/node.d.linux/cpuspeed.in
@@ -56,7 +56,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 scaleto100=${scaleto100:-no}
 
@@ -90,28 +90,28 @@ if [ "$1" = "config" ]; then
         echo "cpu$N.label CPU $N"
         echo "cpu$N.type DERIVE"
 
-	if [ -r $c/cpufreq/cpuinfo_max_freq ]; then
+        if [ -r "$c/cpufreq/cpuinfo_max_freq" ]; then
 
-            MAXHZ=$(cat $c/cpufreq/cpuinfo_max_freq)
+            MAXHZ=$(cat "$c/cpufreq/cpuinfo_max_freq")
             # Adding 10% to $MAXHZ, to cope with polling jitters
             # See bug D#615957
-            MAXHZ=$(( $MAXHZ + $MAXHZ / 10 ))
+            MAXHZ=$(( MAXHZ + MAXHZ / 10 ))
             echo "cpu$N.max $MAXHZ"
 
             if [ "$scaleto100" = "yes" ]; then
-		echo "cpu$N.cdef cpu$N,1000,*,$MAXHZ,/"
+                echo "cpu$N.cdef cpu$N,1000,*,$MAXHZ,/"
             else
-		echo "cpu$N.cdef cpu$N,1000,*"
+                echo "cpu$N.cdef cpu$N,1000,*"
             fi
-	fi
+        fi
 
-	if [ -r $c/cpufreq/cpuinfo_min_freq ]; then
-	    MINHZ=$(cat $c/cpufreq/cpuinfo_min_freq)
+        if [ -r "$c/cpufreq/cpuinfo_min_freq" ]; then
+            MINHZ=$(cat "$c/cpufreq/cpuinfo_min_freq")
             echo "cpu$N.min $MINHZ"
-	fi
+        fi
 
-	print_warning "cpu$N"
-	print_critical "cpu$N"
+        print_warning "cpu$N"
+        print_critical "cpu$N"
 
     done
     exit 0;
@@ -119,7 +119,7 @@ fi
 
 for c in /sys/devices/system/cpu/cpu[0-9]*; do
     N=${c##*/cpu}
-    awk -v cpu=$N '{ cycles += $1 * $2 } 
+    awk -v "cpu=$N" '{ cycles += $1 * $2 }
                END { printf "cpu%d.value %.0f\n", cpu, cycles / 100; }' \
-        $c/cpufreq/stats/time_in_state
+        "$c/cpufreq/stats/time_in_state"
 done

--- a/plugins/node.d.linux/df_abs.in
+++ b/plugins/node.d.linux/df_abs.in
@@ -47,7 +47,7 @@ for multiple mounts.
 
 EOF
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	echo yes
@@ -56,11 +56,11 @@ fi
 
 # Append $mnt in case $dev is not a real block device
 get_fieldname() {
-	dev="$1"
-	mnt="$2"
+	local dev="$1"
+	local mnt="$2"
 	case "$dev" in
 		/* )
-			clean_fieldname $dev
+			clean_fieldname "$dev"
 			;;
 		* )
 			clean_fieldname "$dev $mnt"
@@ -71,7 +71,7 @@ get_fieldname() {
 total=${total:-on}
 
 exclude=${exclude:-iso9660}
-exclude=$(echo $exclude | sed -r -e 's/ +/ -x /g' -e 's/^/-x /') 
+exclude=$(echo "$exclude" | sed -r -e 's/ +/ -x /g' -e 's/^/-x /')
 
 if [ "$1" = "config" ]; then
 
@@ -82,24 +82,26 @@ if [ "$1" = "config" ]; then
 	if [ "$total" = "on" ]; then
 		echo 'graph_total Total'
 	fi
+	# shellcheck disable=SC2086
 	df -P -l $exclude | sed 1d | grep -v "//" | 
-	while read dev size used avail cap mnt; do
-		name="$(get_fieldname $dev $mnt)"
+	while read -r dev size used avail cap mnt; do
+		name="$(get_fieldname "$dev" "$mnt")"
 		echo "$name.label $mnt"
 		echo "$name.cdef $name,1024,*"
-		warn=$(get_warning $name)
-		crit=$(get_critical $name)
+		warn=$(get_warning "$name")
+		crit=$(get_critical "$name")
 		if [ -n "$warn" ]; then
-			echo "$name.warning $((size * $warn / 100))"
+			echo "$name.warning $((size * warn / 100))"
 		fi
 		if [ -n "$crit" ]; then
-			echo "$name.critical $((size * $crit / 100))"
+			echo "$name.critical $((size * crit / 100))"
 		fi
 	done
 	exit 0
 fi
 
+# shellcheck disable=SC2034,SC2086
 df -P -l $exclude | sed 1d | grep -v "//" | 
-   while read dev size used avail cap mnt; do
-	echo "$(get_fieldname $dev $mnt).value $used"
-done
+	while read -r dev size used avail cap mnt; do
+		echo "$(get_fieldname "$dev" "$mnt").value $used"
+	done

--- a/plugins/node.d.linux/entropy.in
+++ b/plugins/node.d.linux/entropy.in
@@ -26,7 +26,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if [ -r /proc/sys/kernel/random/entropy_avail ]; then

--- a/plugins/node.d.linux/forks.in
+++ b/plugins/node.d.linux/forks.in
@@ -26,7 +26,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if [ -r /proc/stat ]; then
@@ -42,6 +42,7 @@ if [ "$1" = "config" ]; then
 
 	echo 'graph_title Fork rate'
 	echo 'graph_args --base 1000 -l 0 '
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel forks / ${graph_period}'
 	echo 'graph_category processes'
 	echo 'graph_info This graph shows the number of forks (new processes started) per second.'
@@ -57,6 +58,3 @@ fi
 
 echo -n "forks.value "
 awk '/processes/ {print $2}' /proc/stat
-
-
-

--- a/plugins/node.d.linux/if_.in
+++ b/plugins/node.d.linux/if_.in
@@ -64,9 +64,10 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 INTERFACE=${0##*if_}
+speed=${speed:-}
 
 # Who whould have thought it's so much work to determine the
 # maximum speed of a network interface.  Buckle up!
@@ -75,13 +76,13 @@ findspeed_mbps() {
     # wifi drivers use "eth*" names.
     IWLIST=$(type -p iwlist)
     if [[ -x "$IWLIST" ]]; then
-        SPEED=$($IWLIST $INTERFACE rate 2>&1 |
+        SPEED=$("$IWLIST" "$INTERFACE" rate 2>&1 |
             awk 'BEGIN { RATE="U" }
                        { if ($2 == "Mb/s") RATE=$1; }
                  END   { print RATE; }')
 
         if [[ "$SPEED" != "U" ]]; then
-            echo $SPEED
+            echo "$SPEED"
             return
         fi
     fi
@@ -89,28 +90,28 @@ findspeed_mbps() {
     # sysfs can report the speed if the driver supports it (but it
     # doesn't work as well for wireless cards, thus why we check for
     # iwlist first)
-    if [[ -r /sys/class/net/$INTERFACE/speed ]]; then
-            SPEED=$(cat /sys/class/net/$INTERFACE/speed 2>/dev/null)
+    if [[ -r "/sys/class/net/$INTERFACE/speed" ]]; then
+            SPEED=$(cat "/sys/class/net/$INTERFACE/speed" 2>/dev/null)
             if [[ "$SPEED" -gt 0 ]]; then
-                echo $SPEED
+                echo "$SPEED"
                 return
             fi
     fi
 
     ETHTOOL=$(type -p ethtool)
     if [[ -x "$ETHTOOL" ]]; then
-        SPEED=$($ETHTOOL $INTERFACE 2>&1 |
+        SPEED=$("$ETHTOOL" "$INTERFACE" 2>&1 |
                  awk '/Speed:/ { gsub(/[^0-9]*/,"",$2); print $2; }')
 
         if [[ $SPEED == [0-9]* ]]; then
-            echo $SPEED
+            echo "$SPEED"
             return
         fi
     fi
 
     MIITOOL=$(type -p mii-tool)
-    if [[ -x $MIITOOL ]]; then
-        case $($MIITOOL $INTERFACE 2>&1) in
+    if [[ -x "$MIITOOL" ]]; then
+        case $("$MIITOOL" "$INTERFACE" 2>&1) in
             *1000base*) echo 1000; return ;;
             *100base*)  echo 100; return ;;
             *10base*)   echo 10; return ;;
@@ -128,7 +129,7 @@ findspeed() {
     fi
 
     if [[ -z "$SPEED" ]] || [[ "$SPEED" == "U" ]]; then
-        printf "up.info Traffic of the %s interface. Unable to determine interface speed." $INTERFACE
+        printf "up.info Traffic of the %s interface. Unable to determine interface speed." "$INTERFACE"
         if [[ $EUID -ne 0 ]]; then
                 echo " Please run the plugin as root."
         else
@@ -138,7 +139,7 @@ findspeed() {
         return
     fi
 
-    BPS=$(( $SPEED * 1000 * 1000 ))
+    BPS=$(( SPEED * 1000 * 1000 ))
 
     cat <<EOF
 up.max $BPS
@@ -171,6 +172,7 @@ case $1 in
         echo "graph_order down up"
         echo "graph_title $INTERFACE traffic"
         echo 'graph_args --base 1000'
+        # shellcheck disable=SC2016
         echo 'graph_vlabel bits in (-) / out (+) per ${graph_period}'
         echo 'graph_category network'
         echo "graph_info This graph shows the traffic of the $INTERFACE network interface. Please note that the traffic is shown in bits per second, not bytes. IMPORTANT: On 32-bit systems the data source for this plugin uses 32-bit counters, which makes the plugin unreliable and unsuitable for most 100-Mb/s (or faster) interfaces, where traffic is expected to exceed 50 Mb/s over a 5 minute period.  This means that this plugin is unsuitable for most 32-bit production environments. To avoid this problem, use the ip_ plugin instead.  There should be no problems on 64-bit systems running 64-bit kernels."
@@ -197,14 +199,13 @@ esac
 
 # Escape dots in the interface name (eg. vlans) before using it as a regex
 if [[ -r /sys/class/net/$INTERFACE/statistics/rx_bytes ]]; then
-    echo "down.value $(cat /sys/class/net/$INTERFACE/statistics/rx_bytes)"
-    echo "up.value $(cat /sys/class/net/$INTERFACE/statistics/tx_bytes)"
+    echo "down.value $(cat "/sys/class/net/$INTERFACE/statistics/rx_bytes")"
+    echo "up.value $(cat "/sys/class/net/$INTERFACE/statistics/tx_bytes")"
 else
     awk -v interface="$INTERFACE" \
-        'BEGIN { gsub(/\./, "\\.", interface) } \
+        'BEGIN { gsub(/\./, "\\.", interface) }
         $1 ~ "^" interface ":" {
-            split($0, a, /: */); $0 = a[2]; \
-            print "down.value " $1 "\nup.value " $9 \
-        }' \
+            split($0, a, /: */); $0 = a[2];
+            print "down.value " $1 "\nup.value " $9}' \
         /proc/net/dev
 fi

--- a/plugins/node.d.linux/if_err_.in
+++ b/plugins/node.d.linux/if_err_.in
@@ -42,7 +42,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 INTERFACE=${0##*/if_err_}
 
@@ -67,6 +67,7 @@ if [ "$1" = "config" ]; then
     echo "graph_order rcvd trans"
     echo "graph_title $INTERFACE errors"
     echo 'graph_args --base 1000'
+    # shellcheck disable=SC2016
     echo 'graph_vlabel packets in (-) / out (+) per ${graph_period}'
     echo 'graph_category network'
     echo "graph_info This graph shows the amount of errors, packet drops, and collisions on the $INTERFACE network interface."
@@ -94,20 +95,20 @@ if [ "$1" = "config" ]; then
 fi;
 
 # Escape dots in the interface name (eg. vlans) before using it as a regex
-if [ -r /sys/class/net/$INTERFACE/statistics/rx_bytes ]; then
-    echo "rcvd.value $(cat /sys/class/net/$INTERFACE/statistics/rx_errors)"
-    echo "trans.value $(cat /sys/class/net/$INTERFACE/statistics/tx_errors)"
-    echo "rxdrop.value $(cat /sys/class/net/$INTERFACE/statistics/rx_dropped)"
-    echo "txdrop.value $(cat /sys/class/net/$INTERFACE/statistics/tx_dropped)"
-    echo "collisions.value $(cat /sys/class/net/$INTERFACE/statistics/collisions)"
+if [ -r "/sys/class/net/$INTERFACE/statistics/rx_bytes" ]; then
+    echo "rcvd.value $(cat "/sys/class/net/$INTERFACE/statistics/rx_errors")"
+    echo "trans.value $(cat "/sys/class/net/$INTERFACE/statistics/tx_errors")"
+    echo "rxdrop.value $(cat "/sys/class/net/$INTERFACE/statistics/rx_dropped")"
+    echo "txdrop.value $(cat "/sys/class/net/$INTERFACE/statistics/tx_dropped")"
+    echo "collisions.value $(cat "/sys/class/net/$INTERFACE/statistics/collisions")"
 else
     awk -v interface="$INTERFACE" \
-        'BEGIN { gsub(/\./, "\\.", interface) } \
+        'BEGIN { gsub(/\./, "\\.", interface) }
         $1 ~ "^" interface ":" {
-            split($0, a, /: */); $0 = a[2]; \
-            print "rcvd.value " $3 "\ntrans.value " $11; \
-            print "rxdrop.value " $4 "\ntxdrop.value " $12; \
-            print "collisions.value " $14; \
+            split($0, a, /: */); $0 = a[2];
+            print "rcvd.value " $3 "\ntrans.value " $11;
+            print "rxdrop.value " $4 "\ntxdrop.value " $12;
+            print "collisions.value " $14;
         }' \
         /proc/net/dev
 fi

--- a/plugins/node.d.linux/interrupts.in
+++ b/plugins/node.d.linux/interrupts.in
@@ -27,7 +27,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if [ -r /proc/stat ]; then
@@ -49,6 +49,7 @@ if [ "$1" = "config" ]; then
 	# lower limit of the graph is '0', and that 1k=1000 (not 1024)
 	echo 'graph_args --base 1000 -l 0'
 	# The Y-axis label
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel interrupts & ctx switches / ${graph_period}'
 	# Graph category
 	echo 'graph_category system'

--- a/plugins/node.d.linux/ip_.in
+++ b/plugins/node.d.linux/ip_.in
@@ -116,11 +116,12 @@ Unknown.
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 IP=${0##*/ip_}
 INPUT=${input:-INPUT}
 OUTPUT=${output:-OUTPUT}
+hostname=${hostname:-}
 
 case $IP in
     *:*) # I know this! This is IPv6!
@@ -134,7 +135,7 @@ esac
 
 if [[ "$1" == "autoconf" ]]; then
     if [[ -r /proc/net/dev ]]; then
-        if ! iptables -L ${INPUT} -v -n -w -x >/dev/null 2>/dev/null; then
+        if ! iptables -L "$INPUT" -v -n -w -x >/dev/null 2>/dev/null; then
             echo "no (could not run iptables as user $(whoami))"
             exit 0
         else
@@ -148,9 +149,9 @@ if [[ "$1" == "autoconf" ]]; then
 fi
 
 if [[ "$1" == "suggest" ]]; then
-    iptables -L ${INPUT} -v -n -x -w 2>/dev/null | awk --posix '$8 ~ /^([0-9]{1,3}\.){3}[0-9]{1,3}$/ { if (done[$8]!=1) {print $8; done[$8]=1;}}'
+    iptables -L "$INPUT" -v -n -x -w 2>/dev/null | awk --posix '$8 ~ /^([0-9]{1,3}\.){3}[0-9]{1,3}$/ { if (done[$8]!=1) {print $8; done[$8]=1;}}'
     if [[ -x /sbin/ip6tables ]]; then
-        ip6tables -L ${INPUT} -v -n -x -w 2>/dev/null | awk --posix '$7 ~ /\/128$/ { if (done[$7]!=1) {a=$7;gsub(/\/128$/, "", a); print a; done[$7]=1;}}'
+        ip6tables -L "$INPUT" -v -n -x -w 2>/dev/null | awk --posix '$7 ~ /\/128$/ { if (done[$7]!=1) {a=$7;gsub(/\/128$/, "", a); print a; done[$7]=1;}}'
     fi
     exit 0
 fi
@@ -164,6 +165,7 @@ if [[ "$1" == "config" ]]; then
     fi
     echo "graph_title $title traffic"
     echo 'graph_args --base 1000'
+    # shellcheck disable=SC2016
     echo 'graph_vlabel bits per ${graph_period}'
     echo 'graph_category network'
     echo 'out.label sent'
@@ -182,6 +184,6 @@ if [[ "$1" == "config" ]]; then
 fi;
 
 # Escape .'s so they don't match _everything_?
-IP=$(echo $IP | sed 's~\.~\\.~g')
-iptables -L ${INPUT} -v -n -x -w  | awk "/$IP"'[ /]/ { print "in.value " $2; exit 0; }'
-iptables -L ${OUTPUT} -v -n -x -w | awk "/$IP"'[ /]/ { print "out.value " $2; exit 0; }'
+escaped_ip=${IP//./\\.}
+iptables -L "$INPUT" -v -n -x -w  | awk "/$escaped_ip"'[ /]/ { print "in.value " $2; exit 0; }'
+iptables -L "$OUTPUT" -v -n -x -w | awk "/$escaped_ip"'[ /]/ { print "out.value " $2; exit 0; }'

--- a/plugins/node.d.linux/load.in
+++ b/plugins/node.d.linux/load.in
@@ -43,7 +43,7 @@ always be included.
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
         echo yes

--- a/plugins/node.d.linux/nfs4_client.in
+++ b/plugins/node.d.linux/nfs4_client.in
@@ -49,6 +49,7 @@ if [ "$1" = "config" ]; then
 
 	echo 'graph_title NFSv4 Client'
 	echo 'graph_args --base 1000 -l 0'
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel requests / ${graph_period}'
 	echo 'graph_total total'
 	echo 'graph_category NFS'

--- a/plugins/node.d.linux/nfs4_client.in
+++ b/plugins/node.d.linux/nfs4_client.in
@@ -32,8 +32,7 @@ proc="read write commit open open_confirm open_noattr open_downgrade close setat
 
 if [ "$1" = "autoconf" ]; then
 	if [ -f "$NFS" ]; then
-		grep -q proc4 "$NFS"
-		if [ $? = 0 ]; then
+		if grep -q proc4 "$NFS"; then
 			echo yes
 		else
 			echo "no (no proc4 in $NFS)"

--- a/plugins/node.d.linux/nfs_client.in
+++ b/plugins/node.d.linux/nfs_client.in
@@ -49,6 +49,7 @@ if [ "$1" = "config" ]; then
 
 	echo 'graph_title NFS Client'
 	echo 'graph_args --base 1000 -l 0'
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel requests / ${graph_period}'
 	echo 'graph_total total'
 	echo 'graph_category NFS'

--- a/plugins/node.d.linux/nfs_client.in
+++ b/plugins/node.d.linux/nfs_client.in
@@ -32,8 +32,7 @@ proc="getattr setattr lookup access readlink read write create mkdir symlink mkn
 
 if [ "$1" = "autoconf" ]; then
 	if [ -f "$NFS" ]; then
-		grep -q proc3 "$NFS"
-		if [ $? = 0 ]; then
+		if grep -q proc3 "$NFS"; then
 			echo yes
 		else
 			echo "no (no proc3 in $NFS)"

--- a/plugins/node.d.linux/nfsd.in
+++ b/plugins/node.d.linux/nfsd.in
@@ -33,7 +33,7 @@ proc="getattr setattr lookup access readlink read write create mkdir symlink mkn
 if [ "$1" = "autoconf" ]; then
 	if [ -f "$NFSD" ]; then
 		grep -q proc3 "$NFSD"
-		if [ $? = 0 ]; then
+		if grep -q proc3 "$NFSD"; then
 			echo yes
 		else
 			echo "no (no proc3 in $NFSD)"
@@ -49,6 +49,7 @@ if [ "$1" = "config" ]; then
 
 	echo 'graph_title NFS Server'
 	echo 'graph_args --base 1000 -l 0'
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel requests / ${graph_period}'
 	echo 'graph_total total'
 	echo 'graph_category NFS'

--- a/plugins/node.d.linux/nfsd4.in
+++ b/plugins/node.d.linux/nfsd4.in
@@ -38,8 +38,7 @@ proc="access close commit create delegpurge delegreturn getattr getfh link lock 
 
 if [ "$1" = "autoconf" ]; then
 	if [ -f "$NFSD" ]; then
-		grep -q proc4ops "$NFSD"
-		if [ $? = 0 ]; then
+		if grep -q proc4ops "$NFSD"; then
 			echo yes
 		else
 			echo "no (no proc4ops in $NFSD)"
@@ -60,6 +59,7 @@ if [ "$1" = "config" ]; then
 
 	echo 'graph_title NFSv4 Server'
 	echo 'graph_args --base 1000 -l 0'
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel requests / ${graph_period}'
 	echo 'graph_total total'
 	echo 'graph_category NFS'
@@ -74,5 +74,5 @@ for a in $proc; do
 	grep proc4ops $NFSD \
 		| cut -f $i -d ' ' \
 		| awk '{print $1}'
-	i=$(expr $i + 1)
+	i=$((i + 1))
 done

--- a/plugins/node.d.linux/open_files.in
+++ b/plugins/node.d.linux/open_files.in
@@ -26,7 +26,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if [ -r /proc/sys/fs/file-nr ]; then
@@ -51,8 +51,8 @@ if [ "$1" = "config" ]; then
 	computed_critical=$(awk '{printf "%d", $3*0.98}' < /proc/sys/fs/file-nr)
 	p_warning=$(print_warning used)
 	p_critical=$(print_critical used)
-	[ -z "$p_warning" ] && echo "used.warning $computed_warning" || echo $p_warning
-	[ -z "$p_critical" ] && echo "used.critical $computed_critical" || echo $p_critical
+	[ -z "$p_warning" ] && echo "used.warning $computed_warning" || echo "$p_warning"
+	[ -z "$p_critical" ] && echo "used.critical $computed_critical" || echo "$p_critical"
 	echo 'max.label max open files'
 	echo 'max.info The maximum supported number of open files. Tune by modifying /proc/sys/fs/file-max.'
 	print_warning max

--- a/plugins/node.d.linux/open_inodes.in
+++ b/plugins/node.d.linux/open_inodes.in
@@ -26,7 +26,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if [ -r /proc/sys/fs/inode-nr ]; then

--- a/plugins/node.d.linux/proc_pri.in
+++ b/plugins/node.d.linux/proc_pri.in
@@ -27,7 +27,7 @@ GNU GPL
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	echo yes

--- a/plugins/node.d.linux/selinux_avcstat.in
+++ b/plugins/node.d.linux/selinux_avcstat.in
@@ -21,7 +21,7 @@ else
 fi
 
 if [ "$1" = "autoconf" ]; then
-        if [ -r $AVCSTATS ]; then
+        if [ -r "$AVCSTATS" ]; then
                 echo yes
         else
                 echo "no (missing $AVCSTATS file)"
@@ -88,17 +88,20 @@ if [ "$1" = "config" ]; then
         exit 0
 fi
 
-if [ -r $AVCSTATS ]; then
-    { read HEADER
-      while read lookups hits misses allocations reclaims frees; do
-        LOOKUPS=$(($LOOKUPS + $lookups))
-        HITS=$(($HITS + $hits))
-        MISSES=$(($MISSES + $misses))
-        ALLOCATIONS=$(($ALLOCATIONS + $allocations))
-        RECLAIMS=$(($RECLAIMS + $reclaims))
-        FREES=$(($FREES + $frees))
+if [ -r "$AVCSTATS" ]; then
+    {
+      # consume (and ignore) the header
+      # shellcheck disable=SC2034
+      read -r HEADER
+      while read -r lookups hits misses allocations reclaims frees; do
+        LOOKUPS=$((LOOKUPS + lookups))
+        HITS=$((HITS + hits))
+        MISSES=$((MISSES + misses))
+        ALLOCATIONS=$((ALLOCATIONS + allocations))
+        RECLAIMS=$((RECLAIMS + reclaims))
+        FREES=$((FREES + frees))
       done
-    } < $AVCSTATS
+    } < "$AVCSTATS"
     echo "lookups.value $LOOKUPS"
     echo "hits.value $HITS"
     echo "misses.value $MISSES"

--- a/plugins/node.d.linux/swap.in
+++ b/plugins/node.d.linux/swap.in
@@ -26,7 +26,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if [ -r /proc/stat ]; then
@@ -42,6 +42,7 @@ if [ "$1" = "config" ]; then
 
 	echo 'graph_title Swap in/out'
 	echo 'graph_args -l 0 --base 1000'
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel pages per ${graph_period} in (-) / out (+)'
 	echo 'graph_category system'
 	echo 'swap_in.label swap'

--- a/plugins/node.d.linux/tcp.in
+++ b/plugins/node.d.linux/tcp.in
@@ -67,7 +67,7 @@ EOF
 			exit 0
 		else
 			echo no
-			exit 1
+			exit 0
 		fi
 esac
 

--- a/plugins/node.d.linux/tcp.in
+++ b/plugins/node.d.linux/tcp.in
@@ -54,14 +54,14 @@ EOF
 			fin_wait2 time_wait close close_wait last_ack \
 			listen closing
 		do
-			echo ${i}.label $i
-			echo ${i}.info Sockets in state $i
+			echo "${i}.label $i"
+			echo "${i}.info Sockets in state $i"
 		done
 
         exit 0
 		;;
     autoconf)
-        if [ -f /proc/net/tcp -o -f /proc/net/tcp6 ]
+        if [ -f /proc/net/tcp ] || [ -f /proc/net/tcp6 ]
 		then
 			echo yes
 			exit 0

--- a/plugins/node.d.linux/uptime.in
+++ b/plugins/node.d.linux/uptime.in
@@ -26,7 +26,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
         echo yes

--- a/plugins/node.d.linux/vlan_.in
+++ b/plugins/node.d.linux/vlan_.in
@@ -16,7 +16,7 @@
 #%# family=manual
 #%# capabilities=autoconf suggest
 
-INTERFACE=$(basename $0 | sed 's/^vlan_//g' | tr '_' '.')
+INTERFACE=$(basename "$0" | sed 's/^vlan_//g' | tr '_' '.')
 
 if [ "$1" = "autoconf" ]; then
     if [ ! -d /proc/net/vlan ] ; then
@@ -39,7 +39,7 @@ fi
 if [ "$1" = "suggest" ]; then
     for file in /proc/net/vlan/*; do
 	if [ ! "$file" = "/proc/net/vlan/config" ]; then
-	    basename $file | tr '.' '_'
+	    basename "$file" | tr '.' '_'
 	fi
     done
     exit 0
@@ -49,6 +49,7 @@ if [ "$1" = "config" ]; then
 	echo "graph_order received transmitted"
 	echo "graph_title VLAN $INTERFACE Traffic"
 	echo 'graph_args --base 1024'
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel bits per ${graph_period} in (-) / out (+)'
 	echo 'graph_category network'
 	echo 'received.label bps'
@@ -66,5 +67,4 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-awk "/bytes received/ { print \"received.value \" \$4 } /bytes transmitted/ { print \"transmitted.value \" \$4 }" < /proc/net/vlan/$INTERFACE
-
+awk '/bytes received/ { print "received.value " $4 } /bytes transmitted/ { print "transmitted.value " $4 }' <"/proc/net/vlan/$INTERFACE"

--- a/plugins/node.d.linux/vserver_cpu_.in
+++ b/plugins/node.d.linux/vserver_cpu_.in
@@ -117,13 +117,14 @@ if [ "$1" = "suggest" ]; then
 	#
 fi
 
-VSERVERS="$vservers"
+VSERVERS="${vservers:-}"
 
-INFO=(`sed 's/.*:\t//' /proc/virtual/info 2>/dev/null || echo '<none>'`)
-KCIN="$[ 16#${INFO[2]} ]";
+# shellcheck disable=SC2207
+INFO=($(sed 's/.*:\t//' /proc/virtual/info 2>/dev/null || echo '<none>'))
+KCIN=$(( 16#${INFO[2]} ))
 
 # If this is 1, then VCI_SPACES is present in the kernel (new in 2.6.19)
-if [ $[ (KCIN >> 10) & 1 ] -eq 1 ]
+if [ $(( (KCIN >> 10) & 1 )) -eq 1 ]
 then 
     NAMELOC="nsproxy"
 else 
@@ -131,70 +132,75 @@ else
 fi
 
 if [ -z "$VSERVERS" ] ; then
-    XIDS=`find /proc/virtual/* -type d -exec basename {} \;`
+    XIDS=$(find /proc/virtual/* -type d -exec basename {} \;)
 else
     # it's really more performant to specify vservers by ids or by linking but not in the configuration-file by name
     XIDS=""
     for i in $VSERVERS ; do
-	if [ -d /proc/virtual/$i ] ; then
-	    XIDS="${XIDS}${i} "
-	else
-	    for j in `find /proc/virtual/* -type d -exec basename {} \;` ; do
-		if [ "$i" = "`cat /proc/virtual/$j/$NAMELOC |grep NodeName |cut -f2`" ] ; then
-		    XIDS="${XIDS}${j} "
-		fi
-	    done
-	fi
+        if [ -d "/proc/virtual/$i" ]; then
+            XIDS="${XIDS}${i} "
+        else
+            # shellcheck disable=SC2044
+            for j in $(find /proc/virtual/* -type d -exec basename {} \;); do
+                if [ "$i" = "$(grep "NodeName" "/proc/virtual/$j/$NAMELOC" | cut -f 2)" ] ; then
+                    XIDS="${XIDS}${j} "
+                fi
+            done
+        fi
     done
 fi
 
 if [ "$1" = "suggest" ]; then
 	if [ -r /proc/virtual/info ]; then
 	        for i in $XIDS ; do
-			LABEL=`cat /proc/virtual/$i/$NAMELOC |grep NodeName |cut -f2`
-			echo $LABEL
+			LABEL=$(grep "NodeName" "/proc/virtual/$i/$NAMELOC" | cut -f 2)
+			echo "$LABEL"
 		done
 		exit 0
 	fi
 fi
 
-BASEPARAM=`basename $0 | sed 's/^vserver_//'`
-MODE=`echo $BASEPARAM | sed 's/^hold.*//'`
+# shellcheck disable=SC2001
+BASEPARAM=$(basename "$0" | sed 's/^vserver_//')
+# shellcheck disable=SC2001
+MODE=$(echo "$BASEPARAM" | sed 's/^hold.*//')
 
-#debug=true
+debug=${debug:-}
 
 if [ -z "$MODE" ] ; then
 	MODE=hold
-	TARGET=`echo $BASEPARAM | sed 's/^hold_//'`
+	# shellcheck disable=SC2001
+	TARGET=$(echo "$BASEPARAM" | sed 's/^hold_//')
 else 
 	MODE=cpu
-	TARGET=`echo $BASEPARAM | sed 's/^cpu_//'`
+	# shellcheck disable=SC2001
+	TARGET=$(echo "$BASEPARAM" | sed 's/^cpu_//')
 fi
 
 CPU1=0
 if [ -n "$TARGET" ] ; then
 	if [ "${#TARGET}" == 1 ] ; then 
-		if [ $debug ] ; then echo $MODE, only on cpu $TARGET, for all vservers ; fi
+		if [ -n "$debug" ]; then echo "$MODE, only on cpu $TARGET, for all vservers"; fi
 		WHAT=ALLVSERVER
 		CPU1=$TARGET
 	else 
-		if [ $debug ] ; then echo $MODE on all cpus together, only for vserver $TARGET ; fi
+		if [ -n "$debug" ]; then echo "$MODE on all cpus together, only for vserver $TARGET"; fi
 		WHAT=VSERVER
 	fi
 else
-	if [ $debug ] ; then echo $MODE for all cpus, for all vservers ; fi
+	if [ -n "$debug" ] ; then echo "$MODE for all cpus, for all vservers"; fi
 	WHAT=ALLVSERVER
 fi
 
-CPUS=$[ `grep ^processor /proc/cpuinfo|wc -l` -1 ]
-CPUS=`seq $CPU1 $CPUS`
+CPUS=$(( $(grep ^processor /proc/cpuinfo | wc -l) - 1 ))
+CPUS=$(seq "$CPU1" "$CPUS")
 
-if [ $debug ] ; then
-	echo cpus= $CPUS
-	echo baseparam= $BASEPARAM
-	echo mode= $MODE 
-	echo target= $TARGET
-	echo what= $WHAT
+if [ -n "$debug" ] ; then
+	echo "cpus= $CPUS"
+	echo "baseparam= $BASEPARAM"
+	echo "mode= $MODE "
+	echo "target= $TARGET"
+	echo "what= $WHAT"
 fi
 
 if [ "$1" = "config" ]; then
@@ -202,10 +208,12 @@ if [ "$1" = "config" ]; then
 	echo 'graph_args --base 1000'
 	if [ "$MODE" == "cpu" ] ; then
 		echo 'graph_title Vserver cpu usage'
+		# shellcheck disable=SC2016
 		echo 'graph_vlabel jiffies used per cpu per ${graph_period}'
 		echo 'graph_info Shows jiffies used per cpu on each vserver.'
 	else
 		echo 'graph_title Vserver cpu on hold'
+		# shellcheck disable=SC2016
 		echo 'graph_vlabel jiffies on hold per cpu per ${graph_period}'
 		echo 'graph_info Shows jiffies on hold used per cpu on each vserver.'
 	fi
@@ -213,9 +221,9 @@ if [ "$1" = "config" ]; then
  	for j in $CPUS ; do 
 		A=0
 	        for i in $XIDS ; do 
-			LABEL=`cat /proc/virtual/$i/$NAMELOC |grep NodeName |cut -f2`
+			LABEL=$(grep "NodeName" "/proc/virtual/$i/$NAMELOC" | cut -f 2)
 			if [ "$WHAT" == "ALLVSERVER" ] || [ "$TARGET" == "$LABEL" ] ; then
-				NAME=`echo $LABEL | cut -d. -f1 |  tr '-' '_'`
+				NAME=$(echo "$LABEL" | cut -d. -f1 |  tr '-' '_')
 	    			if [ "$MODE" == "cpu" ] ; then
 					echo "${NAME}_$j.label cpu usage for cpu $j on $LABEL"
 					echo "${NAME}_$j.info cpu usage for cpu $j on $LABEL."
@@ -238,16 +246,16 @@ fi
 
 for j in $CPUS ; do 
 	for i in $XIDS ; do
-		LABEL=`cat /proc/virtual/$i/$NAMELOC |grep NodeName |cut -f2`
+		LABEL=$(grep "NodeName" "/proc/virtual/$i/$NAMELOC" | cut -f 2)
 		if [ "$WHAT" == "ALLVSERVER" ] || [ "$TARGET" == "$LABEL" ] ; then
-			NAME=`echo $LABEL | cut -d. -f1 |  tr '-' '_'`
+			NAME=$(echo "$LABEL" | cut -d. -f1 |  tr '-' '_')
 			echo -n "${NAME}_$j.value "
 			if [ "$MODE" == "cpu" ] ; then
-				USERCPU=`cat /proc/virtual/$i/sched |grep "cpu $j:"| cut -d' ' -f3`
-				SYSCPU=`cat /proc/virtual/$i/sched |grep "cpu $j:"| cut -d' ' -f4`
-	 			echo $[$USERCPU + $SYSCPU]
+				USERCPU=$(grep "cpu $j:" "/proc/virtual/$i/sched" | cut -d' ' -f 3)
+				SYSCPU=$(grep "cpu $j:" "/proc/virtual/$i/sched" | cut -d' ' -f 4)
+				echo $((USERCPU + SYSCPU))
 			else
-				cat /proc/virtual/$i/sched |grep "cpu $j:"| cut -d' ' -f5
+				grep "cpu $j:" "/proc/virtual/$i/sched" | cut -d ' ' -f 5
 			fi
 		fi	
 	done

--- a/plugins/node.d.linux/vserver_loadavg.in
+++ b/plugins/node.d.linux/vserver_loadavg.in
@@ -76,13 +76,14 @@ if [ "$1" = "autoconf" ]; then
 fi
 
 # if vservers are specified, use them; the default is to use all.
-VSERVERS="$vservers"
+VSERVERS="${vservers:-}"
 
-INFO=(`sed 's/.*:\t//' /proc/virtual/info 2>/dev/null || echo '<none>'`)
-KCIN="$[ 16#${INFO[2]} ]";
+# shellcheck disable=SC2207
+INFO=($(sed 's/.*:\t//' /proc/virtual/info 2>/dev/null || echo '<none>'))
+KCIN=$(( 16#${INFO[2]} ))
 
 # If this is 1, then VCI_SPACES is present in the kernel (new in 2.6.19)
-if [ $[ (KCIN >> 10) & 1 ] -eq 1 ]
+if [ $(( (KCIN >> 10) & 1 )) -eq 1 ]
 then 
     NAMELOC="nsproxy"
 else 
@@ -90,20 +91,21 @@ else
 fi
 
 if [ -z "$VSERVERS" ] ; then
-    XIDS=`find /proc/virtual/* -type d -exec basename {} \;`
+    XIDS=$(find /proc/virtual/* -type d -exec basename {} \;)
 else
     # it's really more performant to specify vservers by ids or not at all
     XIDS=""
     for i in $VSERVERS ; do
-	if [ -d /proc/virtual/$i ] ; then
-	    XIDS="${XIDS}${i} "
-	else
-	    for j in `find /proc/virtual/* -type d -exec basename {} \;` ; do
-		if [ "$i" = "`cat /proc/virtual/$j/$NAMELOC |grep NodeName |cut -f2`" ] ; then
-		    XIDS="${XIDS}${j} "
-		fi
-	    done
-	fi
+        if [ -d "/proc/virtual/$i" ] ; then
+            XIDS="${XIDS}${i} "
+        else
+            # shellcheck disable=SC2044
+            for j in $(find /proc/virtual/* -type d -exec basename {} \;); do
+                if [ "$i" = "$(grep "NodeName" "/proc/virtual/$j/$NAMELOC" | cut -f 2)" ] ; then
+                    XIDS="${XIDS}${j} "
+                fi
+            done
+        fi
     done
 fi
 	
@@ -126,8 +128,8 @@ if [ "$1" = "config" ]; then
 	echo 'graph_category vserver'
 	for xid in $XIDS ; do
 	# Specify the vservers
-		LABEL=`cat /proc/virtual/$xid/$NAMELOC |grep NodeName |cut -f2`
-		NAME=`echo $LABEL | cut -d. -f1 |  tr '-' '_'`
+		LABEL=$(grep "NodeName" "/proc/virtual/$xid/$NAMELOC" | cut -f 2)
+		NAME=$(echo "$LABEL" | cut -d. -f1 |  tr '-' '_')
 		echo "$NAME.label $LABEL: load average"
 		echo "$NAME.info $NAME average load for the past 5 minutes"
 	done 
@@ -137,8 +139,8 @@ if [ "$1" = "config" ]; then
 fi
 
 for xid in $XIDS ; do
-	LABEL=`cat /proc/virtual/$xid/$NAMELOC |grep NodeName |cut -f2`
-	NAME=`echo $LABEL | cut -d. -f1 |  tr '-' '_'`
-	echo -n "$NAME.value ";
-	cat /proc/virtual/$xid/cvirt | grep loadavg: | cut -d' ' -f2	
+	LABEL=$(grep "NodeName" "/proc/virtual/$xid/$NAMELOC" | cut -f 2)
+	NAME=$(echo "$LABEL" | cut -d. -f1 |  tr '-' '_')
+	echo -n "$NAME.value "
+	grep "loadavg:" "/proc/virtual/$xid/cvirt" | cut -d ' ' -f 2
 done

--- a/plugins/node.d.linux/vserver_resources.in
+++ b/plugins/node.d.linux/vserver_resources.in
@@ -180,15 +180,16 @@ if [ "$1" = "autoconf" ]; then
 	exit 0
 fi
 
-VSERVERS="$vservers"
-LIMITS="$limits"
-RESOURCE="$resource"
+VSERVERS="${vservers:-}"
+LIMITS="${limits:-}"
+RESOURCE="${resource:-}"
 
-INFO=(`sed 's/.*:\t//' /proc/virtual/info 2>/dev/null || echo '<none>'`)
-KCIN="$[ 16#${INFO[2]} ]";
+# shellcheck disable=SC2207
+INFO=($(sed 's/.*:\t//' /proc/virtual/info 2>/dev/null || echo '<none>'))
+KCIN=$(( 16#${INFO[2]} ))
 
 # If this is 1, then VCI_SPACES is present in the kernel (new in 2.6.19)
-if [ $[ (KCIN >> 10) & 1 ] -eq 1 ]
+if [ $(( (KCIN >> 10) & 1 )) -eq 1 ]
 then 
     NAMELOC="nsproxy"
 else 
@@ -196,20 +197,21 @@ else
 fi
 
 if [ -z "$VSERVERS" ] ; then
-    XIDS=`find /proc/virtual/* -type d -exec basename {} \;`
+    XIDS=$(find /proc/virtual/* -type d -exec basename {} \;)
 else
     # it's really more performant to specify vservers by ids or not at all
     XIDS=""
     for i in $VSERVERS ; do
-	if [ -d /proc/virtual/$i ] ; then
-	    XIDS="${XIDS}${i} "
-	else
-	    for j in `find /proc/virtual/* -type d -exec basename {} \;` ; do
-		if [ "$i" = "`cat /proc/virtual/$j/$NAMELOC |grep NodeName |cut -f2`" ] ; then
-		    XIDS="${XIDS}${j} "
-		fi
-	    done
-	fi
+        if [ -d "/proc/virtual/$i" ] ; then
+            XIDS="${XIDS}${i} "
+        else
+            # shellcheck disable=SC2044
+            for j in $(find /proc/virtual/* -type d -exec basename {} \;) ; do
+                if [ "$i" = "$(grep "NodeName" "/proc/virtual/$j/$NAMELOC" | cut -f 2)" ]; then
+                    XIDS="${XIDS}${j} "
+                fi
+            done
+        fi
     done
 fi
 
@@ -290,12 +292,12 @@ if [ "$1" = "config" ]; then
 
     
     # do not assume we are on i386 where pagesize is 4096...
-    pagesize=`perl -MPOSIX -e 'print POSIX::sysconf(_SC_PAGESIZE), "\n";'`
+    pagesize=$(perl -MPOSIX -e 'print POSIX::sysconf(_SC_PAGESIZE), "\n";')
     
     for xid in $XIDS ; do
 	    
-	LABEL=`cat /proc/virtual/$xid/$NAMELOC |grep NodeName |cut -f2`
-	NAME=`echo $LABEL | cut -d. -f1 |  tr '-' '_'`
+	LABEL=$(grep "NodeName" "/proc/virtual/$xid/$NAMELOC" | cut -f 2)
+	NAME=$(echo "$LABEL" | cut -d. -f1 |  tr '-' '_')
 
 	case "$RESOURCE" in
 	    PROC)
@@ -353,9 +355,9 @@ if [ "$1" = "config" ]; then
 		;;
 	esac
 	    
-	if [ ! -z "$LIMITS" -a "$LIMITS" = 1 ]; then
-	    LIMIT=`cat /proc/virtual/$xid/limit | grep $RESOURCE | cut -f4`
-	    if [ ${LIMIT:-0} -gt 0 ]; then
+	if [ ! -z "$LIMITS" ] && [ "$LIMITS" = 1 ]; then
+	    LIMIT=$(grep "$RESOURCE" "/proc/virtual/$xid/limit" | cut -f 4)
+	    if [ "${LIMIT:-0}" -gt 0 ]; then
 		echo "$NAME.critical $LIMIT"
 	    fi
 	fi
@@ -365,10 +367,10 @@ fi
 
 
 for xid in $XIDS ; do
-    LABEL=`cat /proc/virtual/$xid/$NAMELOC |grep NodeName |cut -f2`
-    NAME=`echo $LABEL | cut -d. -f1 |  tr '-' '_'`
-    cat /proc/virtual/$xid/limit | awk -v name="${NAME}" -v resource="${RESOURCE}:" \
-	'{ if ( $1 == resource )
-            printf "%s.value %d\n", name, $2 }'
+    LABEL=$(grep "NodeName" "/proc/virtual/$xid/$NAMELOC" | cut -f 2)
+    NAME=$(echo "$LABEL" | cut -d. -f1 |  tr '-' '_')
+    awk -v name="${NAME}" -v resource="${RESOURCE}:" \
+        '{ if ( $1 == resource ) printf "%s.value %d\n", name, $2 }' \
+        "/proc/virtual/$xid/limit"
 done
 

--- a/plugins/node.d.netbsd/df.in
+++ b/plugins/node.d.netbsd/df.in
@@ -41,10 +41,10 @@ if [ "$1" = "config" ]; then
 	/bin/df -P -t $TYPES | tail +2 | grep -v "//" | while read i; do
 		case $i in
 		mfs:*) name=mfs$mfs; mfs=`expr $mfs + 1`;;
-		*) name=`echo $i | awk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;
+		*) name=`echo "$i" | awk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;
 		esac
 		echo -n "$name.label "
-		echo $i | awk '{ print $6 }'
+		echo "$i" | awk '{ print $6 }'
 		echo "$name.warning ${warning:-92}"
 		echo "$name.critical ${critical:-98}"
 	done
@@ -55,8 +55,8 @@ mfs=0
 /bin/df -P -t $TYPES | tail +2 | grep -v "//" | while read i; do
 	case $i in
 	mfs:*) name=mfs$mfs; mfs=`expr $mfs + 1`;;
-	*) name=`echo $i | awk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;
+	*) name=`echo "$i" | awk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;
 	esac
 	echo -n "$name.value "
-	echo $i | awk '{ print $5 }' | cut -f1 -d%
+	echo "$i" | awk '{ print $5 }' | cut -f1 -d%
 done

--- a/plugins/node.d.netbsd/df_inode.in
+++ b/plugins/node.d.netbsd/df_inode.in
@@ -23,12 +23,12 @@ print_values() {
     while read i; do
 	case $i in
 	    mfs:*) name=mfs$mfs; mfs=`expr $mfs + 1`;;
-	    *) name=`echo $i | awk '{
+	    *) name=`echo "$i" | awk '{
 		gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'`
 		;;
 	esac
 	echo -n "$name.value "
-	echo $i | awk '{ print $8 }' | cut -f1 -d%
+	echo "$i" | awk '{ print $8 }' | cut -f1 -d%
     done
 }
 

--- a/plugins/node.d.netbsd/uptime.in
+++ b/plugins/node.d.netbsd/uptime.in
@@ -45,7 +45,7 @@ fi
 boottime=`/sbin/sysctl -n kern.boottime`
 now=`/bin/date +%s`
 
-awk -v boottime=$boottime -v now=$now </dev/null '
+awk -v "boottime=$boottime" -v "now=$now" </dev/null '
 END {
     printf "uptime.value %.2f\n", (now - boottime) / 86400;
 }'

--- a/plugins/node.d.sunos/cpu.in
+++ b/plugins/node.d.sunos/cpu.in
@@ -26,7 +26,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if [ -x /usr/bin/kstat ]; then

--- a/plugins/node.d.sunos/df.in
+++ b/plugins/node.d.sunos/df.in
@@ -43,7 +43,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 DF=${df:-/usr/sbin/df}
 TAIL=/usr/bin/tail
@@ -67,12 +67,13 @@ if [ "$1" = "config" ]; then
     # device name.  Since the plugin already changed names this
     # should be ok.
 
-    $DF -k -l $only | $TAIL +2 | while read dev size used avail pct mnt; do
+    # shellcheck disable=SC2086
+    $DF -k -l ${only:-} | $TAIL +2 | while read -r dev size used avail pct mnt; do
 
 	case $dev:$mnt in
 	    /usr/lib*|ctfs:*|objfs:*|mnttab:*|sharefs:*|*:/cdrom/*|*:/media/*) continue;;
-	    swap:*) name=$(clean_fieldname $mnt);;
-	    *:*)    name=$(clean_fieldname $dev);;
+	    swap:*) name=$(clean_fieldname "$mnt");;
+	    *:*)    name=$(clean_fieldname "$dev");;
 	esac
         echo "$name.label $mnt"
 	print_warning "$name"
@@ -81,11 +82,12 @@ if [ "$1" = "config" ]; then
     exit 0
 fi
 
-$DF -k -l $only | $TAIL +2 | while read dev size used avail pct mnt; do
+# shellcheck disable=SC2034,SC2086
+$DF -k -l ${only:-} | $TAIL +2 | while read -r dev size used avail pct mnt; do
 	case $dev:$mnt in
 	    /usr/lib*|ctfs:*|objfs:*|mnttab:*|sharefs:*|*:/cdrom/*|*:/media/*) continue;;
-	    swap:*) name=$(clean_fieldname $mnt);;
-	    *:*)    name=$(clean_fieldname $dev);;
+	    swap:*) name=$(clean_fieldname "$mnt");;
+	    *:*)    name=$(clean_fieldname "$dev");;
 	esac
         echo "$name.value $pct" | cut -f1 -d% 
 done

--- a/plugins/node.d.sunos/df_inode.in
+++ b/plugins/node.d.sunos/df_inode.in
@@ -44,7 +44,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 DF=${df:-/usr/sbin/df}
 TAIL=/usr/bin/tail

--- a/plugins/node.d.sunos/if_.in
+++ b/plugins/node.d.sunos/if_.in
@@ -40,7 +40,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 INTERFACE=${0##*/if_}
 

--- a/plugins/node.d.sunos/if_err_.in
+++ b/plugins/node.d.sunos/if_err_.in
@@ -40,7 +40,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 INTERFACE=${0##*/if_err_}
 

--- a/plugins/node.d.sunos/io_ops_.in
+++ b/plugins/node.d.sunos/io_ops_.in
@@ -35,23 +35,23 @@ PERL=${PERL:-@@PERL@@}
 
 if [ -z "$FUNCTION" ]; then
 	exit
-elif [ $FUNCTION = "busy" ]; then
+elif [ "$FUNCTION" = "busy" ]; then
 	TITLE="Busy & Wait"
 	IN=rtime
 	INNAME=busy
 	OUT=wtime
-	OUTNAME=wait
+	OUTNAME="wait"
 	CDEF=",100,*"
 	GARGS="--lower-limit 0 --upper-limit 100"
 	VLABEL='%'
-elif [ $FUNCTION = "bytes" ]; then
+elif [ "$FUNCTION" = "bytes" ]; then
 	TITLE="I/O"
 	IN=nread
 	INNAME=$IN
 	OUT=nwritten
 	OUTNAME=$OUT
 	VLABEL='Bytes per second'
-elif [ $FUNCTION = "ops" ]; then
+elif [ "$FUNCTION" = "ops" ]; then
 	TITLE="Operations"
 	IN=reads
 	INNAME=$IN
@@ -80,17 +80,17 @@ if [ "$1" = "suggest" ]; then
 fi
 
 REGEX="$MODULE"
-if [ $MODULE = "sd" ]; then
+if [ "$MODULE" = "sd" ]; then
 	REGEX="/^(s?sd|vdc|zvblk)$/"
 	NAME="Disk Device"
-elif [ $MODULE = "dad" ]; then
+elif [ "$MODULE" = "dad" ]; then
 	NAME="IDE Disk Device"
-elif [ $MODULE = "md" ]; then
+elif [ "$MODULE" = "md" ]; then
 	NAME="Disksuite"
-elif [ $MODULE = "nfs" ]; then
+elif [ "$MODULE" = "nfs" ]; then
 	NAME="NFS"
 	CLASS=nfs
-elif [ $MODULE = "st" ]; then
+elif [ "$MODULE" = "st" ]; then
 	NAME="Tape"
 	CLASS=tape
 else

--- a/plugins/node.d.sunos/load.in
+++ b/plugins/node.d.sunos/load.in
@@ -44,7 +44,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
         echo 'yes'

--- a/plugins/node.d.sunos/memory.in
+++ b/plugins/node.d.sunos/memory.in
@@ -59,7 +59,7 @@ Fixme: Using kstat would be much better
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 TOP=${top:-/usr/local/bin/top}
 

--- a/plugins/node.d.sunos/paging_in.in
+++ b/plugins/node.d.sunos/paging_in.in
@@ -26,7 +26,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if [ -x /usr/bin/kstat ]; then

--- a/plugins/node.d.sunos/paging_out.in
+++ b/plugins/node.d.sunos/paging_out.in
@@ -26,7 +26,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if [ -x /usr/bin/kstat ]; then

--- a/plugins/node.d/amavis.in
+++ b/plugins/node.d/amavis.in
@@ -56,9 +56,6 @@ classify more spam as "surley spam" and so be able to elliminate it.
   #%# family=auto
   #%# capabilities=autoconf
 
-=head1 VERSION
-
-  $Id$
 
 =head1 BUGS
 
@@ -86,7 +83,7 @@ LOGTAIL=${logtail:-logtail}
 STATEFILE=$MUNIN_PLUGSTATE/amavis.offset
 
 if [ "$1" = "autoconf" ]; then
-        if [ -f "${AMAVIS_LOG}" -a -n "${LOGTAIL}" -a -x "${LOGTAIL}" ] ; then
+	if [ -f "${AMAVIS_LOG}" ] && [ -n "${LOGTAIL}" ] && [ -x "${LOGTAIL}" ] ; then
 		echo yes
 		exit 0
 	else
@@ -131,18 +128,17 @@ then
 	if [ $ARGS != 0 ]; then
 	    $LOGTAIL -f ${AMAVIS_LOG} -o ${STATEFILE} | grep 'amavis\[.*\]:' > ${TEMP_FILE}
 	else
-	    $LOGTAIL ${AMAVIS_LOG} ${STATEFILE} | grep 'amavis\[.*\]:' > ${TEMP_FILE}
+	    "$LOGTAIL" "${AMAVIS_LOG}" "${STATEFILE}" | grep 'amavis\[.*\]:' > "${TEMP_FILE}"
 	fi
-	total=$(grep -c 'Hits:' ${TEMP_FILE})
-	virus=$(grep -c 'INFECTED.*Hits:' ${TEMP_FILE})
-	spamm=$(grep -c 'SPAMMY.*Hits:' ${TEMP_FILE})
-	spams=$(grep -c 'SPAM .*Hits:' ${TEMP_FILE})
+	total=$(grep -c 'Hits:' "$TEMP_FILE")
+	virus=$(grep -c 'INFECTED.*Hits:' "$TEMP_FILE")
+	spamm=$(grep -c 'SPAMMY.*Hits:' "$TEMP_FILE")
+	spams=$(grep -c 'SPAM .*Hits:' "$TEMP_FILE")
 
-	/bin/rm -f $TEMP_FILE
+	/bin/rm -f "$TEMP_FILE"
 fi
 
 echo "virus.value ${virus}"
 echo "spam_maybe.value ${spamm}"
 echo "spam_sure.value ${spams}"
 echo "total.value ${total}"
-

--- a/plugins/node.d/amavis.in
+++ b/plugins/node.d/amavis.in
@@ -73,10 +73,6 @@ GPLv2
 
 =cut
 
-mktempfile () {
-    cmd=`echo $MUNIN_MKTEMP | sed s/\\$1/$1/`
-    $cmd
-}
 
 AMAVIS_LOG=${amavislog:-/var/log/mail/mail.info}
 LOGTAIL=${logtail:-logtail}
@@ -94,7 +90,7 @@ fi
 
 # Try tailing a random file to check how arguments are passed
 ARGS=0
-`$LOGTAIL /etc/hosts 2>/dev/null >/dev/null`
+"$LOGTAIL" /etc/hosts 2>/dev/null >/dev/null
 if [ $? = 66 ]; then
     if [ ! -n "$logtail" ]; then
 	ARGS=1
@@ -121,12 +117,11 @@ virus=U
 spamm=U
 spams=U
 
-TEMP_FILE=$(mktempfile munin-amavis.XXXXXX)
+TEMP_FILE=$(@@MKTEMP@@ munin-amavis.XXXXXX)
 
-if [ -n "$TEMP_FILE" -a -f "$TEMP_FILE" ]
-then
-	if [ $ARGS != 0 ]; then
-	    $LOGTAIL -f ${AMAVIS_LOG} -o ${STATEFILE} | grep 'amavis\[.*\]:' > ${TEMP_FILE}
+if [ -n "$TEMP_FILE" ] && [ -f "$TEMP_FILE" ]; then
+	if [ "$ARGS" != 0 ]; then
+	    "$LOGTAIL" -f "${AMAVIS_LOG}" -o "${STATEFILE}" | grep 'amavis\[.*\]:' > "${TEMP_FILE}"
 	else
 	    "$LOGTAIL" "${AMAVIS_LOG}" "${STATEFILE}" | grep 'amavis\[.*\]:' > "${TEMP_FILE}"
 	fi

--- a/plugins/node.d/apc_envunit_.in
+++ b/plugins/node.d/apc_envunit_.in
@@ -64,16 +64,16 @@ else
   fi
 fi
 
-UNITS=""
-COMMUNITY="public"
-SNMPGET=`which snmpget 2>/dev/null`
+UNITS=${units:-}
+COMMUNITY=${community:-public}
+SNMPGET=$(which snmpget 2>/dev/null)
 
-if [ "$units" ]; then UNITS=$units ; fi
-if [ "$oid" ]; then TOID=$oid ; fi
-if [ "$community" ]; then COMMUNITY=$community ; fi
+if [ -n "${oid:-}" ]; then TOID=$oid ; fi
 
-SNMPOPTS="-Ov -Oq -v1 -c ${COMMUNITY}"
 
+snmp_get() {
+  "$SNMPGET" -Ov -Oq -v1 -c "$COMMUNITY"
+}
 
 
 if [ "$1" = "autoconf" ]; then
@@ -108,9 +108,9 @@ if [ "$1" = "config" ]; then
 fi
 
 for m in ${UNITS} ; do
-  v1=`${SNMPGET} ${SNMPOPTS} $m ${TOID}.1`
-  v2=`${SNMPGET} ${SNMPOPTS} $m ${TOID}.2`
-  mm=`echo ${m} | tr '-' '_'`
+  v1=$(snmp_get "$m" "${TOID}.1")
+  v2=$(snmp_get "$m" "${TOID}.2")
+  mm=$(echo "$m" | tr '-' '_')
   echo "${mm}_${LETTER}1.value $v1"
   echo "${mm}_${LETTER}2.value $v2"
 done

--- a/plugins/node.d/apc_envunit_.in
+++ b/plugins/node.d/apc_envunit_.in
@@ -49,7 +49,7 @@ Unknown
 
 =cut
 
-type=`echo $0 | sed -e 's/.*_\(.*\)/\1/'`
+type=$(echo "$0" | sed -e 's/.*_\(.*\)/\1/')
 if [ "${type}" = temperature ] ; then
   TOID="enterprises.318.1.1.10.3.13.1.1.3"
   NAME="temperature"
@@ -78,13 +78,13 @@ SNMPOPTS="-Ov -Oq -v1 -c ${COMMUNITY}"
 
 if [ "$1" = "autoconf" ]; then
   if [ -z "${UNITS}" ] ; then echo "no (no units to monitor)" ; exit 0 ; fi
-  if [ -z "$SNMPGET" -o ! -x "$SNMPGET" ] ; then 
+  if [ -z "$SNMPGET" ] || [ ! -x "$SNMPGET" ] ; then
       echo "no (no snmpget executable)"
       exit 0
   fi
 
   for m in ${UNITS} ; do
-    if ping -c1 -q $m >/dev/null 2>&1 ; then continue ; fi
+    if ping -c1 -q "$m" >/dev/null 2>&1; then continue; fi
     echo "no (can't reach $m)" ; exit 0
   done
   echo "yes" ; exit 0
@@ -100,7 +100,7 @@ if [ "$1" = "config" ]; then
   echo "graph_title Environmental units (${NAME} probes)"
   echo "graph_vlabel ${LABEL}"
   for m in ${UNITS} ; do
-    mm=`echo ${m} | tr '-' '_'`
+    mm=$(echo "$m" | tr '-' '_')
     echo "${mm}_${LETTER}1.label $m ${NAME} #1"
     echo "${mm}_${LETTER}2.label $m ${NAME} #2"
   done

--- a/plugins/node.d/courier_.in
+++ b/plugins/node.d/courier_.in
@@ -57,9 +57,6 @@ SERVICE=${service:-$(basename "$0" | sed 's/^courier_//g')}
 OFFSET_FILE=${MUNIN_PLUGSTATE}/courier_${SERVICE}.offset
 LOGTAIL=${logtail:-/usr/sbin/logtail}
 
-mktempfile () {
-@@MKTEMP@@
-}
 
 case $1 in
     autoconf|detect)
@@ -88,14 +85,14 @@ EOF
 esac
 
 ARGS=0
-`$LOGTAIL /etc/hosts 2>/dev/null >/dev/null`
+"$LOGTAIL" /etc/hosts 2>/dev/null >/dev/null
 if [ $? = 66 ]; then
     if [ ! -n "$logtail" ]; then
         ARGS=1
     fi
 fi
 
-TEMP_FILE=`mktempfile munin-courier.XXXXXX`
+TEMP_FILE=$(@@MKTEMP@@ munin-courier.XXXXXX)
 
 if [ -z "$TEMP_FILE" ] || [ ! -f "$TEMP_FILE" ]; then
     exit 3

--- a/plugins/node.d/courier_.in
+++ b/plugins/node.d/courier_.in
@@ -53,7 +53,7 @@ Unknown
 
 # Set the location of the courier logs
 COURIER_LOG=${logfile:-/var/log/mail.log}
-SERVICE=${service:-`basename $0 | sed 's/^courier_//g'`}
+SERVICE=${service:-$(basename "$0" | sed 's/^courier_//g')}
 OFFSET_FILE=${MUNIN_PLUGSTATE}/courier_${SERVICE}.offset
 LOGTAIL=${logtail:-/usr/sbin/logtail}
 
@@ -63,8 +63,7 @@ mktempfile () {
 
 case $1 in
     autoconf|detect)
-    if [ -f ${COURIER_LOG} -a -x ${LOGTAIL} ] 
-    then
+    if [ -f "$COURIER_LOG" ] &&  [ -x "$LOGTAIL" ]; then
 	# Makes no sense for wildcard plugin to autoconf to yes
 	# unless you can provide suggestions.
 	echo no
@@ -98,21 +97,21 @@ fi
 
 TEMP_FILE=`mktempfile munin-courier.XXXXXX`
 
-if [ -z "$TEMP_FILE" -o ! -f "$TEMP_FILE" ]; then
+if [ -z "$TEMP_FILE" ] || [ ! -f "$TEMP_FILE" ]; then
     exit 3
 fi
 
-if [ $ARGS != 0 ]; then
-    ${LOGTAIL} -f ${COURIER_LOG} -o ${OFFSET_FILE} | grep "$SERVICE" > ${TEMP_FILE}
+if [ "$ARGS" != 0 ]; then
+    "$LOGTAIL" -f "${COURIER_LOG}" -o "${OFFSET_FILE}" | grep "$SERVICE" > "$TEMP_FILE"
 else
-    ${LOGTAIL} ${COURIER_LOG} ${OFFSET_FILE} | grep "$SERVICE" > ${TEMP_FILE}
+    "$LOGTAIL" "${COURIER_LOG}" "${OFFSET_FILE}" | grep "$SERVICE" > "$TEMP_FILE"
 fi
-connection=`grep Connection ${TEMP_FILE} | wc -l`
-disconnected=`grep DISCONNECTED ${TEMP_FILE} | wc -l`
-login=`grep LOGIN ${TEMP_FILE} | wc -l`
-logout=`grep LOGOUT ${TEMP_FILE} | wc -l`
+connection=$(grep Connection "$TEMP_FILE" | wc -l)
+disconnected=$(grep DISCONNECTED "$TEMP_FILE" | wc -l)
+login=$(grep LOGIN "$TEMP_FILE" | wc -l)
+logout=$(grep LOGOUT "$TEMP_FILE" | wc -l)
 
-rm ${TEMP_FILE}
+rm "$TEMP_FILE"
 
 echo "connection.value ${connection}"
 echo "disconnected.value ${disconnected}"

--- a/plugins/node.d/courier_mta_mailqueue.in
+++ b/plugins/node.d/courier_mta_mailqueue.in
@@ -42,7 +42,7 @@ SPOOLDIR=${spooldir:-/var/lib/courier/msgq/}
 
 case $1 in
     autoconf|detect)
-	if [ -d $SPOOLDIR/ -a -r $SPOOLDIR/ ] ; then
+	if [ -d "$SPOOLDIR/" ] && [ -r "$SPOOLDIR/" ] ; then
 	    echo yes
 	    exit 0
         else
@@ -60,7 +60,7 @@ EOF
 	exit 0;;
 esac
 
-cd $SPOOLDIR >/dev/null 2>/dev/null || {
+cd "$SPOOLDIR" >/dev/null 2>/dev/null || {
      echo "# Cannot cd to $SPOOLDIR"
      exit 1
 }

--- a/plugins/node.d/digitemp_.in
+++ b/plugins/node.d/digitemp_.in
@@ -44,11 +44,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 =cut
 
+# common values: digitemp_DS2490, digitemp_DS9097, digitemp_DS9097U
 digitemp=${0##*/}
 model=${digitemp##*_}
 digitemprc=${digitemprc:-/etc/digitemp.conf}
 
-if ! [ -x "`which $digitemp`" ]; then
+if ! [ -x "$(which "$digitemp")" ]; then
     echo "$digitemp not found" >&2
     exit 1
 fi
@@ -58,7 +59,7 @@ if [ "$1" = "config" ]; then
     echo 'graph_vlabel degrees C'
     echo 'graph_category sensors'
     echo "graph_info This graph shows the temperature read from $model 1-wire sensors"
-    $digitemp -c "$digitemprc" -q -a -o '%s %R' | grep -v ^Found | while read sensor serial; do
+    $digitemp -c "$digitemprc" -q -a -o '%s %R' | grep -v ^Found | while read -r sensor serial; do
 	echo "sensor$serial.label sensor #$sensor"
 	echo "sensor$serial.type GAUGE"
 	echo "sensor$serial.info Temperature from sensor #$sensor"

--- a/plugins/node.d/ejabberd_.in
+++ b/plugins/node.d/ejabberd_.in
@@ -149,9 +149,9 @@ parse_vhosts_from_config_yaml() {
     local vhosts
     # try to parse a single-line yaml list, e.g.:
     #   hosts: ["foo.example.org", 'bar.example.com']
-    vhosts=$(grep -E "^hosts:\s*\[" "$filename" \
+    vhosts=$(grep -E '^hosts:\s*\[' "$filename" \
         | sed -E 's/^.*\[(.+)].*$/\1/' \
-        | tr "," "\n" \
+        | tr ',' '\n' \
         | sed -E 's/^.*["'\''](.+)["'\''].*$/\1/')
     if [ -z "$vhosts" ]; then
         # try to parse a multi-line yaml list, e.g.:
@@ -160,7 +160,7 @@ parse_vhosts_from_config_yaml() {
         #      - 'bar.example.com'
         vhosts=$(grep -vE '^(\s*#|$)' "$filename" \
             | sed -n '/^hosts:$/,/^\w/p;' \
-            | grep "^\s*-" \
+            | grep '^\s*-' \
             | sed -E 's/^.+["'\''](.*)["'\'']\s*$/\1/')
     fi
     echo "$vhosts"
@@ -207,7 +207,7 @@ parse_vhosts_from_config() {
         return 1
     else
         # we found a config (or its location was specified)
-        if echo "$configfile" | grep -qi "\.cfg$"; then
+        if echo "$configfile" | grep -qi '\.cfg$'; then
             vhosts=$(parse_vhosts_from_config_cfg "$configfile")
         else
             vhosts=$(parse_vhosts_from_config_yaml "$configfile")

--- a/plugins/node.d/fail2ban.in
+++ b/plugins/node.d/fail2ban.in
@@ -42,8 +42,7 @@ displayed.
 
 =head1 BUGS
 
-Needs bash. Uses bashisms ${parm/?/pat/string} and $'...' to avoid
-running external programs.
+Needs bash, due zo using bashisms to avoid running external programs.
 
 =head1 AUTHOR
 
@@ -65,13 +64,12 @@ client=${client:-/usr/bin/fail2ban-client}
 
 # List jails, one on each line
 list_jails() {
-    ${client} status | while read line
-    do
+    "$client" status | while read -r line; do
         case $line in
             *'Jail list:'*)
                 line="${line##*Jail list*:}"
                 line="${line//[ $'\t']/}"
-                [ -n "$line" ] && printf "${line//,/$'\n'}\n"
+                if [ -n "$line" ]; then echo "${line//,/$'\n'}"; fi
                 ;;
         esac
     done
@@ -79,15 +77,13 @@ list_jails() {
 
 # Print the munin values
 values() {
-    list_jails | while read jail
-    do
-        ${client} status ${jail} | while read line
-        do
+    list_jails | while read -r jail; do
+        "$client" status "$jail" | while read -r line; do
             case $line in
                 *'Currently banned'*)
                     line="${line##*Currently banned:}"
                     num="${line//[ $'\t']/}"
-                    echo ${jail//[^0-9A-Za-z]/_}.value ${num}
+                    echo "${jail//[^0-9A-Za-z]/_}.value $num"
                     ;;
             esac
         done
@@ -104,20 +100,16 @@ config() {
     echo 'graph_args --base 1000 -l 0'
     echo 'graph_total total'
 
-    list_jails | while read jail
-    do
-        echo ${jail//[^0-9A-Za-z]/_}.label $jail
+    list_jails | while read -r jail; do
+        echo "${jail//[^0-9A-Za-z]/_}.label $jail"
     done
 }
 
 # Print autoconfiguration hint
 autoconf() {
-    if [ -e ${client} ]
-    then
-        if [ -x ${client} ]
-        then
-            if ${client} ping >/dev/null
-            then
+    if [ -e "$client" ]; then
+        if [ -x "$client" ]; then
+            if "$client" ping >/dev/null; then
                 echo "yes"
             else
                 echo "no (fail2ban-server does not respond to ping)"

--- a/plugins/node.d/foldingathome.in
+++ b/plugins/node.d/foldingathome.in
@@ -13,23 +13,16 @@
 #%# family=contrib
 #%# capabilities=autoconf
 
-PATH=/usr/local/fah
-FILE=${file:=unitinfo.txt}
+FOLDING_PATH=/usr/local/fah
+data_filename=$FOLDING_PATH/${file:-unitinfo.txt}
 
 if [ "$1" = "autoconf" ]; then
-    if ( cat $PATH/$FILE 2>/dev/null >/dev/null ); then
+    if [ -r "$data_filename" ]; then
         echo yes
-        exit 0
     else
-        if [ $? -eq 127 ]
-        then
-            echo "no (F@H not found)"
-            exit 0
-        else
-            echo no
-            exit 0
-        fi
+        echo "no (F@H file '$data_filename' not found)"
     fi
+    exit 0
 fi
 
 if [ "$1" = "config" ]; then
@@ -39,8 +32,8 @@ if [ "$1" = "config" ]; then
     echo 'graph_vlabel % finished'
     echo 'done.label done folding'
     echo 'done.type GAUGE'
-    echo 'done.max 100'''
+    echo 'done.max 100'
     exit 0
 fi
 
-echo `/bin/grep "Progress" $PATH/$FILE | /bin/sed 's/^.*: \(.*\)%.*/done.value \1/'`
+grep "Progress" "$data_filename" | /bin/sed 's/^.*: \(.*\)%.*/done.value \1/'

--- a/plugins/node.d/foldingathome_rank.in
+++ b/plugins/node.d/foldingathome_rank.in
@@ -23,23 +23,21 @@ if [ "$1" = "autoconf" ]; then
 fi
 
 if [ "$1" = "config" ]; then
-
     echo 'graph_title Folding@Home Rank'
     echo 'graph_args -l 0 --base 1000'
     echo 'graph_vlabel rank'
     echo 'rank.label rank'
     echo 'rank.type GAUGE'
-    echo 'rank.max 12000'''
+    echo 'rank.max 12000'
     exit 0
 fi
 
-rank=`wget "http://vspx27.stanford.edu/cgi-bin/main.py?qtype=userpage&username=8d" -q -t 1 -T 5 -O - | egrep "<TD> <font size=3> <b> [0-9]* </b> of [0-9]* </font></TD>" | sed 's/.*<font size=3> <b> \([0-9]*\) .*/\1/'`
-if [ "$rank" = "" ]; then
-	if [ -f $statefile ]; then
-		echo rank.value `cat $statefile`
+rank=$(wget "http://vspx27.stanford.edu/cgi-bin/main.py?qtype=userpage&username=8d" -q -t 1 -T 5 -O - | grep -E "<TD> <font size=3> <b> [0-9]* </b> of [0-9]* </font></TD>" | sed 's/.*<font size=3> <b> \([0-9]*\) .*/\1/')
+if [ -z "$rank" ]; then
+	if [ -f "$statefile" ]; then
+		echo "rank.value $(cat "$statefile")"
 	fi
 else
-	echo $rank > $statefile
-	echo rank.value $rank
+	echo "$rank" >"$statefile"
+	echo "rank.value $rank"
 fi
-

--- a/plugins/node.d/foldingathome_wu.in
+++ b/plugins/node.d/foldingathome_wu.in
@@ -43,7 +43,6 @@ if [ "$1" = "autoconf" ]; then
 fi
 
 if [ "$1" = "config" ]; then
-
     echo 'graph_title Folding@Home Working Units submited'
     echo 'graph_args -l 0 --base 1000'
     echo 'graph_vlabel WU done'
@@ -52,14 +51,13 @@ if [ "$1" = "config" ]; then
     exit 0
 fi
 
-wu=$(wget "http://vspx27.stanford.edu/cgi-bin/main.py?qtype=userpage&username=8d" -q -t 1 -T 5 -O - | egrep -A 2 "<TD> WU</TD>" | grep "<b>" | sed 's/.*<b> \([0-9]*\) .*/\1/')
+wu=$(wget "http://vspx27.stanford.edu/cgi-bin/main.py?qtype=userpage&username=8d" -q -t 1 -T 5 -O - | grep -E -A 2 "<TD> WU</TD>" | grep "<b>" | sed 's/.*<b> \([0-9]*\) .*/\1/')
 
-if [ "$wu" = "" ]; then
-	if [ -f $statefile ]; then
-		echo wu.value `cat $statefile`
+if [ -z "$wu" ]; then
+	if [ -f "$statefile" ]; then
+		echo "wu.value $(cat "$statefile")"
 	fi
 else
-	echo $wu > $statefile
-	echo wu.value $wu
+	echo "$wu" > "$statefile"
+	echo "wu.value $wu"
 fi
-

--- a/plugins/node.d/freeradius_acct.in
+++ b/plugins/node.d/freeradius_acct.in
@@ -43,7 +43,7 @@ Copyright (C) 2008 Alan DeKok <aland@deployingradius.com>
 
 =cut
 
-RADMIN=${radmin:-`which radmin 2>/dev/null`}
+RADMIN=${radmin:-$(which radmin 2>/dev/null)}
 RADMIN=${RADMIN:-/usr/sbin/radmin}
 SOCKETFILE=${socketfile:-/var/run/radiusd/radiusd.sock}
 
@@ -59,6 +59,7 @@ if [ "$1" = "config" ]; then
     echo 'graph_title FreeRADIUS Accounting Requests'
     echo 'graph_args --base 1000 -l 0 '
     echo 'graph_period second'
+    # shellcheck disable=SC2016
     echo 'graph_vlabel requests / ${graph_period}'
     echo 'graph_category Other'
 
@@ -105,4 +106,4 @@ if [ "$1" = "config" ]; then
     exit 0
 fi
 
-$RADMIN -f $SOCKETFILE -e "stats client acct" | awk '{print $1".value " $2}'
+$RADMIN -f "$SOCKETFILE" -e "stats client acct" | awk '{print $1".value " $2}'

--- a/plugins/node.d/freeradius_auth.in
+++ b/plugins/node.d/freeradius_auth.in
@@ -43,7 +43,7 @@ Copyright (C) 2008 Alan DeKok <aland@deployingradius.com>
 
 =cut
 
-RADMIN=${radmin:-`which radmin 2>/dev/null`}
+RADMIN=${radmin:-$(which radmin 2>/dev/null)}
 RADMIN=${RADMIN:-/usr/sbin/radmin}
 SOCKETFILE=${socketfile:-/var/run/radiusd/radiusd.sock}
 
@@ -59,6 +59,7 @@ if [ "$1" = "config" ]; then
     echo 'graph_title FreeRADIUS Authentication Requests'
     echo 'graph_args --base 1000 -l 0 '
     echo 'graph_period second'
+    # shellcheck disable=SC2016
     echo 'graph_vlabel requests / ${graph_period}'
     echo 'graph_category Other'
 
@@ -120,4 +121,4 @@ if [ "$1" = "config" ]; then
     exit 0
 fi
 
-$RADMIN -f $SOCKETFILE -e "stats client auth" | awk '{print $1".value " $2}'
+$RADMIN -f "$SOCKETFILE" -e "stats client auth" | awk '{print $1".value " $2}'

--- a/plugins/node.d/freeradius_proxy_acct.in
+++ b/plugins/node.d/freeradius_proxy_acct.in
@@ -43,7 +43,7 @@ Copyright (C) 2008 Alan DeKok <aland@deployingradius.com>
 
 =cut
 
-RADMIN=${radmin:-`which radmin 2>/dev/null`}
+RADMIN=${radmin:-$(which radmin 2>/dev/null)}
 RADMIN=${RADMIN:-/usr/sbin/radmin}
 SOCKETFILE=${socketfile:-/var/run/radiusd/radiusd.sock}
 
@@ -59,6 +59,7 @@ if [ "$1" = "config" ]; then
     echo 'graph_title FreeRADIUS Proxied Accounting Requests'
     echo 'graph_args --base 1000 -l 0 '
     echo 'graph_period second'
+    # shellcheck disable=SC2016
     echo 'graph_vlabel requests / ${graph_period}'
     echo 'graph_category Other'
 
@@ -105,4 +106,4 @@ if [ "$1" = "config" ]; then
     exit 0
 fi
 
-$RADMIN -f $SOCKETFILE -e "stats home_server acct" | awk '{print $1".value " $2}'
+$RADMIN -f "$SOCKETFILE" -e "stats home_server acct" | awk '{print $1".value " $2}'

--- a/plugins/node.d/freeradius_proxy_auth.in
+++ b/plugins/node.d/freeradius_proxy_auth.in
@@ -43,7 +43,7 @@ Copyright (C) 2008 Alan DeKok <aland@deployingradius.com>
 
 =cut
 
-RADMIN=${radmin:-`which radmin 2>/dev/null`}
+RADMIN=${radmin:-$(which radmin 2>/dev/null)}
 RADMIN=${RADMIN:-/usr/sbin/radmin}
 SOCKETFILE=${socketfile:-/var/run/radiusd/radiusd.sock}
 
@@ -59,6 +59,7 @@ if [ "$1" = "config" ]; then
     echo 'graph_title FreeRADIUS Proxied Authentication Requests'
     echo 'graph_args --base 1000 -l 0 '
     echo 'graph_period second'
+    # shellcheck disable=SC2016
     echo 'graph_vlabel requests / ${graph_period}'
     echo 'graph_category Other'
 
@@ -120,4 +121,4 @@ if [ "$1" = "config" ]; then
     exit 0
 fi
 
-$RADMIN -f $SOCKETFILE -e "stats home_server auth" | awk '{print $1".value " $2}'
+$RADMIN -f "$SOCKETFILE" -e "stats home_server auth" | awk '{print $1".value " $2}'

--- a/plugins/node.d/hddtemp.in
+++ b/plugins/node.d/hddtemp.in
@@ -35,5 +35,4 @@ if [ "$1" = "config" ]; then
         exit 0
 fi
 
-for a in $drives ; do printf "$a.value $(hddtemp -n -q /dev/$a)\n" ; done
-
+for a in $drives ; do printf '%s.value %s\n' "$a" "$(hddtemp -n -q "/dev/$a")" ; done

--- a/plugins/node.d/hddtemp.in
+++ b/plugins/node.d/hddtemp.in
@@ -12,6 +12,7 @@
 #
 #%# family=contrib
 
+drives=${drives:-}
 HDDTEMP=/usr/sbin/hddtemp
 
 if [ "$1" = "autoconf" ]; then
@@ -30,7 +31,7 @@ if [ "$1" = "config" ]; then
         echo 'graph_args --base 1000 -l 0'
         echo 'graph_vlabel Degrees Celsius'
         echo 'graph_category sensors'
-        for a in $drives ; do echo $a.label $a ; done
+        for a in $drives ; do echo "$a.label $a"; done
         exit 0
 fi
 

--- a/plugins/node.d/ipac-ng.in
+++ b/plugins/node.d/ipac-ng.in
@@ -62,13 +62,12 @@ if [ "$1" = "config" ]; then
         exit 0
 fi;
 
-fetchipac || error=1  
-if [ "$error" != "1" ]; then
+if fetchipac; then
         ipacsum -s 5m -x -f "$UP" | tail -n 1 | cut -d : -f 2 | awk \
-                {'print "up.value " $1'}                             
+                '{print "up.value " $1}'                             
         ipacsum -s 5m -x -f "$DOWN" | tail -n 1 | cut -d : -f 2 | awk \
-                {'print "down.value " $1'}                             
+                '{print "down.value " $1}'                             
 else
-        echo 'up.value 0'
-        echo 'down.value 0'
+        echo 'up.value U'
+        echo 'down.value U'
 fi

--- a/plugins/node.d/mbmon_.in
+++ b/plugins/node.d/mbmon_.in
@@ -21,10 +21,14 @@
 #%# family=contrib
 #%# capabilities=autoconf suggest
 
-what=`basename $0 | sed 's/^mbmon_//g'`
+what=$(basename "$0" | sed 's/^mbmon_//g')
+mbmon=${mbmon:-$(which mbmon)}
+
 
 if [ "$1" = "suggest" ]; then
-	printf "TEMP\nFAN\nVoltage\n"
+	echo 'TEMP'
+	echo 'FAN'
+	echo 'Voltage'
 	exit 0
 fi
 
@@ -100,7 +104,3 @@ case $what in
 		exit 0
 		;;
 esac
-
-
-
-

--- a/plugins/node.d/mbmon_.in
+++ b/plugins/node.d/mbmon_.in
@@ -33,16 +33,12 @@ if [ "$1" = "suggest" ]; then
 fi
 
 if [ "$1" = "autoconf" ]; then
-	if $mbmon -c 1 > /dev/null 2>/dev/null ; then
-		printf "yes\n"
-		exit 0
+	if [ -z "$mbmon" ] || [ ! -x "$mbmon" ]; then
+		echo "no (executable 'mbmon' not found)"
+	elif "$mbmon" -c 1 > /dev/null 2>/dev/null; then
+		echo "yes"
 	else
-		if [ $?=127 ] ;then
-			echo "no (executable not found)"
-		else
-			echo "no (mbmon could not read sensor values)"
-		fi
-		exit 0
+		echo "no (mbmon could not read sensor values)"
 	fi
 	exit 0
 fi

--- a/plugins/node.d/multiping.in
+++ b/plugins/node.d/multiping.in
@@ -54,10 +54,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 =cut
 
-if [ -z "$host" ]; then
-    file_host=$(basename $0 | sed 's/^ping_//g')
-    host=${host:-${file_host:-www.google.com}}
-fi
+
+host=${host:-www.google.com}
+
 
 if [ "$1" = "config" ]; then
     echo graph_title Ping times

--- a/plugins/node.d/multiping.in
+++ b/plugins/node.d/multiping.in
@@ -78,8 +78,9 @@ fi
 for hosts in $host 
 do
     export site=$((site + 1))
-    ${ping:-ping} ${ping_args:-'-c 2'} ${hosts} ${ping_args2} \
-	| perl -n -e 'print "site$ENV{'site'}.value ", $1 / 1000, "\n" 
-        if m@min/avg/max.*\s\d+(?:\.\d+)?/(\d+(?:\.\d+)?)/\d+(?:\.\d+)?@; 
-        print "site$ENV{'site'}_packetloss.value $1\n" if /(\d+)% packet loss/;'
+    # shellcheck disable=SC2086
+    "${ping:-ping}" ${ping_args:-'-c 2'} ${hosts} ${ping_args2:-} \
+        | perl -n -e 'print "site$ENV{site}.value ", $1 / 1000, "\n"
+            if m@min/avg/max.*\s\d+(?:\.\d+)?/(\d+(?:\.\d+)?)/\d+(?:\.\d+)?@;
+            print "site$ENV{site}_packetloss.value $1\n" if /(\d+)% packet loss/;'
 done

--- a/plugins/node.d/multiping.in
+++ b/plugins/node.d/multiping.in
@@ -65,7 +65,7 @@ if [ "$1" = "config" ]; then
     echo 'graph_category network'
     echo 'graph_info This graph shows ping RTT statistics.'
     for hosts in $host; do
-	site=`expr $site + 1`
+        site=$((site + 1))
 	echo "site$site.label $hosts"
 	echo "site$site.info Ping RTT statistics for $hosts."
 	echo "site$site.draw LINE2"
@@ -77,7 +77,7 @@ fi
 
 for hosts in $host 
 do
-    export site=$(expr $site + 1)
+    export site=$((site + 1))
     ${ping:-ping} ${ping_args:-'-c 2'} ${hosts} ${ping_args2} \
 	| perl -n -e 'print "site$ENV{'site'}.value ", $1 / 1000, "\n" 
         if m@min/avg/max.*\s\d+(?:\.\d+)?/(\d+(?:\.\d+)?)/\d+(?:\.\d+)?@; 

--- a/plugins/node.d/multips.in
+++ b/plugins/node.d/multips.in
@@ -35,9 +35,6 @@ interpreted by "grep" (and not egrep or perl).
   #%# family=manual
   #%# capabilities=autoconf
 
-=head1 VERSION
-
-  $Id$
 
 =head1 BUGS
 
@@ -54,6 +51,10 @@ GPLv2
 =cut
 
 . "$MUNIN_LIBDIR/plugins/plugin.sh"
+
+
+names=${names:-}
+
 
 if [ "$1" = "autoconf" ]; then
 	if [ -z "$names" ]; then
@@ -76,8 +77,8 @@ if [ "$1" = "config" ]; then
 	echo 'graph_category processes'
 	echo 'graph_args --base 1000 --vertical-label processes -l 0'
 	for name in $names; do
-	    	fieldname=$(clean_fieldname $name)
-		eval REGEX='"${regex_'$name'-\<'$name'\>}"'
+		fieldname=$(clean_fieldname "$name")
+		eval REGEX='"${regex_'"$name"'-\<'"$name"'\>}"'
 
 		echo "$fieldname.label $name"
 		echo "$fieldname.draw LINE2"
@@ -89,13 +90,13 @@ if [ "$1" = "config" ]; then
 fi
 
 for name in $names; do
-        fieldname=$(clean_fieldname $name)
-	printf "$fieldname.value "
+        fieldname=$(clean_fieldname "$name")
+	printf "%s.value " "$fieldname"
 
-	eval REGEX='"${regex_'$name'-\<'$name'\>}"'
+	eval REGEX='"${regex_'"$name"'-\<'"$name"'\>}"'
 	PGREP=$(which pgrep)
-	if [ -n "$PGREP" -a -x "$PGREP" ]; then
-		$PGREP -f -l "$name" | grep "$REGEX" | wc -l
+	if [ -n "$PGREP" ] && [ -x "$PGREP" ]; then
+		"$PGREP" -f -l "$name" | grep "$REGEX" | wc -l
 	elif [ -x /usr/ucb/ps ]; then
 		# Solaris without pgrep. How old is that?
 		/usr/ucb/ps auxwww | grep "$REGEX" | grep -v grep | wc -l

--- a/plugins/node.d/multips.in
+++ b/plugins/node.d/multips.in
@@ -59,10 +59,9 @@ names=${names:-}
 if [ "$1" = "autoconf" ]; then
 	if [ -z "$names" ]; then
 		echo "no (Configuration required)"
-		exit 0
+	else
+		echo yes
 	fi
-
-	echo yes
 	exit 0
 fi
 

--- a/plugins/node.d/multips.in
+++ b/plugins/node.d/multips.in
@@ -53,7 +53,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if [ -z "$names" ]; then

--- a/plugins/node.d/multips_memory.in
+++ b/plugins/node.d/multips_memory.in
@@ -104,11 +104,10 @@ names=${names:-}
 
 if [ "$1" = "autoconf" ]; then
     if [ -z "$names" ]; then
-	echo "no (Configuration required)"
-	exit 0
+        echo "no (Configuration required)"
+    else
+        echo yes
     fi
-
-    echo yes
     exit 0
 fi
 

--- a/plugins/node.d/multips_memory.in
+++ b/plugins/node.d/multips_memory.in
@@ -99,7 +99,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
     if [ -z "$names" ]; then

--- a/plugins/node.d/multips_memory.in
+++ b/plugins/node.d/multips_memory.in
@@ -70,7 +70,6 @@ all processes matching the process name, as reported by ps.
 
   0.1 first release, based on multips as distributed in Debian.
 
-  $Id $
 
 =head1 BUGS AND RESTRICTIONS
 
@@ -101,6 +100,8 @@ GPLv2
 
 . "$MUNIN_LIBDIR/plugins/plugin.sh"
 
+names=${names:-}
+
 if [ "$1" = "autoconf" ]; then
     if [ -z "$names" ]; then
 	echo "no (Configuration required)"
@@ -119,7 +120,7 @@ fi
 monitor=${monitor:-rss}
 
 if [ "$1" = "config" ]; then
-	echo graph_title Process $monitor summed by name
+	echo "graph_title Process $monitor summed by name"
 	echo 'graph_category processes'
 	echo 'graph_args --base 1024 -l 0'
 	echo 'graph_vlabel memory'
@@ -137,7 +138,7 @@ fi
 for name in $names; do
         fieldname="$(clean_fieldname "$name")"
 
-	ps -eo $monitor,comm | gawk '
+	ps -eo "$monitor,comm" | gawk '
 BEGIN              { total = "U"; } # U = Unknown. 
 /grep/             { next; }
 $2 ~ /^'"$name"'$/ { total = total + ($1*1024); }

--- a/plugins/node.d/munin_update.in
+++ b/plugins/node.d/munin_update.in
@@ -77,7 +77,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ -z "$UPDATE_STATSFILE" ]; then
     UPDATE_STATSFILE="$MUNIN_DBDIR/munin-update.stats"

--- a/plugins/node.d/munin_update.in
+++ b/plugins/node.d/munin_update.in
@@ -58,9 +58,6 @@ Munin-update removes the "domain" information on all hosts.  If there
 are two hosts with the same host name in different domains then one of
 them will be disappeared by the munin-update collection process.
 
-=head1 VERSION
-
-  $Id$
 
 =head1 AUTHOR
 
@@ -109,8 +106,8 @@ if [ "$1" = "config" ]; then
 	echo 'graph_vlabel seconds'
 	echo 'graph_category munin'
 	echo 'graph_info This graph shows the time it takes to collect data from each hosts that munin collects data on. Munin-master is run from cron every 5 minutes and we want each of the munin-update runs to complete before the next one starts.  If munin-update uses too long time to run on one host run it with --debug to determine which plugin(s) are slow and solve the problem with them if possible.'
-	sed '/^UD|/!d; s/.*;//; s/|/ /;' < $UPDATE_STATSFILE | sort | 
-	while read i j; do
+	sed '/^UD|/!d; s/.*;//; s/|/ /;' < "$UPDATE_STATSFILE" | sort |
+	while read -r i j; do
             name="$(clean_fieldname "$i")"
 	    echo "$name.label $i"
 	    echo "$name.warning 240"
@@ -119,14 +116,14 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-[ -f $UPDATE_STATSFILE ] || {
+[ -f "$UPDATE_STATSFILE" ] || {
     echo 'error.value 1'
     echo "error.extinfo Plugin cannot read stats file $UPDATE_STATSFILE"
     exit 0
 }
 
-sed '/^UD|/!d; s/.*;//; s/|/ /;' < $UPDATE_STATSFILE | sort | 
-while read i j; do
+sed '/^UD|/!d; s/.*;//; s/|/ /;' < "$UPDATE_STATSFILE" | sort |
+while read -r i j; do
         name="$(clean_fieldname "$i")"
 	echo "$name.value $j"
 done

--- a/plugins/node.d/munin_update.in
+++ b/plugins/node.d/munin_update.in
@@ -76,13 +76,10 @@ GPLv2
 
 . "$MUNIN_LIBDIR/plugins/plugin.sh"
 
-if [ -z "$UPDATE_STATSFILE" ]; then
-    UPDATE_STATSFILE="$MUNIN_DBDIR/munin-update.stats"
-fi
 
-if [ -z "$MUNIN_UPDATE_LOCATION" ]; then
-    MUNIN_UPDATE_LOCATION="$MUNIN_LIBDIR/munin-update";
-fi
+UPDATE_STATSFILE=${UPDATE_STATSFILE:-$MUNIN_DBDIR/munin-update.stats}
+MUNIN_UPDATE_LOCATION=${MUNIN_UPDATE_LOCATION:-$MUNIN_LIBDIR/munin-update}
+
 
 if [ "$1" = "autoconf" ]; then
 	if [ -e "$MUNIN_UPDATE_LOCATION" ] ; then

--- a/plugins/node.d/mysql_bytes.in
+++ b/plugins/node.d/mysql_bytes.in
@@ -33,7 +33,7 @@ GPLv2
 
 =cut
 
-MYSQLOPTS="$mysqlopts";
+MYSQLOPTS="${mysqlopts:-}"
 MYSQLADMIN=${mysqladmin:-mysqladmin}
 
 if [ "$1" = "autoconf" ]; then
@@ -57,6 +57,7 @@ fi
 if [ "$1" = "config" ]; then
 	echo 'graph_title MySQL throughput'
 	echo 'graph_args --base 1024'
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel bytes received (-) / sent (+) per ${graph_period}'
 	echo 'graph_info Note that this is a old plugin which is no longer installed by default.  It is retained for compatability with old installations.'
 	echo 'graph_category mysql'
@@ -75,4 +76,6 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-($MYSQLADMIN $MYSQLOPTS extended-status 2>/dev/null || ( echo Bytes_sent a a U; echo Bytes_received a a U)) | awk '/Bytes_sent/ { print "sent.value " $4} /Bytes_received/ { print "recv.value " $4}'
+# shellcheck disable=SC2086
+("$MYSQLADMIN" $MYSQLOPTS extended-status 2>/dev/null || ( echo Bytes_sent a a U; echo Bytes_received a a U)) \
+	| awk '/Bytes_sent/ { print "sent.value " $4} /Bytes_received/ { print "recv.value " $4}'

--- a/plugins/node.d/mysql_bytes.in
+++ b/plugins/node.d/mysql_bytes.in
@@ -37,14 +37,10 @@ MYSQLOPTS="${mysqlopts:-}"
 MYSQLADMIN=${mysqladmin:-mysqladmin}
 
 if [ "$1" = "autoconf" ]; then
-	$MYSQLADMIN --version 2>/dev/null >/dev/null
-	if [ $? -eq 0 ]
-	then
-		$MYSQLADMIN $MYSQLOPTS extended-status 2>/dev/null >/dev/null
-		if [ $? -eq 0 ]
-		then
+	if "$MYSQLADMIN" --version 2>/dev/null >/dev/null; then
+		# shellcheck disable=SC2086
+		if "$MYSQLADMIN" $MYSQLOPTS extended-status 2>/dev/null >/dev/null; then
 			echo yes
-			exit 0
 		else
 			echo "no (could not connect to mysql)"
 		fi

--- a/plugins/node.d/mysql_innodb.in
+++ b/plugins/node.d/mysql_innodb.in
@@ -112,26 +112,26 @@ print_config() {
     echo 'free.label Bytes free'
     echo 'free.type GAUGE'
     echo 'free.min 0'
-    echo 'free.warning' $WARNING:
-    echo 'free.critical' $CRITICAL:
+    echo "free.warning $WARNING:"
+    echo "free.critical $CRITICAL:"
     exit 0
 }
 
 print_data() {
-    innodb_free | xargs -r printf "free.value %s\n"
+    innodb_free | xargs -r printf 'free.value %s\n'
 }
 
 check_autoconf() {
 
     # Check client
-    if [ ! -x $MYSQL ]; then
+    if [ ! -x "$MYSQL" ]; then
 	echo "no ($MYSQL not executable)"
 	return 0
     fi
 
     # Check server
     $MEXEC "select(1);" | \
-	while read res; do
+	while read -r res; do
 	    case $res in
 		1)
 		# All is well
@@ -143,8 +143,9 @@ check_autoconf() {
 	    esac
     done
 
+    # shellcheck disable=SC2034
     $MEXEC "SHOW VARIABLES LIKE 'innodb_file_per_table';" | \
-	while read var res; do
+	while read -r var res; do
 	    case $res in
 		OFF)
 		# All is well
@@ -161,7 +162,7 @@ check_autoconf() {
     done
 
     $MEXEC "SELECT count(*) FROM tables WHERE ENGINE = 'InnoDB';" | \
-	while read res; do
+	while read -r res; do
 	    if [ "$res" = "0" ]; then
 		echo "no (No visible tables use InnoDB)"
 		return 0

--- a/plugins/node.d/mysql_innodb.in
+++ b/plugins/node.d/mysql_innodb.in
@@ -99,8 +99,12 @@ MYSQLOPTS="${mysqlopts:---user=munin --password=munin --host=localhost}"
 WARNING=${warning:-2147483648}   # 2GB
 CRITICAL=${critical:-1073741824} # 1GB
 
-# Convenient variables
-MEXEC="$MYSQL $MYSQLOPTS --batch --skip-column-names --database=information_schema --execute"
+
+mysql_exec() {
+    # shellcheck disable=SC2086
+    "$MYSQL" $MYSQLOPTS --batch --skip-column-names --database=information_schema --execute
+}
+
 
 ## No user serviceable parts below
 print_config() {
@@ -130,7 +134,7 @@ check_autoconf() {
     fi
 
     # Check server
-    $MEXEC "select(1);" | \
+    mysql_exec "select(1);" | \
 	while read -r res; do
 	    case $res in
 		1)
@@ -144,7 +148,7 @@ check_autoconf() {
     done
 
     # shellcheck disable=SC2034
-    $MEXEC "SHOW VARIABLES LIKE 'innodb_file_per_table';" | \
+    mysql_exec "SHOW VARIABLES LIKE 'innodb_file_per_table';" | \
 	while read -r var res; do
 	    case $res in
 		OFF)
@@ -161,7 +165,7 @@ check_autoconf() {
 	    esac
     done
 
-    $MEXEC "SELECT count(*) FROM tables WHERE ENGINE = 'InnoDB';" | \
+    mysql_exec "SELECT count(*) FROM tables WHERE ENGINE = 'InnoDB';" | \
 	while read -r res; do
 	    if [ "$res" = "0" ]; then
 		echo "no (No visible tables use InnoDB)"
@@ -175,14 +179,14 @@ check_autoconf() {
 
 # Get major.minor version of the server
 mysql_version() {
-    $MEXEC "SELECT version();" | awk '{printf "%1.1f", $1}'
+    mysql_exec "SELECT version();" | awk '{printf "%1.1f", $1}'
 }
 
 # InnoDB free bytes for MySQL 5.1 and newer
 innodb_free_new() {
-    t=$($MEXEC "SELECT count(*) FROM tables WHERE ENGINE = 'InnoDB';")
+    t=$(mysql_exec "SELECT count(*) FROM tables WHERE ENGINE = 'InnoDB';")
     if [ "$t" -gt "0" ]; then
-	$MEXEC "SELECT data_free FROM tables WHERE ENGINE = 'InnoDB' LIMIT 1;"
+        mysql_exec "SELECT data_free FROM tables WHERE ENGINE = 'InnoDB' LIMIT 1;"
     else
 	echo >&2 "$0: Error: No visible tables use InnoDB"
 	echo U
@@ -192,7 +196,7 @@ innodb_free_new() {
 
 # InnoDB free bytes for MySQL 5.0 and older
 innodb_free_old() {
-    $MEXEC "SELECT table_comment FROM tables WHERE ENGINE = 'InnoDB' LIMIT 1;" \
+    mysql_exec "SELECT table_comment FROM tables WHERE ENGINE = 'InnoDB' LIMIT 1;" \
 	| awk '/^InnoDB free:/ {print $3 * 1024}'
 }
 

--- a/plugins/node.d/mysql_slowqueries.in
+++ b/plugins/node.d/mysql_slowqueries.in
@@ -33,14 +33,10 @@ MYSQLOPTS=${mysqlopts:-}
 MYSQLADMIN=${mysqladmin:-mysqladmin}
 
 if [ "$1" = "autoconf" ]; then
-        $MYSQLADMIN --version 2>/dev/null >/dev/null
-        if [ $? -eq 0 ]
-        then
-                $MYSQLADMIN $MYSQLOPTS status 2>/dev/null >/dev/null
-                if [ $? -eq 0 ]
-                then
+        if "$MYSQLADMIN" --version 2>/dev/null >/dev/null; then
+                # shellcheck disable=SC2086
+                if "$MYSQLADMIN" $MYSQLOPTS status 2>/dev/null >/dev/null; then
                         echo yes
-                        exit 0
                 else
                         echo "no (could not connect to mysql)"
                 fi

--- a/plugins/node.d/mysql_slowqueries.in
+++ b/plugins/node.d/mysql_slowqueries.in
@@ -29,7 +29,7 @@ GPLv2
 
 =cut
 
-MYSQLOPTS="$mysqlopts"
+MYSQLOPTS=${mysqlopts:-}
 MYSQLADMIN=${mysqladmin:-mysqladmin}
 
 if [ "$1" = "autoconf" ]; then
@@ -53,6 +53,7 @@ fi
 if [ "$1" = "config" ]; then
 	echo 'graph_title MySQL slow queries'
 	echo 'graph_args --base 1000 -l 0'
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel slow queries / ${graph_period}'
 	echo 'graph_category mysql'
 	echo 'graph_info Note that this is a old plugin which is no longer installed by default.  It is retained for compatability with old installations.'
@@ -65,4 +66,5 @@ if [ "$1" = "config" ]; then
 fi
 
 /usr/bin/printf "queries.value "
-($MYSQLADMIN $MYSQLOPTS status 2>/dev/null || echo a a a a a a a a U) | awk '{print $9}'
+# shellcheck disable=SC2086
+("$MYSQLADMIN" $MYSQLOPTS status 2>/dev/null || echo a a a a a a a a U) | awk '{print $9}'

--- a/plugins/node.d/mysql_threads.in
+++ b/plugins/node.d/mysql_threads.in
@@ -46,14 +46,10 @@ MYSQLOPTS=${mysqlopts:-}
 MYSQLADMIN=${mysqladmin:-mysqladmin}
 
 if [ "$1" = "autoconf" ]; then
-        $MYSQLADMIN --version 2>/dev/null >/dev/null
-        if [ $? -eq 0 ]
-        then
-                $MYSQLADMIN $MYSQLOPTS status 2>/dev/null >/dev/null
-                if [ $? -eq 0 ]
-                then
+        if "$MYSQLADMIN" --version 2>/dev/null >/dev/null; then
+                # shellcheck disable=SC2086
+                if "$MYSQLADMIN" $MYSQLOPTS status 2>/dev/null >/dev/null; then
                         echo yes
-                        exit 0
                 else
                         echo "no (could not connect to mysql)"
                 fi

--- a/plugins/node.d/mysql_threads.in
+++ b/plugins/node.d/mysql_threads.in
@@ -42,7 +42,7 @@ munin-node.
 
 =cut
 
-MYSQLOPTS="$mysqlopts"
+MYSQLOPTS=${mysqlopts:-}
 MYSQLADMIN=${mysqladmin:-mysqladmin}
 
 if [ "$1" = "autoconf" ]; then
@@ -75,4 +75,5 @@ if [ "$1" = "config" ]; then
 fi
 
 /usr/bin/printf "threads.value "
-($MYSQLADMIN $MYSQLOPTS status 2>/dev/null || echo 'a a a U') | awk '{print $4}'
+# shellcheck disable=SC2086
+("$MYSQLADMIN" $MYSQLOPTS status 2>/dev/null || echo 'a a a U') | awk '{print $4}'

--- a/plugins/node.d/named.in
+++ b/plugins/node.d/named.in
@@ -131,15 +131,14 @@ do_stats () {
     echo "tcp.value $(pick_stat RTCP "$XSTATS")"
     
     # Get a total of errors
-    errexpr="
-	    `pick_stat RNXD "$XSTATS"` +
-	    `pick_stat RFail "$XSTATS"` +
-	    `pick_stat RErr "$XSTATS"` +
-	    `pick_stat SErr "$XSTATS"` +
-	    `pick_stat RIQ "$XSTATS"` + 
-	    `pick_stat RFErr "$XSTATS"` ";
-
-    echo "errors.value `expr $errexpr`"
+    local error_value
+    error_value=$(( $(pick_stat RNXD "$XSTATS")
+                   + $(pick_stat RFail "$XSTATS")
+                   + $(pick_stat RErr "$XSTATS")
+                   + $(pick_stat SErr "$XSTATS")
+                   + $(pick_stat RIQ "$XSTATS")
+                   + $(pick_stat RFErr "$XSTATS") ))
+    echo "errors.value $error_value"
 }
 
 case $1 in

--- a/plugins/node.d/named.in
+++ b/plugins/node.d/named.in
@@ -71,7 +71,8 @@ munin-node.
 
 =cut
 
-if [ -n "$logfile" ]; then
+
+if [ -n "${logfile:-}" ]; then
     SYSLOGFILE=$logfile
 else 
     if [ -f /var/adm/messages ]; then
@@ -84,50 +85,50 @@ fi
 # ----------------------------------------------------------------------
 
 pick_stat () {
-    ret=`echo "$2" | sed "s/.* *$1=\([0-9]*\).*/\1/"`
+    ret=$(echo "$2" | sed 's/.* *'"$1"'=\([0-9]*\).*/\1/')
     if [ ! "$ret" ]; then
     	echo 0;
     else
-    	echo $ret
+        echo "$ret"
     fi
 }
 
 do_stats () {
 
-    if [ ! -f $SYSLOGFILE ] ; then 
-	echo $SYSLOGFILE is unavailable to me >&2
-	exit 1
+    if [ ! -f "$SYSLOGFILE" ]; then
+        echo "$SYSLOGFILE is unavailable to me" >&2
+        exit 1
     fi
 
     # Get out the last XSTATS and NSTATS lines
-    XSTATS=`grep 'named.*XSTATS' "$SYSLOGFILE" | tail -1`
-    # NSTATS=`grep 'named.*NSTATS' "$SYSLOGFILE" | tail -1`
+    XSTATS=$(grep 'named.*XSTATS' "$SYSLOGFILE" | tail -1)
+    # NSTATS=$(grep 'named.*NSTATS' "$SYSLOGFILE" | tail -1)
 
     # We concentrate on what clients communicate with us about
     # and counters that we suspect can indicate abuse or error conditions
 
     # Received Queries: Total volume of queries received. 
     # This should be nice and smooth.
-    echo "queries.value `pick_stat RQ "$XSTATS"`"
+    echo "queries.value $(pick_stat RQ "$XSTATS")"
 
     # Sent Answers: This should be the same as RQ except when there are
     # errors.  May not be very interesting.
-    echo "answers.value `pick_stat SAns "$XSTATS"`"
+    echo "answers.value $(pick_stat SAns "$XSTATS")"
 
     # Sent and Forwarded queries, in a proxy setting this should be
     # the same as Received Queries (?)
-    echo "forwarded.value `pick_stat SFwdQ "$XSTATS"`" 
+    echo "forwarded.value $(pick_stat SFwdQ "$XSTATS")"
 
     # Received Zone Transfer queries - should be low.  High value could
     # indicate some odd error or some kind of abuse
-    echo "axfr.value `pick_stat RAXFR "$XSTATS"`"	# Received AXFR Qs
+    echo "axfr.value $(pick_stat RAXFR "$XSTATS")"	# Received AXFR Qs
 
     # Received TCP connections: These are used for zone transfers or
     # oversized (>512 byte) answers.  A high value here could indicate
     # that you need to trim down the size of your answers somehow (Do you
     # have a ton of MXes or NSes that gets reported back?), or this could
     # be due to an error.  Or it could be due to abuse.
-    echo "tcp.value `pick_stat RTCP "$XSTATS"`"
+    echo "tcp.value $(pick_stat RTCP "$XSTATS")"
     
     # Get a total of errors
     errexpr="

--- a/plugins/node.d/netopia.in
+++ b/plugins/node.d/netopia.in
@@ -9,6 +9,7 @@ if [ "$1" = "config" ]; then
 	echo "graph_order down up" 
 	echo "graph_title ADSL Traffic"
 	echo 'graph_args --base 1000'
+        # shellcheck disable=SC2016
 	echo 'graph_vlabel bits in (-) / out (+) per ${graph_period}'
 	echo 'down.label received'
         echo 'down.type DERIVE'
@@ -26,6 +27,6 @@ if [ "$1" = "config" ]; then
 fi;
 
 printf "down.value "
-snmpget -Ov $hostname $COMMUNITY interfaces.ifTable.ifEntry.ifInOctets.3 | sed 's/^.*: //'
+snmpget -Ov "$hostname" "$COMMUNITY" interfaces.ifTable.ifEntry.ifInOctets.3 | sed 's/^.*: //'
 printf "up.value "
-snmpget -Ov $hostname $COMMUNITY interfaces.ifTable.ifEntry.ifOutOctets.3 | sed 's/^.*: //'
+snmpget -Ov "$hostname" "$COMMUNITY" interfaces.ifTable.ifEntry.ifOutOctets.3 | sed 's/^.*: //'

--- a/plugins/node.d/ntp_kernel_err.in
+++ b/plugins/node.d/ntp_kernel_err.in
@@ -51,7 +51,7 @@ fi
 
 printf 'ntp_err.value '
 
-if [ $(ntpq -c version | grep --extended-regexp --only-matching '[[:digit:]]\.[[:digit:]]\.[[:digit:]]' | tr -d '.') -ge 427 ]
+if [ "$(ntpq -c version | grep --extended-regexp --only-matching '[[:digit:]]\.[[:digit:]]\.[[:digit:]]' | tr -d '.')" -ge 427 ]
 then
     ntpq -c kerninfo | awk '/^estimated error:/ { print $3 / 1000 }'
 else

--- a/plugins/node.d/ntp_kernel_pll_freq.in
+++ b/plugins/node.d/ntp_kernel_pll_freq.in
@@ -46,8 +46,8 @@ if [ "$1" = "autoconf" ]; then
     exit 0
 fi
 
-if [ -f @@CONFDIR@@/ntp-freq-comp ]; then
-    fcomp=`cat @@CONFDIR@@/ntp-freq-comp`
+if [ -f "@@CONFDIR@@/ntp-freq-comp" ]; then
+    fcomp=$(cat "@@CONFDIR@@/ntp-freq-comp")
 else
     fcomp=0
 fi
@@ -65,7 +65,7 @@ fi
 
 printf 'ntp_pll_freq.value '
 
-if [ $(ntpq -c version | grep --extended-regexp --only-matching '[[:digit:]]\.[[:digit:]]\.[[:digit:]]' | tr -d '.') -ge 427 ]
+if [ "$(ntpq -c version | grep --extended-regexp --only-matching '[[:digit:]]\.[[:digit:]]\.[[:digit:]]' | tr -d '.')" -ge 427 ]
 then
     cmd=ntpq
 else

--- a/plugins/node.d/ntp_kernel_pll_off.in
+++ b/plugins/node.d/ntp_kernel_pll_off.in
@@ -51,7 +51,7 @@ fi
 
 printf 'ntp_pll_off.value '
 
-if [ $(ntpq -c version | grep --extended-regexp --only-matching '[[:digit:]]\.[[:digit:]]\.[[:digit:]]' | tr -d '.') -ge 427 ]
+if [ "$(ntpq -c version | grep --extended-regexp --only-matching '[[:digit:]]\.[[:digit:]]\.[[:digit:]]' | tr -d '.')" -ge 427 ]
 then
     ntpq -c kerninfo | awk '/^pll offset:/ { print $3 / 1000 }'
 else

--- a/plugins/node.d/ntp_offset.in
+++ b/plugins/node.d/ntp_offset.in
@@ -37,6 +37,10 @@ Loosely based on ntp_ plugin, but reworked to shell.
 
 =cut
 
+
+nodelay=${nodelay:-}
+
+
 do_autoconf () {
     ntpq -c help >/dev/null 2>&1 || { echo 'no (no ntpq program)'; exit 0; }
 
@@ -59,6 +63,7 @@ do_autoconf () {
 do_config () {
     syspeer="$(ntpq -n -p | grep '^[*o]')"
 
+    # shellcheck disable=SC2086
     set - $syspeer
 
     peer=$1
@@ -88,6 +93,7 @@ do_ () {
     # Fetch operation
     syspeer="$(ntpq -n -p | grep '^[*o]')"
 
+    # shellcheck disable=SC2086
     set - $syspeer
 
     # peer=$1
@@ -105,7 +111,7 @@ EOF
 
 case $1 in
     autoconf|config|'')
-       do_$1
+       "do_$1"
        exit $?
        ;;
     *)

--- a/plugins/node.d/nutups_.in
+++ b/plugins/node.d/nutups_.in
@@ -123,4 +123,3 @@ case "$FUNCTION" in
 		current "$1"
 		;;
 esac
-

--- a/plugins/node.d/perdition.in
+++ b/plugins/node.d/perdition.in
@@ -49,9 +49,6 @@ Unknown
 
 =cut
 
-mktempfile () {
-@@MKTEMP@@
-}
 
 # Set the location of the perdition logs
 PERDITION_LOG=${logfile:-/var/log/perdition.log}
@@ -93,14 +90,14 @@ EOF
 esac
 
 ARGS=0
-`$LOGTAIL /etc/hosts 2>/dev/null >/dev/null`
+"$LOGTAIL" /etc/hosts 2>/dev/null >/dev/null
 if [ $? = 66 ]; then
     if [ ! -n "$logtail" ]; then
         ARGS=1
     fi
 fi
 
-TEMP_FILE=`mktempfile munin-perdition.XXXXXX`
+TEMP_FILE=$(@@MKTEMP@@ munin-perdition.XXXXXX)
 
 if [ -z "$TEMP_FILE" ] || [ ! -f "$TEMP_FILE" ]; then
     exit 3

--- a/plugins/node.d/perdition.in
+++ b/plugins/node.d/perdition.in
@@ -60,8 +60,7 @@ LOGTAIL=${logtail:-/usr/sbin/logtail}
 
 case $1 in
     autoconf|detect)
-    if [ -f ${PERDITION_LOG} -a -x ${LOGTAIL} ]
-    then
+    if [ -f "$PERDITION_LOG" ] && [ -x "$LOGTAIL" ]; then
         echo yes
         exit 0
     else
@@ -85,9 +84,9 @@ EOF
     # Echo warnnig and critical attributes if set in the plugin config
     for i in imap imaps pop pops fatal connection disconnected; do
         warn=\$${i}_warn; eval val=$warn
-        [ "$val" ] && echo "$i.warning ${val}"
+        [ -n "${val:-}" ] && echo "$i.warning ${val}"
         crit=\$${i}_crit; eval val=$crit
-        [ "$val" ] && echo "$i.critical ${val}"
+        [ -n "${val:-}" ] && echo "$i.critical ${val}"
     done
     exit 0
     ;;
@@ -103,24 +102,24 @@ fi
 
 TEMP_FILE=`mktempfile munin-perdition.XXXXXX`
 
-if [ -z "$TEMP_FILE" -o ! -f "$TEMP_FILE" ]; then
+if [ -z "$TEMP_FILE" ] || [ ! -f "$TEMP_FILE" ]; then
     exit 3
 fi
 
-if [ $ARGS != 0 ]; then
-    ${LOGTAIL} -f ${PERDITION_LOG} -o ${OFFSET_FILE} > ${TEMP_FILE}
+if [ "$ARGS" != 0 ]; then
+    "$LOGTAIL" -f "$PERDITION_LOG" -o "$OFFSET_FILE" > "$TEMP_FILE"
 else
-    ${LOGTAIL} ${PERDITION_LOG} ${OFFSET_FILE} > ${TEMP_FILE}
+    "$LOGTAIL" "$PERDITION_LOG" "$OFFSET_FILE" > "$TEMP_FILE"
 fi
-connection=`grep "Connect:" ${TEMP_FILE} | wc -l`
-disconnected=`grep "Close:" ${TEMP_FILE} | wc -l`
-imap=`grep 'port="143" status="ok"' ${TEMP_FILE} | wc -l`
-imaps=`grep 'port="993" status="ok"' ${TEMP_FILE} | wc -l`
-pop=`grep 'port="110" status="ok"' ${TEMP_FILE} | wc -l`
-pops=`grep 'port="995" status="ok"' ${TEMP_FILE} | wc -l`
-fatal=`grep 'Fatal [e|E]rror' ${TEMP_FILE} | wc -l`
+connection=$(grep "Connect:" "$TEMP_FILE" | wc -l)
+disconnected=$(grep "Close:" "$TEMP_FILE" | wc -l)
+imap=$(grep 'port="143" status="ok"' "$TEMP_FILE" | wc -l)
+imaps=$(grep 'port="993" status="ok"' "$TEMP_FILE" | wc -l)
+pop=$(grep 'port="110" status="ok"' "$TEMP_FILE" | wc -l)
+pops=$(grep 'port="995" status="ok"' "$TEMP_FILE" | wc -l)
+fatal=$(grep 'Fatal [e|E]rror' "$TEMP_FILE" | wc -l)
 
-rm ${TEMP_FILE}
+rm "$TEMP_FILE"
 
 echo "connection.value ${connection}"
 echo "disconnected.value ${disconnected}"

--- a/plugins/node.d/postfix_mailqueue.in
+++ b/plugins/node.d/postfix_mailqueue.in
@@ -87,7 +87,7 @@ munin-node.
 POSTCONFSPOOL="$(postconf -h queue_directory 2>/dev/null || echo /var/spool/postfix)"
 SPOOLDIR=${spooldir:-$POSTCONFSPOOL}
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 case $1 in
     autoconf|detect)

--- a/plugins/node.d/postfix_mailqueue.in
+++ b/plugins/node.d/postfix_mailqueue.in
@@ -92,7 +92,7 @@ SPOOLDIR=${spooldir:-$POSTCONFSPOOL}
 case $1 in
     autoconf|detect)
 	
-	if [ -d $SPOOLDIR ] ; then
+	if [ -d "$SPOOLDIR" ] ; then
 	    echo yes
 	    exit 0
         else
@@ -113,22 +113,22 @@ corrupt.label corrupt
 hold.label held
 EOF
 	for field in active deferred maildrop incoming corrupt hold; do
-		print_warning $field
-		print_critical $field
+		print_warning "$field"
+		print_critical "$field"
 	done
 	exit 0;;
 esac
 
-cd $SPOOLDIR >/dev/null 2>/dev/null || {
+cd "$SPOOLDIR" >/dev/null 2>/dev/null || {
      echo "# Cannot cd to $SPOOLDIR"
      exit 1
 }
 
 cat <<EOF
-deferred.value `(test -d deferred && find deferred -type f ) | wc -l`
-active.value `(test -d active && find active -type f ) | wc -l`
-maildrop.value `(test -d maildrop && find maildrop -type f ) | wc -l`
-incoming.value `(test -d incoming && find incoming -type f ) | wc -l`
-corrupt.value `(test -d corrupt && find corrupt -type f ) | wc -l`
-hold.value `( test -d hold && find hold -type f ) | wc -l`
+deferred.value $( { test -d deferred && find deferred -type f; } | wc -l)
+active.value $( { test -d active && find active -type f; } | wc -l)
+maildrop.value $( { test -d maildrop && find maildrop -type f; } | wc -l)
+incoming.value $( { test -d incoming && find incoming -type f; } | wc -l)
+corrupt.value $( { test -d corrupt && find corrupt -type f; } | wc -l)
+hold.value $( { test -d hold && find hold -type f; } | wc -l)
 EOF

--- a/plugins/node.d/processes.in
+++ b/plugins/node.d/processes.in
@@ -288,7 +288,7 @@ if [ "$1" = "config" ]; then
         echo "zombie.label zombie"
         echo "zombie.draw STACK"
         echo "zombie.colour $ZOMBIE"
-        echo "zombie.info The number of defunct ("zombie") processes (process terminated and parent not waiting)."
+        echo "zombie.info The number of defunct ('zombie') processes (process terminated and parent not waiting)."
         print_warning zombie
         print_critical zombie
     fi
@@ -308,7 +308,8 @@ if [ "$1" = "config" ]; then
 fi
 
 if [ "$OPERSYS" = "Linux" ]; then
-    $ps --no-header -eo s | $awk '
+    # shellcheck disable=SC2016
+    "$ps" --no-header -eo s | "$awk" '
 { processes++; stat[$1]++ }
 END {
 print "processes.value "        0+processes;
@@ -322,7 +323,8 @@ print "zombie.value "           0+stat["Z"];
 }'
 
 elif [ "$OPERSYS" = "SunOS" ]; then
-    $ps -e -o s | $awk '
+    # shellcheck disable=SC2016
+    "$ps" -e -o s | "$awk" '
 { total++; stat[$1]++ }
 END {
 print "total.value "    0+total;
@@ -333,7 +335,8 @@ print "stopped.value "  0+stat["T"];
 print "zombie.value "   0+stat["Z"];
 }'
 elif [ "$OPERSYS" = "FreeBSD" ]; then
-    $ps -axo state= | sed -e 's/^\(.\).*/\1/' | $awk '
+    # shellcheck disable=SC2016
+    "$ps" -axo state= | sed -e 's/^\(.\).*/\1/' | "$awk" '
 { processes++; stat[$1]++ }
 END {
 print "processes.value "        0+processes;
@@ -348,7 +351,8 @@ print "zombie.value "           0+stat["Z"];
 }'
 elif [ "$OPERSYS" = "OpenBSD" ]; then
     # First line is header. Remove it.
-    $ps -axo state= | sed '1d' | sed -e 's/^\(.\).*/\1/' | $awk '
+    # shellcheck disable=SC2016
+    "$ps" -axo state= | sed '1d' | sed -e 's/^\(.\).*/\1/' | "$awk" '
 { processes++; stat[$1]++ }
 END {
 print "processes.value "        0+processes;
@@ -361,7 +365,8 @@ print "zombie.value "           0+stat["Z"];
 }'
 elif [ "$OPERSYS" = "NetBSD" ]; then
     # First line is header. Remove it.
-    $ps -axo state= | sed '1d' | sed -e 's/^\(.\).*/\1/' | $awk '
+    # shellcheck disable=SC2016
+    "$ps" -axo state= | sed '1d' | sed -e 's/^\(.\).*/\1/' | "$awk" '
 { processes++; stat[$1]++ }
 END {
 print "processes.value "        0+processes;
@@ -376,7 +381,8 @@ print "zombie.value "           0+stat["Z"];
 
 elif [ "$OPERSYS" = "Darwin" ]; then
     # First line is header. Remove it.
-    $ps -axo state= | sed '1d' | sed -e 's/^\(.\).*/\1/' | $awk '
+    # shellcheck disable=SC2016
+    "$ps" -axo state= | sed '1d' | sed -e 's/^\(.\).*/\1/' | "$awk" '
 { processes++; stat[$1]++ }
 END {
 print "processes.value "        0+processes;
@@ -390,7 +396,8 @@ print "zombie.value "           0+stat["Z"];
 
 elif [ "$OPERSYS" = "CYGWIN" ]; then
     # First line is header. Remove it. Also remove WINPID duplicates.
-    $ps -aW | sed '1d' | cut -c 30-36 | sort -u | $awk '
+    # shellcheck disable=SC2016
+    "$ps" -aW | sed '1d' | cut -c 30-36 | sort -u | "$awk" '
 { processes++; }
 END {
 print "processes.value "        0+processes;
@@ -398,7 +405,8 @@ print "processes.value "        0+processes;
 
 elif [ "$OPERSYS" = "HP-UX" ]; then
     # First line is header. Remove it.
-    $ps -el | sed '1d' | $awk '{print $2}' | $awk '
+    # shellcheck disable=SC2016
+    "$ps" -el | sed '1d' | "$awk" '{print $2}' | "$awk" '
 { processes++; stat[$1]++ }
 END {
 print "processes.value "        0+processes;

--- a/plugins/node.d/processes.in
+++ b/plugins/node.d/processes.in
@@ -62,34 +62,29 @@ munin-node.
 =cut
 
 # Search for program in $PATH unless predefined.
-[ $awk ]     || awk="awk"
-[ $ps ]      || ps="ps"
+awk=${awk:-awk}
+ps=${ps:-ps}
 
 # Find operating system
-[ $OPERSYS ] || OPERSYS=`uname | cut -f 1 -d _` || exit 1
+OPERSYS=${OPERSYS:-$(uname | cut -f 1 -d _)}
+[ -z "$OPERSYS" ] && echo >&2 "Failed to detect environment via uname" && exit 1
 
 if [ "$1" = "autoconf" ]; then
-        case "$OPERSYS" in
+    case "$OPERSYS" in
         Linux|SunOS|FreeBSD|OpenBSD|NetBSD|Darwin|CYGWIN)
-        $ps >/dev/null 2>/dev/null
-        if [ $? -ne 0 ]
-        then
-            echo "no (ps=$ps failed)"
+            if ! "$ps" >/dev/null 2>/dev/null; then
+                echo "no (ps=$ps failed)"
+            elif ! echo | "$awk" '{ print "Hei" }' >/dev/null 2>/dev/null; then
+                echo "no (awk=$awk failed)"
+            else
+                echo yes
+            fi
             exit 0
-        fi
-        echo | $awk '{ print "Hei" }' >/dev/null 2>/dev/null
-        if [ $? -ne 0 ]
-        then
-            echo "no (awk=$awk failed)"
+            ;;
+        *)
+            echo "no (unknown OS)"
             exit 0
-        fi
-    echo yes
-    exit 0
-    ;;
-    *)
-    echo "no (unknown OS)"
-    exit 0
-    ;;
+            ;;
     esac
 fi
 

--- a/plugins/node.d/processes.in
+++ b/plugins/node.d/processes.in
@@ -93,7 +93,7 @@ if [ "$1" = "autoconf" ]; then
     esac
 fi
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 # Define colours
 RUNNABLE='22ff22'         # Green

--- a/plugins/node.d/ps_.in
+++ b/plugins/node.d/ps_.in
@@ -44,7 +44,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 myname=`basename $0 | sed 's/^ps_//g'`
 

--- a/plugins/node.d/ps_.in
+++ b/plugins/node.d/ps_.in
@@ -46,7 +46,7 @@ GPLv2
 
 . "$MUNIN_LIBDIR/plugins/plugin.sh"
 
-myname=`basename $0 | sed 's/^ps_//g'`
+myname=$(basename "$0" | sed 's/^ps_//g')
 
 name="${name-\<$myname\>}"
 REGEX="${regex-\<$name\>}"
@@ -63,7 +63,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-	echo graph_title Number of $myname processes
+	echo "graph_title Number of $myname processes"
 	echo 'graph_args --base 1000 --vertical-label processes -l 0'
 	echo 'graph_category processes'
 	echo "count.label $myname"

--- a/plugins/node.d/psu_.in
+++ b/plugins/node.d/psu_.in
@@ -41,7 +41,7 @@ suggestions.
 
 EOF
 
-name=`basename $0 | sed 's/^psu_//g'`
+name=$(basename "$0" | sed 's/^psu_//g')
 
 if [ "$1" = "autoconf" ]; then
 	echo yes
@@ -54,7 +54,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-	echo graph_title Number of processes owned by $name
+	echo "graph_title Number of processes owned by $name"
 	echo 'graph_args --base 1000 --vertical-label processes -l 0'
 	echo 'graph_category processes'
 	echo "count.label $name"

--- a/plugins/node.d/qmailqstat.in
+++ b/plugins/node.d/qmailqstat.in
@@ -16,18 +16,17 @@
 #
 # Configuration:
 #  [qmailstat]
-#      env.qmailstat /usr/bin/qmail-qstat
+#      env.qmailqstat /usr/bin/qmail-qstat
 #
 # Magic markers - optional - used by installation scripts and munin-config:
 #
 #%# family=auto
 #%# capabilities=autoconf
 
-QMAILQSTAT=/var/qmail/bin/qmail-qstat
-if [ "$qmailqstat" ]; then QMAILSTAT=$qmailqstat ; fi
+QMAILQSTAT=${qmailqstat:-/var/qmail/bin/qmail-qstat}
 
 if [ "$1" = "autoconf" ]; then
-        if [ -f ${QMAILQSTAT} ] ; then
+        if [ -f "$QMAILQSTAT" ] ; then
                 echo yes
                 exit 0
         else

--- a/plugins/node.d/qmailscan.in
+++ b/plugins/node.d/qmailscan.in
@@ -37,23 +37,23 @@ if [ "$1" = "config" ]; then
         echo 'graph_args --base 1000 -l 0 '
         echo 'graph_vlabel Daily Virus Types'
         echo 'graph_category Mail'
-        grep "`date +%d\ %b\ %Y`" $LOG0 $LOG1 | \
-		grep -v 'Disallowed  characters found in MIME headers|Disallowed breakage found in header name - potential virus|Disallowed MIME comment found in header name - potential virus' | \
-	       sed 's/clamdscan.*$//' | sed 's/[ \t]*$//' | \
-	       cut -f 5 | sort | uniq -c | sort -r | sed 's/\.\|-/_/g' | while read i; do
-	               name=`echo $i | awk '{print $2}'`;
-	               echo "$name.label $name" ;
-	               echo "'$name.draw LINE2";
-	       done
+        grep "$(date "+%d %b %Y")" "$LOG0" "$LOG1" | \
+               grep -vE 'Disallowed  characters found in MIME headers|Disallowed breakage found in header name - potential virus|Disallowed MIME comment found in header name - potential virus' | \
+               sed 's/clamdscan.*$//' | sed 's/[ \t]*$//' | \
+               cut -f 5 | sort | uniq -c | sort -r | sed 's/\.\|-/_/g' | while read -r i; do
+                       name=$(echo "$i" | awk '{print $2}')
+                       echo "$name.label $name"
+                       echo "$name.draw LINE2"
+               done
 
         exit 0
 fi
 
-grep "`date +%d\ %b\ %Y`" $LOG0 $LOG1 | \
-	egrep -v 'Disallowed  characters found in MIME headers|Disallowed breakage found in header name - potential virus|Disallowed MIME comment found in header name - potential virus' | \
-	sed 's/clamdscan.*$//' | sed 's/[ \t]*$//' | \
-	cut -f 5 | sort | uniq -c | sort -r | sed 's/\.\|-/_/g' | while read i; do
-		name=`echo $i | awk '{print $2}'`;
-		printf "%s.value " $name;
-		echo $i | awk '{print $1}'
-	done
+grep "$(date "+%d %b %Y")" "$LOG0" "$LOG1" | \
+        grep -vE 'Disallowed  characters found in MIME headers|Disallowed breakage found in header name - potential virus|Disallowed MIME comment found in header name - potential virus' | \
+        sed 's/clamdscan.*$//' | sed 's/[ \t]*$//' | \
+        cut -f 5 | sort | uniq -c | sort -r | sed 's/\.\|-/_/g' | while read -r i; do
+                name=$(echo "$i" | awk '{print $2}')
+                printf "%s.value " "$name"
+                echo "$i" | awk '{print $1}'
+        done

--- a/plugins/node.d/sendmail_mailqueue.in
+++ b/plugins/node.d/sendmail_mailqueue.in
@@ -38,10 +38,8 @@ GPLv2
 
 =cut
 
-MSP_QUEUE=/var/spool/mqueue-client
-MTA_QUEUE=/var/spool/mqueue
-if [ "$mspqueue"  ]; then MSP_QUEUE=$mspqueue ; fi
-if [ "$mtaqueue"  ]; then MTA_QUEUE=$mtaqueue ; fi
+MSP_QUEUE=${mspqueue:-/var/spool/mqueue-client}
+MTA_QUEUE=${mtaqueue:-/var/spool/mqueue}
 
 if [ "$1" = "autoconf" ]; then
 	if [ -d "$MSP_QUEUE" ] && [ -d "$MTA_QUEUE" ] ; then

--- a/plugins/node.d/sendmail_mailqueue.in
+++ b/plugins/node.d/sendmail_mailqueue.in
@@ -44,7 +44,7 @@ if [ "$mspqueue"  ]; then MSP_QUEUE=$mspqueue ; fi
 if [ "$mtaqueue"  ]; then MTA_QUEUE=$mtaqueue ; fi
 
 if [ "$1" = "autoconf" ]; then
-	if [ -d ${MSP_QUEUE} -a -d ${MTA_QUEUE} ] ; then
+	if [ -d "$MSP_QUEUE" ] && [ -d "$MTA_QUEUE" ] ; then
 		echo yes
 		exit 0
 	else
@@ -65,6 +65,6 @@ fi
 
 # Append /. to directory to force following symlinks at the start
 # point.
-mspmails=$(find ${MSP_QUEUE}/. -type f -name '[qQ]*' 2>/dev/null | fgrep -v '.hoststat' | wc -l)
-mtamails=$(find ${MTA_QUEUE}/. -type f -name '[qQ]*' 2>/dev/null | fgrep -v '.hoststat' | wc -l)
-echo "mails.value `expr ${mspmails} + ${mtamails}`"
+mspmails=$(find "${MSP_QUEUE}/." -type f -name '[qQ]*' 2>/dev/null | grep -vF '.hoststat' | wc -l)
+mtamails=$(find "${MTA_QUEUE}/." -type f -name '[qQ]*' 2>/dev/null | grep -vF '.hoststat' | wc -l)
+echo "mails.value $((mspmails + mtamails))"

--- a/plugins/node.d/sendmail_mailstats.in
+++ b/plugins/node.d/sendmail_mailstats.in
@@ -33,10 +33,9 @@ GPLv2
 
 =cut
 
-if [ -n "$mailstats" ];
-        then MAILSTATS=$mailstats;
-        else MAILSTATS=`which mailstats 2>/dev/null`;
-fi
+
+MAILSTATS=${mailstats:-$(which mailstats 2>/dev/null)}
+
 
 if [ "$1" = "autoconf" ]; then
         if [ -n "$MAILSTATS" ] && [ -x "$MAILSTATS" ]

--- a/plugins/node.d/sendmail_mailstats.in
+++ b/plugins/node.d/sendmail_mailstats.in
@@ -39,7 +39,7 @@ if [ -n "$mailstats" ];
 fi
 
 if [ "$1" = "autoconf" ]; then
-        if [ -n "$MAILSTATS" -a -x "$MAILSTATS" ]
+        if [ -n "$MAILSTATS" ] && [ -x "$MAILSTATS" ]
                 then echo yes
                 else echo "no (no mailstats command)"
         fi  
@@ -49,6 +49,7 @@ fi
 if [ "$1" = "config" ]; then
 	echo "graph_title Sendmail email traffic"
 	echo "graph_order received sent rejected discarded"
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel messages/${graph_period}'
 	echo "graph_category sendmail"
 	echo "discarded.label discarded"

--- a/plugins/node.d/sendmail_mailtraffic.in
+++ b/plugins/node.d/sendmail_mailtraffic.in
@@ -39,7 +39,7 @@ if [ -n "$mailstats" ];
 fi
 
 if [ "$1" = "autoconf" ]; then
-	if [ -n "$MAILSTATS" -a -x "$MAILSTATS" ]
+	if [ -n "$MAILSTATS" ] && [ -x "$MAILSTATS" ]
 		then echo yes
 		else echo "no (no mailstats command)"
 	fi
@@ -50,6 +50,7 @@ if [ "$1" = "config" ]; then
 
 	echo "graph_title Sendmail email volumes"
 	echo "graph_order received sent"
+	# shellcheck disable=SC2016
 	echo 'graph_vlabel bytes/${graph_period}'
 	echo "graph_category sendmail"
 	echo "received.label received"

--- a/plugins/node.d/sendmail_mailtraffic.in
+++ b/plugins/node.d/sendmail_mailtraffic.in
@@ -33,10 +33,9 @@ GPLv2
 
 =cut
 
-if [ -n "$mailstats" ];
-	then MAILSTATS=$mailstats;
-	else MAILSTATS=`which mailstats 2>/dev/null`;
-fi
+
+MAILSTATS=${mailstats:-$(which mailstats 2>/dev/null)}
+
 
 if [ "$1" = "autoconf" ]; then
 	if [ -n "$MAILSTATS" ] && [ -x "$MAILSTATS" ]

--- a/plugins/node.d/snort_alerts.in
+++ b/plugins/node.d/snort_alerts.in
@@ -57,11 +57,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 =cut
 
 
-if [ -z $statsfile  ]; then
-        _target=/var/snort/snort.stats
-else
-        _target=$statsfile
-fi
+_target=${statsfile:-/var/snort/snort.stats}
+
 
 if [ "$1" = "autoconf" ]; then
         if [ -f "$_target" ]; then
@@ -91,4 +88,4 @@ if [ "$1" = "config" ]; then
 fi
 
 printf "alerts.value "
-echo $(tail -n1 $_target| awk -F, '{ print $4 }')
+tail -n1 "$_target" | awk -F, '{ print $4 }'

--- a/plugins/node.d/snort_alerts.in
+++ b/plugins/node.d/snort_alerts.in
@@ -64,7 +64,7 @@ else
 fi
 
 if [ "$1" = "autoconf" ]; then
-        if [ -f $_target ]; then
+        if [ -f "$_target" ]; then
                 echo yes
         else
                 echo "no ($_target not readable)"
@@ -78,12 +78,12 @@ if [ "$1" = "config" ]; then
         echo 'graph_vlabel Alerts / second'
         echo 'graph_scale no'
         echo 'alerts.label Alerts/second'
-	if [ -n "$warning" ]; then
-		echo "alerts.warning $warning"
-	fi
-	if [ -n "$critical" ]; then
-		echo "alerts.critical $critical"
-	fi
+        if [ -n "${warning:-}" ]; then
+                echo "alerts.warning $warning"
+        fi
+        if [ -n "${critical:-}" ]; then
+                echo "alerts.critical $critical"
+        fi
         echo 'alerts.info The number of alerts per second'
         echo 'graph_category Snort'
 

--- a/plugins/node.d/snort_bytes_pkt.in
+++ b/plugins/node.d/snort_bytes_pkt.in
@@ -64,7 +64,7 @@ else
 fi
 
 if [ "$1" = "autoconf" ]; then
-        if [ -f $_target ]; then
+        if [ -f "$_target" ]; then
                 echo yes
         else
                 echo "no ($_target not readable)"
@@ -78,12 +78,12 @@ if [ "$1" = "config" ]; then
         echo 'graph_vlabel KBytes / pkt'
         echo 'graph_scale no'
         echo 'bytes_pkt.label KBytes/pkt'
-	if [ -n "$warning" ]; then
-		echo "bytes_pkt.warning $warning"
-	fi
-	if [ -n "$critical" ]; then
-		echo "bytes_pkt.critical $critical"
-	fi
+        if [ -n "${warning:-}" ]; then
+                echo "bytes_pkt.warning $warning"
+        fi
+        if [ -n "${critical:-}" ]; then
+                echo "bytes_pkt.critical $critical"
+        fi
         echo 'bytes_pkt.info Average size per packet'
         echo 'graph_category Snort'
 

--- a/plugins/node.d/snort_bytes_pkt.in
+++ b/plugins/node.d/snort_bytes_pkt.in
@@ -57,11 +57,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 =cut
 
 
-if [ -z $statsfile  ]; then
-        _target=/var/snort/snort.stats
-else
-        _target=$statsfile
-fi
+_target=${statsfile:-/var/snort/snort.stats}
+
 
 if [ "$1" = "autoconf" ]; then
         if [ -f "$_target" ]; then
@@ -91,4 +88,4 @@ if [ "$1" = "config" ]; then
 fi
 
 printf "bytes_pkt.value "
-echo $(tail -n1 $_target| awk -F, '{ print $6 }')
+tail -n1 "$_target" | awk -F, '{ print $6 }'

--- a/plugins/node.d/snort_drop_rate.in
+++ b/plugins/node.d/snort_drop_rate.in
@@ -57,11 +57,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 =cut
 
 
-if [ -z $statsfile  ]; then
-        _target=/var/snort/snort.stats
-else
-        _target=$statsfile
-fi
+_target=${statsfile:-/var/snort/snort.stats}
+
 
 if [ "$1" = "autoconf" ]; then
         if [ -f "$_target" ]; then
@@ -91,4 +88,4 @@ if [ "$1" = "config" ]; then
 fi
 
 printf "droprate.value "
-echo $(tail -n1 $_target| awk -F, '{ print $2 }')
+tail -n1 "$_target" | awk -F, '{ print $2 }'

--- a/plugins/node.d/snort_drop_rate.in
+++ b/plugins/node.d/snort_drop_rate.in
@@ -64,7 +64,7 @@ else
 fi
 
 if [ "$1" = "autoconf" ]; then
-        if [ -f $_target ]; then
+        if [ -f "$_target" ]; then
                 echo yes
         else
                 echo "no ($_target not readable)"
@@ -78,12 +78,12 @@ if [ "$1" = "config" ]; then
         echo 'graph_vlabel % percent'
         echo 'graph_scale no'
         echo 'droprate.label % percent'
-	if [ -n "$warning" ]; then
-		echo "droprate.warning $warning"
-	fi
-	if [ -n "$critical" ]; then
-		echo "droprate.critical $critical"
-	fi
+        if [ -n "${warning:-}" ]; then
+                echo "droprate.warning $warning"
+        fi
+        if [ -n "${critical:-}" ]; then
+                echo "droprate.critical $critical"
+        fi
         echo 'droprate.info Packet drop rate in %'
         echo 'graph_category Snort'
 

--- a/plugins/node.d/snort_pattern_match.in
+++ b/plugins/node.d/snort_pattern_match.in
@@ -58,11 +58,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 =cut
 
 
-if [ -z $statsfile  ]; then
-        _target=/var/snort/snort.stats
-else
-        _target=$statsfile
-fi
+_target=${statsfile:-/var/snort/snort.stats}
+
 
 if [ "$1" = "autoconf" ]; then
         if [ -f "$_target" ]; then
@@ -92,4 +89,4 @@ if [ "$1" = "config" ]; then
 fi
 
 printf "pattmatch.value "
-echo $(tail -n1 $_target| awk -F, '{ print $7 }')
+tail -n1 "$_target" | awk -F, '{ print $7 }'

--- a/plugins/node.d/snort_pattern_match.in
+++ b/plugins/node.d/snort_pattern_match.in
@@ -65,7 +65,7 @@ else
 fi
 
 if [ "$1" = "autoconf" ]; then
-        if [ -f $_target ]; then
+        if [ -f "$_target" ]; then
                 echo yes
         else
                 echo "no ($_target not readable)"
@@ -79,12 +79,12 @@ if [ "$1" = "config" ]; then
         echo 'graph_vlabel % percent'
         echo 'graph_scale no'
         echo 'pattmatch.label % percent'
-	if [ -n "$warning" ]; then
-		echo "pattmatch.warning $warning"
-	fi
-	if [ -n "$critical" ]; then
-		echo "pattmatch.critical $critical"
-	fi
+        if [ -n "${warning:-}" ]; then
+                echo "pattmatch.warning $warning"
+        fi
+        if [ -n "${critical:-}" ]; then
+                echo "pattmatch.critical $critical"
+        fi
         echo 'pattmatch.info The percent of data received that Snort processes in pattern matching'
         echo 'graph_category Snort'
 

--- a/plugins/node.d/snort_pkts.in
+++ b/plugins/node.d/snort_pkts.in
@@ -57,15 +57,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 =cut
 
+statsfile=${statsfile:-}
 
-if [ -z $statsfile  ]; then
+if [ -z "$statsfile" ]; then
         _target=/var/snort/snort.stats
 else
         _target=$statsfile
 fi
 
 if [ "$1" = "autoconf" ]; then
-        if [ -f $_target ]; then
+        if [ -f "$_target" ]; then
                 echo yes
         else
                 echo "no ($_target not readable)"
@@ -76,15 +77,16 @@ fi
 if [ "$1" = "config" ]; then
         echo 'graph_title Snort Avg packets/s'
         echo 'graph_args --base 1000 -l 0'
-        echo 'graph_vlabel Packets / second'
+        # shellcheck disable=SC2016
+        echo 'graph_vlabel Packets / ${graph_period}'
         echo 'graph_scale no'
-        echo 'pktsec.label Packets/second'
-	if [ -n "$warning" ]; then
-		echo "pktsec.warning $warning"
-	fi
-	if [ -n "$critical" ]; then
-		echo "pktsec.critical $critical"
-	fi
+        echo 'pktsec.label Packets'
+        if [ -n "${warning:-}" ]; then
+            echo "pktsec.warning $warning"
+        fi
+        if [ -n "${critical:-}" ]; then
+            echo "pktsec.critical $critical"
+        fi
         echo 'pktsec.info The number of packets per second'
         echo 'graph_category Snort'
 

--- a/plugins/node.d/snort_pkts.in
+++ b/plugins/node.d/snort_pkts.in
@@ -92,4 +92,4 @@ if [ "$1" = "config" ]; then
 fi
 
 printf "pktsec.value "
-echo $( tail -n1 $_target| awk -F, '{ print $5 }') \* 1000|bc -l
+tail -n1 "$_target" | awk -F, '{ print $5 * 1000 }'

--- a/plugins/node.d/snort_traffic.in
+++ b/plugins/node.d/snort_traffic.in
@@ -57,11 +57,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 =cut
 
 
-if [ -z $statsfile  ]; then
-        _target=/var/snort/snort.stats
-else
-        _target=$statsfile
-fi
+_target=${statsfile:-/var/snort/snort.stats}
+
 
 if [ "$1" = "autoconf" ]; then
         if [ -f "$_target" ]; then
@@ -91,4 +88,4 @@ if [ "$1" = "config" ]; then
 fi
 
 printf "traffic.value "
-echo $(tail -n1 $_target| awk -F, '{ print $3 }')
+tail -n1 "$_target" | awk -F, '{ print $3 }'

--- a/plugins/node.d/snort_traffic.in
+++ b/plugins/node.d/snort_traffic.in
@@ -64,7 +64,7 @@ else
 fi
 
 if [ "$1" = "autoconf" ]; then
-        if [ -f $_target ]; then
+        if [ -f "$_target" ]; then
                 echo yes
         else
                 echo "no ($_target not readable)"
@@ -78,12 +78,12 @@ if [ "$1" = "config" ]; then
         echo 'graph_vlabel Mbits / second'
         echo 'graph_scale no'
         echo 'traffic.label Mbits/second'
-	if [ -n "$warning" ]; then
-		echo "traffic.warning $warning"
-	fi
-	if [ -n "$critical" ]; then
-		echo "traffic.critical $critical"
-	fi
+        if [ -n "${warning:-}" ]; then
+                echo "traffic.warning $warning"
+        fi
+        if [ -n "${critical:-}" ]; then
+                echo "traffic.critical $critical"
+        fi
         echo 'traffic.info Traffic in Mbites per second'
         echo 'graph_category Snort'
 

--- a/plugins/node.d/squeezebox_.in
+++ b/plugins/node.d/squeezebox_.in
@@ -39,10 +39,6 @@ or whatever the player is connected to.
  #%# family=auto
  #%# capabilities=autoconf suggest
 
-=head1 VERSION
-
- $Id$
-
 =head1 BUGS
 
 None known
@@ -62,18 +58,16 @@ PORT=${squeezecenter_port:-9090}
 NC=${netcat:-nc}
 
 if [ "$1" = "autoconf" ]; then
-        if [ ! "which $NC 1>/dev/null 2>&1" ]; then
+        if ! which "$NC" 1>/dev/null 2>&1; then
 		echo "no (no netcat/nc binary found)"
 		exit 0
 	fi
-	echo exit | $NC $HOST $PORT 1>/dev/null 2>&1
-	RET=$?
-	if [ "$RET" != "0" ]; then
+	if ! echo exit | "$NC" "$HOST" "$PORT" 1>/dev/null 2>&1; then
 		echo "no (no connection on $HOST port $PORT)"
 		exit 0
 	fi
-	VERSION=$(printf "%b" "version ?\nexit\n" | $NC $HOST $PORT 2>/dev/null)
-	if [ "$VERSION" != "" ]; then
+	VERSION=$(printf "%b" "version ?\\nexit\\n" | "$NC" "$HOST" "$PORT" 2>/dev/null)
+	if [ -n "$VERSION" ]; then
 		echo "yes"
 		exit 0
 	else
@@ -100,12 +94,12 @@ fi
 # example: 5 * * * * /usr/share/munin/plugins/squeezebox_ update
 
 if [ "$1" = "update" ]; then
-	printf "%b" "rescan\nexit\n" | $NC $HOST $PORT >/dev/null
+	printf "%b" "rescan\\nexit\\n" | "$NC" "$HOST" "$PORT" >/dev/null
 	exit 0
 fi
 
 
-CHECK=$(echo $0 | cut -d _ -f 2-)
+CHECK=$(echo "$0" | cut -d _ -f 2-)
 case "$CHECK" in
 	songs)
 		ATTR="songs"
@@ -137,15 +131,16 @@ case "$CHECK" in
 		;;
 esac
 
-if [ "$ATTR" = "" -a "$CMD" = "" ]; then
+if [ -z "$ATTR" ] && [ -z "$CMD" ]; then
 	echo "Urk"
 	exit 2
 fi
 
 if [ "$CMD" = "years" ]; then
-	no_of_years=$(printf "%b" "years\nexit\n" | $NC $HOST $PORT | sed 's/%3A/:/g' | cut -d ':' -f 2)
-	years_array=$(printf "%b" "years 0 $no_of_years\nexit\n" | $NC $HOST $PORT | sed 's/%3A/:/g' | cut -d ' ' -f 4- | sed 's/year://g' | cut -d ' ' -f -$no_of_years)
-	arr1=( `echo "$years_array" | tr -s ' ' ' '` )
+        no_of_years=$(printf "%b" "years\\nexit\\n" | "$NC" "$HOST" "$PORT" | sed 's/%3A/:/g' | cut -d ':' -f 2)
+        years_array=$(printf "%b" "years 0 $no_of_years\\nexit\\n" | "$NC" "$HOST" "$PORT" | sed 's/%3A/:/g' | cut -d ' ' -f 4- | sed 's/year://g' | cut -d ' ' -f "-$no_of_years")
+        # shellcheck disable=SC2207
+        arr1=( $(echo "$years_array" | tr -s ' ' ' ') )
 	(( no_of_years-- )) # We don't need that last entry in the array
 	if [ "$1" = "config" ]; then
                 echo "graph_title Number of years"
@@ -155,49 +150,50 @@ if [ "$CMD" = "years" ]; then
 		# echo $years_array | tr '[:space:]' " y"
 		# echo "graph_order y0"
 		printf "graph_order y"
-        echo $years_array | sed 's/ / y/g'
+                echo "${years_array// / y}"
 
-		for i in `seq 0 $no_of_years`; do
-			year=$(echo ${arr1[$i]})
-			if [ $year = 0 ]; then
-				echo y0.label No year
-			else
-				echo y${year}.label $year
-			fi
-			if [ $i = 0 ]; then
-				echo y${year}.draw AREA
-			else
-				echo y${year}.draw STACK
-			fi
-		done
-		exit 0
-	fi
-	for i in `seq 0 $no_of_years`; do
-		year=$(echo ${arr1[$i]})
-		printf "y%s.value " ${year}
-		printf "%b" "albums 0 0 year:${year}\nexit\n" | $NC $HOST $PORT | sed 's/%3A/:/g' | cut -d ':' -f 3
-	done
-elif [ "$CMD" = "signalstrength" -o "$CMD" = "mixer volume" ]; then
+                for i in $(seq 0 "$no_of_years"); do
+                        year=${arr1[$i]}
+                        if [ "$year" = 0 ]; then
+                                echo "y0.label No year"
+                        else
+                                echo "y${year}.label $year"
+                        fi
+                        if [ "$i" = 0 ]; then
+                                echo "y${year}.draw AREA"
+                        else
+                                echo "y${year}.draw STACK"
+                        fi
+                done
+                exit 0
+        fi
+        for i in $(seq 0 "$no_of_years"); do
+                year=${arr1[$i]}
+                printf "y%s.value " "$year"
+                printf "%b" "albums 0 0 year:${year}\\nexit\\n" | "$NC" "$HOST" "$PORT" | sed 's/%3A/:/g' | cut -d ':' -f 3
+        done
+elif [ "$CMD" = "signalstrength" ] || [ "$CMD" = "mixer volume" ]; then
         if [ "$1" = "config" ]; then
             echo "graph_title $TITLE"
             echo "graph_category radio"
-            COUNT=$(printf "%b" "player count ?\nexit\n" | $NC $HOST $PORT | cut -d " " -f 3)
+            COUNT=$(printf "%b" 'player count ?\nexit\n' | "$NC" "$HOST" "$PORT" | cut -d " " -f 3)
             (( COUNT-- ))
-            for ID in $(seq 0 $COUNT); do
-                MAC=$(printf "%b" "player id $ID ?\nexit\n" | $NC $HOST $PORT | cut -d " " -f 4 | sed 's/%3A/:/g')
-		NAME=$(printf "%b" "player name $MAC ?\nexit\n" | $NC $HOST $PORT | cut -d " " -f 4 | sed 's/%20/ /g')
-		MAC2=$(echo $MAC | sed 's/://g; s/\./_/g')
-	        echo "$MAC2.label $NAME"
+            for ID in $(seq 0 "$COUNT"); do
+                MAC=$(printf "%b" "player id $ID ?\\nexit\\n" | "$NC" "$HOST" "$PORT" | cut -d " " -f 4 | sed 's/%3A/:/g')
+                NAME=$(printf "%b" "player name $MAC ?\\nexit\\n" | "$NC" "$HOST" "$PORT" | cut -d " " -f 4 | sed 's/%20/ /g')
+                MAC2=${MAC//:/}
+                MAC2=${MAC2//./_}
+                echo "$MAC2.label $NAME"
             done
             exit 0
         fi
-        COUNT=$(printf "%b" "player count ?\nexit\n" | $NC $HOST $PORT | cut -d " " -f 3)
+        COUNT=$(printf "%b" 'player count ?\nexit\n' | "$NC" "$HOST" "$PORT" | cut -d " " -f 3)
         (( COUNT-- ))
-        for ID in $(seq 0 $COUNT); do
-            MAC=$(printf "%b" "player id $ID ?\nexit\n" | $NC $HOST $PORT | cut -d " " -f 4 | sed 's/%3A/:/g')
-            VAL=$(printf "%b" "$MAC $CMD ?\nexit\n"| $NC $HOST $PORT | cut -d " " -f 2- | sed "s/$CMD //")
-            MAC2=$(echo $MAC| sed 's/://g')
-            [ $VAL -eq 0 ] && VAL=100
+        for ID in $(seq 0 "$COUNT"); do
+            MAC=$(printf "%b" "player id $ID ?\\nexit\\n" | "$NC" "$HOST" "$PORT" | cut -d " " -f 4 | sed 's/%3A/:/g')
+            VAL=$(printf "%b" "$MAC $CMD ?\\nexit\\n"| "$NC" "$HOST" "$PORT" | cut -d " " -f 2- | sed "s/$CMD //")
+            MAC2=${MAC//:/}
+            [ "$VAL" -eq 0 ] && VAL=100
             echo "$MAC2.value $VAL"
 	done
 else
@@ -210,5 +206,5 @@ else
 	fi
 	CMD="info total $ATTR "
 	echo -n "$ATTR.value "
-	printf "%b" "$CMD ?\nexit\n" | $NC $HOST $PORT | sed "s/^$CMD//"
+	printf "%b" "$CMD ?\\nexit\\n" | "$NC" "$HOST" "$PORT" | sed "s/^$CMD//"
 fi

--- a/plugins/node.d/vmstat.in
+++ b/plugins/node.d/vmstat.in
@@ -31,7 +31,7 @@ GPLv2
 
 =cut
 
-. $MUNIN_LIBDIR/plugins/plugin.sh
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "autoconf" ]; then
 	if ( vmstat 1 1 >/dev/null 2>&1 ); then


### PR DESCRIPTION
* fix many shellcheck issues of the current shell-based plugins
* add a "lint" target to the Makefile for style checks
    * for now: sh, bash, python
    * perl is currently missing, since the plugins are not perlcritic-clean
* add a travis step for this lint target
    * this should help contributors (and reviewers) to detect problems in advance