### PR TITLE
Update default warning threshold

### DIFF
--- a/plugins/node.d/snmp__fc_if_.in
+++ b/plugins/node.d/snmp__fc_if_.in
@@ -129,7 +129,7 @@ if ($ARGV[0] and $ARGV[0] eq "config")
 	print "recv.graph no\n";
 	print "recv.cdef recv,8,*\n";
 	print "recv.max 4000000000\n";
-	print "recv.warning ", (-$warn), "\n" if defined $warn;
+	print "recv.warning $warn\n" if defined $warn;
 	print "send.label bps\n";
 	print "send.type DERIVE\n";
 	print "send.min 0\n";

--- a/plugins/node.d/snmp__if_multi.in
+++ b/plugins/node.d/snmp__if_multi.in
@@ -666,7 +666,7 @@ sub do_config_if {
     print "recv.cdef recv,8,*\n";
     print "recv.max $speed\n" if $speed;
     print "recv.min 0\n";
-    print "recv.warning ", (-$warn), "\n" if defined $warn;
+    print "recv.warning $warn\n" if defined $warn;
     print "send.label bps\n";
     print "send.type DERIVE\n";
     print "send.negative recv\n";


### PR DESCRIPTION
As `recv` is a positve value, setting the warning threshold negative makes it launch an alarm when the value is actually OK