### PR TITLE
Fix munin-asyncd fork bomb

### DIFF
--- a/node/_bin/munin-asyncd.in
+++ b/node/_bin/munin-asyncd.in
@@ -169,8 +169,12 @@ MAIN: while($keepgoing) {
 			);
 
 			unless ($sock) {
-				warn "Error creating socket: $!, moving to next plugin to try again";
-				next;
+				if ($do_fork) {
+					die "Error creating socket: $!";
+				} else {
+					warn "Error creating socket: $!, moving to next plugin to try again";
+					next;
+				}
 			}
 
 			<$sock>; # skip header


### PR DESCRIPTION
If a forked child can't connect to munin-node, it should die rather than
moving to the next plugin. The latter leads to the child also forking
itself, recursively spawning an uncontrolled number of processes, which
quickly exhausts system resources.

Also applicable for stable-2.0.