### PR TITLE
Do not bump spoolfetch timestamp from non-timestamped values

### DIFF
--- a/lib/Munin/Master/UpdateWorker.pm
+++ b/lib/Munin/Master/UpdateWorker.pm
@@ -682,8 +682,10 @@ sub uw_handle_fetch {
 		my ($field, $arg, $value) = ($1, $2, $3);
 
 		my $when = $now; # Default is NOW, unless specified
+		my $when_is_now = 1;
 		if ($value =~ /^(\d+):(.+)$/) {
 			$when = $1;
+			$when_is_now = 0;
 			$value = $2;
 		}
 
@@ -692,7 +694,7 @@ sub uw_handle_fetch {
 		$when = round_to_granularity($when, $update_rate_in_seconds) if $is_update_aligned;
 
 		# Update last_timestamp if the current update is more recent
-		$last_timestamp = $when if $when > $last_timestamp;
+		$last_timestamp = $when if (!$when_is_now && $when > $last_timestamp);
 
 		# Update all data-driven components: State, RRD, Graphite
 		my $ds_id = $self->_db_state_update($plugin, $field, $when, $value);


### PR DESCRIPTION
Master assumes `$now` whenever it sees a non-timestamped value in spoolfetch data, which also bumps spoolfetch timestamp, leading to potential data loss in subsequent runs (see #933 for example).

This patch decouples the latter from the former: It will not consider `$now` for deriving `$last_timestamp`, but it will still use it for storing the particular value. It would be better to use the max observed timestamp for this, before falling back to `$now`, but stream-like processing of spoolfetch data does not afford this (as discussed in #938).

This is a re-work of #938 for 2.999, both of which address issue #940.