### PR TITLE
Avoid SpoolReader/SpoolWriter races with synchronized (atomic-like) updates to spool files

### DIFF
--- a/node/_bin/munin-asyncd.in
+++ b/node/_bin/munin-asyncd.in
@@ -24,6 +24,7 @@ use warnings;
 
 use IO::Socket;
 use IO::File;
+use IO::Select;
 use File::Path qw(mkpath);
 use Getopt::Long;
 use Pod::Usage;
@@ -40,7 +41,8 @@ my $timeout = 3600;
 my $minrate = 300;
 my $retaincount = 7;
 my $nocleanup;
-my $do_fork;
+my $do_fork = 0;
+my $subproc_read_timeout = 60;
 my $verbose;
 my $debug;
 my $help;
@@ -88,10 +90,14 @@ my $spoolwriter = Munin::Node::SpoolWriter->new(
 	interval_size => $intervalsize,
 	interval_keep => $retaincount,
 	hostname  => $metahostname,
+	commit_mode => 1 + $do_fork, # 1=do commit, 2=fork commit
+	commit_suffix => $$, # use our pid as suffix for tmp files
 );
 $0 = "munin-asyncd [$metahostname] [idle]";
 
 my $process_name = "main";
+
+my $select = IO::Select->new if ($do_fork);
 
 my @plugins;
 {
@@ -157,7 +163,8 @@ MAIN: while($keepgoing) {
 		$last_updated{$plugin} = $when;
 		$when_next = min($when_next, $when + max($plugin_rate, $minrate));
 
-		if ($do_fork && fork()) {
+		if ($do_fork && open my $cfh, '-|') {
+			$select->add($cfh);
 			# parent, return directly
 			next PLUGIN;
 		}
@@ -196,6 +203,24 @@ MAIN: while($keepgoing) {
 
 	print STDERR "[$$][$process_name] closing sock\n" if $verbose;
 	$sock = undef;
+
+	if ($do_fork) {
+	    my $bufs;
+	    while ($select->count) {
+		foreach my $cfh ($select->can_read($subproc_read_timeout)) {
+		    our $buf; local *buf = \$bufs->{fileno($cfh)}; $buf ||= '';
+		    unless (sysread $cfh, $buf, 4096, length($buf)) {
+			while ($buf =~ s/\G(\w+)\s+(.+)\n//) {
+			    if ($1 eq 'commit') {
+				$spoolwriter->add_file_to_commit($2);
+			    }
+			}
+			$select->remove($cfh);
+		    }
+		}
+	    }
+	}
+	$spoolwriter->do_commit();
 
 	$spoolwriter->set_metadata("lastruntime", $when);
 


### PR DESCRIPTION
`munin-asyncd` by default queries munin-node in turn for each plugin and writes to spool files. With `--fork` this happens in parallel. On the other hand `munin-async` iterates through spool files and scans them for new data.

Nothing stops spoolreader from reading from a file while (or before) spoolwriter writes to it in a particular round of updates. After such a spoolfetch, the master will have missed any updates written to spool files after spoolreader visited them. If it did fetch data that had already been written in that round, the master will also have bumped the spoolfetch timestamp and therefore it will skip over such data in subsequent spoolfetch, which means data loss.

This race condition is particularly evident when spoolfetch and spoolwriter coincide. For example if `munin-update` runs on the master every 5 minutes and `munin-asyncd` wakes up at the same time, the nodes visited by `munin-update` in the first 30-60 seconds are most likely to exhibit this problem. `munin-asyncd --fork` does help, but again if some munin plugins take a long time to run the respective services will be susceptible to data loss.

The proposed patch addresses the problem by emulating atomic-like updates to spool files. SpoolWriter writes updates to copies of spool files and moves (renames) them over in one go at the end. In fork mode, this involves pipe IPC where `munin-asyncd` reads files to be committed from its' children processes stdout.