### PR TITLE
Fix syntax error in make install sh code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ install-plugins-prime: install-plugins build $(PLUGINS) Makefile Makefile.config
 	    fi                                                 \
 	done
 	@# Some HP-UX plugins need *.adv support files in LIBDIR
-	if [ "$(OSTYPE)" = "hp-ux" ]; then mv $(LIBDIR)/plugins/*.adv $(LIBDIR); done
+	if [ "$(OSTYPE)" = "hp-ux" ]; then mv $(LIBDIR)/plugins/*.adv $(LIBDIR); fi
 	$(INSTALL) -m 0644 build/plugins/plugins.history $(LIBDIR)/plugins/
 	$(INSTALL) -m 0644 build/plugins/plugin.sh $(LIBDIR)/plugins/
 


### PR DESCRIPTION
if should be closed with fi, not done.

Fixes:

if [ "linux" = "hp-ux" ]; then mv /var/tmp/portage/net-analyzer/munin-2.0.38/image//usr/libexec/munin/plugins/*.adv /var/tmp/portage/net-analyzer/munin-2.0.38/image//usr/libexec/munin; done
/bin/sh: -c: line 0: syntax error near unexpected token `done'
/bin/sh: -c: line 0: `if [ "linux" = "hp-ux" ]; then mv /var/tmp/portage/net-analyzer/munin-2.0.38/image//usr/libexec/munin/plugins/*.adv /var/tmp/portage/net-analyzer/munin-2.0.38/image//usr/libexec/munin; done'
make: *** [Makefile:146: install-plugins-prime] Error 1