### PR TITLE
Makefile: DESTDIR handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ doc:
 
 .PHONY: install
 install: $(BUILD_SCRIPT)
-	"$(BUILD_SCRIPT)" install --destdir=$(DESTDIR) --verbose
+	"$(BUILD_SCRIPT)" install --destdir="$(DESTDIR)" --verbose
 	@# various directory placeholders (e.g. "@@SPOOLDIR@@") need to be replaced
 	grep -rl --null "@@" "$(DESTDIR)" | xargs -0 sed -i \
 		-e "$$(perl -I lib -M"Munin::Common::Defaults" \
@@ -63,7 +63,7 @@ clean: $(BUILD_SCRIPT)
 # perl module
 
 $(BUILD_SCRIPT): Build.PL
-	$(PERL) Build.PL --destdir=$(DESTDIR) --installdirs=$(INSTALLDIRS) --verbose
+	$(PERL) Build.PL --destdir="$(DESTDIR)" --installdirs="$(INSTALLDIRS)" --verbose
 
 
 ######################################################################

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ doc:
 install: $(BUILD_SCRIPT)
 	"$(BUILD_SCRIPT)" install --destdir="$(DESTDIR)" --verbose
 	@# various directory placeholders (e.g. "@@SPOOLDIR@@") need to be replaced
-	grep -rl --null "@@" "$(DESTDIR)" | xargs -0 sed -i \
+	grep -rl --null "@@" "$(or $(DESTDIR),.)" | xargs -0 sed -i \
 		-e "$$(perl -I lib -M"Munin::Common::Defaults" \
 			-e "Munin::Common::Defaults->print_as_sed_substitutions();")"
 


### PR DESCRIPTION
`make install` previously broke on an empty `DESTDIR` variable. Now it defaults to `.` (current directory), if empty.