### PR TITLE
LimitsOld: load configuration from file

### DIFF
--- a/lib/Munin/Master/LimitsOld.pm
+++ b/lib/Munin/Master/LimitsOld.pm
@@ -63,7 +63,7 @@ my $force          = 0;
 my $verbose        = 0;
 my $force_run_as_root = 0;
 my %notes          = ();
-my $config;
+my $config = Munin::Master::Config->instance()->{config};
 my $modified     = 0;
 my %default_text = (
     "default" =>


### PR DESCRIPTION
While packaging munin 2.999.9 I noticed, that `munin-limits` does not seem to load the configuration file:

```
Use of uninitialized value in concatenation (.) or string at /usr/share/perl5/Munin/Master/LimitsOld.pm line 124.
Use of uninitialized value in concatenation (.) or string at /usr/share/perl5/Munin/Master/LimitsOld.pm line 128.
Could not open /munin-limits.lock for read/write: Permission denied
 at /usr/share/perl5/Munin/Common/Logger.pm line 216.
```

The proposed changes just add `my $config = Munin::Master::Config->instance()->{config};` (as seen in `lib/Munin/Master/Update.pm`.

I am not sure about the following details:
* Do we need to `use Munin::Master::Config` before?
* I think, this change is not sufficient for actually *parsing* the config file. This would probably require something like `$config->parse_config_from_file($conffile);` at the end of `limits_startup`. But I am confused, that I did not see this code pattern in other places.