### PR TITLE
fix warning on node list operation

### DIFF
--- a/lib/Munin/Node/Server.pm
+++ b/lib/Munin/Node/Server.pm
@@ -167,7 +167,7 @@ sub _process_command_line {
 
     DEBUG ("DEBUG: Running command '$_'.") if $config->{DEBUG};
     if (/^list\s*([0-9a-zA-Z\.\-]+)?/i) {
-	my $hostname_lc = defined($1) ? lc($1) : undef;
+	my $hostname_lc = defined($1) ? lc($1) : '';
         _list_services($session, $hostname_lc);
     }
     elsif (/^cap\s?(.*)/i) {


### PR DESCRIPTION
  Use of uninitialized value $node in exists at .../sandbox/lib/perl5/Munin/Node/Server.pm line 332, <STDIN> line 1.