### PR TITLE
UpdateWorker: do not emit warnings for missing datasets

### DIFF
--- a/lib/Munin/Master/UpdateWorker.pm
+++ b/lib/Munin/Master/UpdateWorker.pm
@@ -499,8 +499,12 @@ sub _db_state_update {
 		WHERE ds.name = ?");
 	$sth_ds->execute($node_id, $plugin, $field);
 	my ($ds_id) = $sth_ds->fetchrow_array();
-	DEBUG "_db_state_update.ds_id:$ds_id";
 	$sth_ds->finish();
+	if (! defined $ds_id) {
+		$dbh->disconnect();
+		return undef;
+	}
+	DEBUG "_db_state_update.ds_id:$ds_id";
 
 	my $sth_state = $dbh->prepare_cached("SELECT last_epoch, last_value FROM state WHERE id = ? AND type = ?");
 	$sth_state->execute($ds_id, "ds");
@@ -712,7 +716,8 @@ sub uw_handle_fetch {
 
 		# Update all data-driven components: State, RRD, Graphite
 		my $ds_id = $self->_db_state_update($plugin, $field, $when, $value);
-	        DEBUG "[DEBUG] ds_id($plugin, $field, $when, $value) = $ds_id";
+		continue if (! defined $ds_id);
+		DEBUG "[DEBUG] ds_id($plugin, $field, $when, $value) = $ds_id";
 
 		my ($rrd_file, $rrd_field);
 		{


### PR DESCRIPTION
Currently the demo server (running 2.999.9-1) emits warnings after every run of `munin-update`:

```
Use of uninitialized value $ds_id in concatenation (.) or string at /usr/share/perl5/Munin/Master/UpdateWorker.pm line 487, <GEN0> line 51.
Use of uninitialized value $ds_id in concatenation (.) or string at /usr/share/perl5/Munin/Master/UpdateWorker.pm line 709, <GEN0> line 51.
Use of uninitialized value $rrd_file in concatenation (.) or string at /usr/share/perl5/Munin/Master/UpdateWorker.pm line 735, <GEN0> line 51.
Use of uninitialized value $rrd_file in concatenation (.) or string at /usr/share/perl5/Munin/Master/UpdateWorker.pm line 1351, <GEN0> line 51.
Use of uninitialized value $rrd_file in concatenation (.) or string at /usr/share/perl5/Munin/Master/UpdateWorker.pm line 1369, <GEN0> line 51.
Use of uninitialized value in subroutine entry at /usr/share/perl5/Munin/Master/UpdateWorker.pm line 1370, <GEN0> line 51.
Use of uninitialized value $rrd_file in concatenation (.) or string at /usr/share/perl5/Munin/Master/UpdateWorker.pm line 1375, <GEN0> line 51.
```

This changeset prevents the situations where access to uninitialized values happens.

But I am not sure, whether these warnings indicate a permanent failure (are datasets currently stored at all?), since they were repeated during every update period.