### PR TITLE
drop Alien::RRDtool dependency

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -122,7 +122,6 @@ my $build = Module::Build->new(
         'Net::Server::Fork'      => '0',
         'Parallel::ForkManager'  => '0',
         'Params::Validate'       => '1.08',
-        'Alien::RRDtool'         => '0',
         'URI'                    => '1.59',
         'XML::Dumper'            => '0',
     },


### PR DESCRIPTION
this module is nowhere used and this fixes

  *************************************************
  *  BUILD
  *************************************************
  Checking prerequisites...
    requires:
      !  Alien::RRDtool is not installed

  ERRORS/WARNINGS FOUND IN PREREQUISITES.  You may wish to install the versions
  of the modules indicated above before proceeding with this installation

  Run 'Build installdeps' to install missing prerequisites.