### PR TITLE
fix warning on munin-update

### DIFF
--- a/lib/Munin/Master/Update.pm
+++ b/lib/Munin/Master/Update.pm
@@ -174,7 +174,7 @@ sub _run_workers {
 
 	WORKER_LOOP:
 	for my $worker (@{$self->{workers}}) {
-		my $worker_pid = $pm->start();
+		my $worker_pid = $pm->start($worker);
 		next WORKER_LOOP if $worker_pid;
 
 		my $res;


### PR DESCRIPTION
  Use of uninitialized value $ident in concatenation (.) or string at /home/christian/Coding/workspace/munin/sandbox/lib/perl5/Munin/Master/Update.pm line 175.