### PR TITLE
Revert "fix warning on node list operation"

### DIFF
--- a/node/lib/Munin/Node/Server.pm
+++ b/node/lib/Munin/Node/Server.pm
@@ -168,7 +168,7 @@ sub _process_command_line {
 
     logger ("DEBUG: Running command '$_'.") if $config->{DEBUG};
     if (/^list\s*([0-9a-zA-Z\.\-]+)?/i) {
-	my $hostname_lc = defined($1) ? lc($1) : '';
+	my $hostname_lc = defined($1) ? lc($1) : undef;
         _list_services($session, $hostname_lc);
     }
     elsif (/^cap\s?(.*)/i) {


### PR DESCRIPTION
Reverts munin-monitoring/munin#1002

Result of discussion: leave it as `undef` and do the check in `master` within `_list_services`.