### PR TITLE
 [munin-node-configure] fail on non-zero autoconf exit

### DIFF
--- a/script/munin-node-configure
+++ b/script/munin-node-configure
@@ -82,7 +82,6 @@ sub parse_args
 	my $verbose = 0;
 	my $pidebug = 0;
 	my ($suggest, $shell, $removes, $newer);
-	my $exit_not_error = 1;
 	my @families;
 	my (@snmp_hosts, $snmpver, $snmpcomm, $snmpport, $snmpdomain);
     my ($snmp3username, $snmp3authpass, $snmp3authproto, $snmp3privpass, $snmp3privproto);
@@ -92,7 +91,6 @@ sub parse_args
         'version'         => \&print_version_and_exit,
 
         'suggest!'        => \$suggest,
-        'exitnoterror!'   => \$exit_not_error,
         'newer=s'         => \$newer,
 
         'shell!'          => \$shell,
@@ -166,7 +164,6 @@ sub parse_args
     $config->reinitialize({
         %$config,
 
-        exit_not_error => $exit_not_error,
         suggest        => $suggest,
 
         shell          => $shell,
@@ -354,12 +351,7 @@ sub run_plugin
 		elsif ($plugin_exit) {
             $plugin->log_error("Non-zero exit during $mode ($plugin_exit)");
 
-			# Verboten according to the specification, but lots of plugins
-            # still exit(1) it during autoconf.  So making it a non-fatal error
-			# for the time being
-			return unless ($mode eq 'autoconf'
-			           and $plugin_exit == 1
-			           and $config->{exit_not_error});
+	    return;
 		}
 	}
 


### PR DESCRIPTION
all plugins should match this behavior now