### PR TITLE
[plugins] set munin_stats family to manual

### DIFF
--- a/plugins/node.d/munin_stats
+++ b/plugins/node.d/munin_stats
@@ -18,7 +18,7 @@
 #
 #
 # Magic markers (used by munin-node-configure and some installation scripts):
-#%# family=auto
+#%# family=manual
 #%# capabilities=autoconf
 
 use strict;


### PR DESCRIPTION
munin_stats currently does not work with the rewritten munin 3.0