### PR TITLE
[plugins] fix procfs swap

### DIFF
--- a/plugins/node.d.linux/procfs
+++ b/plugins/node.d.linux/procfs
@@ -246,7 +246,7 @@ if ( -r "/proc/swaps" ) {
 	 type  => "DERIVE",
 	 min   => 0,
 	 graph => "no",
-	 value => $vmstat{pswpin}[0]  || $stat{swap}[0],
+	 value => defined($vmstat{pswpin}) ? $vmstat{pswpin}[0] : $stat{swap}[0],
 	},
 	swap_out =>
 	{
@@ -254,7 +254,7 @@ if ( -r "/proc/swaps" ) {
 	 type     => "DERIVE",
 	 min      => "0",
 	 negative => "swap_in",
-	 value    => $vmstat{pswpout}[0] || $stat{swap}[1]
+	 value    => defined($vmstat{pswpin}) ? $vmstat{pswpout}[0] : $stat{swap}[1],
 	},
        },
       }


### PR DESCRIPTION
/proc/stat does not contain any swap entires
when the vmstat value is zero it gets overridden

note: procfs seems not to be in stable-2.0