### PR TITLE
Partly remove explicit database disconnect calls

### DIFF
--- a/lib/Munin/Master/HTML.pm
+++ b/lib/Munin/Master/HTML.pm
@@ -583,7 +583,6 @@ RENDERING:
 		use JSON;
 		print encode_json( \%template_params );
 	}
-	$dbh->disconnect();
 }
 
 sub _get_params_groups {
@@ -842,7 +841,6 @@ sub get_param
 	my $datafilename = $ENV{MUNIN_DBURL} || "$Munin::Common::Defaults::MUNIN_DBDIR/datafile.sqlite";
 	my $dbh = Munin::Master::Update::get_dbh();
 	my ($value) = $dbh->selectrow_array("SELECT value FROM param WHERE name = ?", undef, ($param));
-	$dbh->disconnect();
 	return $value;
 }
 

--- a/lib/Munin/Master/LimitsOld.pm
+++ b/lib/Munin/Master/LimitsOld.pm
@@ -568,8 +568,6 @@ sub process_service {
 	$sth_state_upt->execute($new_state, $ds_id, "ds");
     }
     generate_service_message($hash);
-    $dbh_state->disconnect();
-    $dbh->disconnect();
 }
 
 

--- a/lib/Munin/Master/Update.pm
+++ b/lib/Munin/Master/Update.pm
@@ -53,7 +53,6 @@ sub run {
 		my $dbh = get_dbh();
 		$self->_db_init($dbh, $dbh);
 		$config_old = $self->_db_params_update($dbh, $config);
-		$dbh->disconnect();
 	}
 
         $self->{workers} = $self->_create_workers();


### PR DESCRIPTION
Database connections are freed implicitly during garbage collection.
We want to rely on this.

Partly reverting c8148a992637e365b7fa6329c7cb4f2d30c0735f