### PR TITLE
Build.PL: name and version

### DIFF
--- a/master/Build.PL
+++ b/master/Build.PL
@@ -3,9 +3,12 @@ use MasterBuilder;
 use warnings;
 use strict;
 
+my $version = `../getversion`;
+chomp($version);
+
 my $build = MasterBuilder->new(
-    dist_name      => 'Munin::Master',
-    dist_version   => '0.0.0',
+    module_name    => 'Munin::Master',
+    dist_version   => $version,
     dist_author    => 'The Munin Team <fix@example.com>',
     dist_abstract  => 'The Munin Master',
     license        => 'gpl',

--- a/node/Build.PL
+++ b/node/Build.PL
@@ -3,9 +3,12 @@ use NodeBuilder;
 use warnings;
 use strict;
 
+my $version = `../getversion`;
+chomp($version);
+
 my $build = NodeBuilder->new(
-    dist_name      => 'Munin::Node',
-    dist_version   => '0.0.0',
+    module_name    => 'Munin::Node',
+    dist_version   => $version,
     dist_author    => 'The Munin Team <fix@example.com>',
     dist_abstract  => 'The Munin Node',
     license        => 'gpl',


### PR DESCRIPTION
Fix the following warning that is emitted during the build process:
```
No 'module_name' was provided and it could not be inferred ...
```

Reported by bcg via IRC.