### PR TITLE
munin-node: set default port if not mentioned in config file

### DIFF
--- a/node/lib/Munin/Node/Server.pm
+++ b/node/lib/Munin/Node/Server.pm
@@ -153,6 +153,15 @@ sub process_request
 }
 
 
+# This method is used by Net::Server for retrieving default values (in case they are not specified
+# in the given "conf_file").
+sub default_values {
+    return {
+        port => 4949,
+    };
+}
+
+
 sub _process_command_line {
     my ($session, $cmd_line) = @_;
 


### PR DESCRIPTION
According to the documentation, munin-node's default port is 4949.
But this default was not configured up to now.
Thus if no "port" line was specified in "munin-node.conf", then the
implicit default port of Net::Server (20203) was used.

Closes: #873