### PR TITLE
ProcessManager: remove \n from output before it's logged

### DIFF
--- a/master/lib/Munin/Master/ProcessManager.pm
+++ b/master/lib/Munin/Master/ProcessManager.pm
@@ -263,6 +263,7 @@ sub _do_work {
 	}
     };
     if ($EVAL_ERROR) {
+        $EVAL_ERROR =~ s/\R//;
         ERROR "[ERROR] $worker died with '$EVAL_ERROR'";
         $res = undef;
         $retval = $E_DIED;


### PR DESCRIPTION
EVAL_ERROR can be "[FATAL] Socket read from ... line 254.\n" which would
then be logged as "... line 254.\n'\n" by next line, two lines. Fix it by
removing \n and other line ends from EVAL_ERROR.

This fixes bug #1057.