### PR TITLE
[munin-node-configure] add disable keyword to disable plugins

### DIFF
--- a/doc/plugin/use.rst
+++ b/doc/plugin/use.rst
@@ -104,6 +104,12 @@ timeout <seconds>
 command <command>
   Run <command> instead of plugin. %c will be expanded to what would otherwise have been run. E.g. command sudo -u root %c.
 
+disable_autoconf <boolean>
+  If set to True, ignore plugin when running munin-node-configure.
+  This prevents the plugin even when possibly be supported on the system to be installed.
+
+  Default: False
+
 .. note::
 
    When configuring a munin plugin, add the least amount of extra

--- a/lib/Munin/Node/Config.pm
+++ b/lib/Munin/Node/Config.pm
@@ -280,6 +280,9 @@ sub _parse_plugin_line {
     elsif ($var_name eq 'update_rate') {
         return (update_rate => $var_value);
     }
+    elsif ($var_name eq 'disable_autoconf') {
+        return (disable_autoconf => _convert_bool($var_value));
+    }
     elsif (index($var_name, 'env.') == 0) {
         return (env => { substr($var_name, length 'env.') => $var_value});
     }
@@ -337,6 +340,15 @@ sub _apply_wildcard_to_service {
 
     $self->{sconf}{$service} = $sconf;
     return;
+}
+
+
+sub _convert_bool {
+    my ($arg) = @_;
+
+    return 1 if grep(/^$arg$/x, qw(true True TRUE));
+    return 0 if grep(/^$arg$/x, qw(false False FALSE));
+    croak "Invalid boolean value '$arg'";
 }
 
 

--- a/script/munin-node-configure
+++ b/script/munin-node-configure
@@ -247,6 +247,9 @@ sub gather_suggestions
     $plugins->{library}->prepare_plugin_environment($plugins->names);
 
     foreach my $plugin ($plugins->list) {
+        my $disable_autoconf = $config->{sconf}{$plugin->{name}}{disable_autoconf};
+        next if defined $disable_autoconf && $disable_autoconf;
+
         fetch_plugin_autoconf($plugins, $plugin);
         fetch_plugin_suggestions($plugins, $plugin);
     }


### PR DESCRIPTION
Suggested by #1066 

To disable a plugin, put a file in CONFDIR/plugin-conf.d with the content:

    [pluginname]
    disable true