### PR TITLE
plugins/nginx_request: stats are for all ports (80+443), never for single port

### DIFF
--- a/plugins/node.d/nginx_request.in
+++ b/plugins/node.d/nginx_request.in
@@ -66,7 +66,6 @@ if (! eval "require LWP::UserAgent;"){
 }
 
 my $URL = exists $ENV{'url'} ? $ENV{'url'} : "http://localhost/nginx_status";
-my $port = exists $ENV{'port'} ? $ENV{'port'} : "80";
 
 if ( exists $ARGV[0] and $ARGV[0] eq "autoconf" )
 {
@@ -99,7 +98,7 @@ if ( exists $ARGV[0] and $ARGV[0] eq "config" )
 	print "graph_vlabel Requests per \${graph_period}\n";
 	print "request.type DERIVE\n";
 	print "request.min 0\n";
-	print "request.label requests port $port\n";
+	print "request.label requests\n";
 	print "request.draw LINE\n";
 
 	exit 0;


### PR DESCRIPTION
Plugin label defaulted to text "requests port 80" and required special
config to output more modern label "requests port 443".

Nginx stats contains sum of all ports, never single port. You can not generate
stats for 80 and 443 separately. It's much simpler to just remove "env.port"
support so that port config is not needed and label is correct.