### PR TITLE
plugins/squid_traffic: allow negative numbers

### DIFF
--- a/plugins/node.d/squid_traffic.in
+++ b/plugins/node.d/squid_traffic.in
@@ -126,7 +126,7 @@ sub query_squid {
     $cachemgr->syswrite($request, length($request));
     my @lines = $cachemgr->getlines();
     for(my $i = 0; $i <= $#lines; $i++) {
-	if($lines[$i] =~ /$target\s+(\d+)/) {
+	if($lines[$i] =~ /$target\s+(-?\d+)/) {
 	    print "$1.value $2\n";
 	}
     }


### PR DESCRIPTION
Sometimes squid's status output contains negative numbers. Allow and
return them as is.