### PR TITLE
munin-asyncd: retry connection to node once in startup

### DIFF
--- a/node/_bin/munin-asyncd.in
+++ b/node/_bin/munin-asyncd.in
@@ -76,7 +76,14 @@ unless (-d $SPOOLDIR) {
 my $sock = new IO::Socket::INET(
 	PeerAddr        => "$host",
 	Proto   => 'tcp'
-) || die "Error creating socket: $!";
+);
+if (!$sock) {
+	sleep 20;
+	$sock = new IO::Socket::INET(
+		PeerAddr        => "$host",
+		Proto   => 'tcp'
+	) || die "Error creating socket: $!";
+}
 my $nodeheader = <$sock>;
 print $sock "quit\n";
 close ($sock);


### PR DESCRIPTION
On startup munin-asyncd connects to munin-node to get node hostname.
Sometimes on reboot / restart in systemd-environment munin-node is not
ready yet to accept incoming connection, and asyncd dies. Do small sleep
and retry if this happens, instead of die().