### PR TITLE
Build.PL: fix build on systems where Perl's INC path doesn't contain "."

### DIFF
--- a/master/Build.PL
+++ b/master/Build.PL
@@ -1,3 +1,4 @@
+BEGIN { push @INC, '.'; }
 use MasterBuilder;
 
 use warnings;

--- a/node/Build.PL
+++ b/node/Build.PL
@@ -1,3 +1,4 @@
+BEGIN { push @INC, '.'; }
 use NodeBuilder;
 
 use warnings;

--- a/plugins/Build.PL
+++ b/plugins/Build.PL
@@ -1,3 +1,4 @@
+BEGIN { push @INC, '.'; }
 use PluginsBuilder;
 
 use warnings;


### PR DESCRIPTION
This is needed on Fedora and I remember seeing something similar on Debian too.