### PR TITLE
remove the usage of List::Util::any()

### DIFF
--- a/lib/Munin/Common/Utils.pm
+++ b/lib/Munin/Common/Utils.pm
@@ -8,7 +8,6 @@ our @ISA = qw/Exporter/;
 our @EXPORT_OK = qw( is_valid_hostname );
 
 use Params::Validate qw( :all );
-use List::Util qw( all any );
 
 ### Set operations #############################################################
 
@@ -23,8 +22,8 @@ sub is_valid_hostname {
 
     # each part
     my @parts = (split(/[.]/, $hostname));
-    return if any { length > 63 } @parts;
-    return if any { ! /^[a-z0-9\-]+$/ } @parts;
+    return if grep { length > 63 } @parts;
+    return if grep { ! /^[a-z0-9\-]+$/ } @parts;
 
     return $hostname;
 


### PR DESCRIPTION
This is added only in Perl 5.20+.

Prior it was in the "SUGGESTED ADDITIONS" since them being very simple
to implement in perl.

5.20 does implement them in XS, but a simple "grep {} @A" is enough. It
isn't that efficient, since there is no shortcut eval, but it isn't in a
time critical code path anyway.

And portability is always better than unused efficiency.