### PR TITLE
munin-asyncd: sync munin-cron and munin-asyncd runtimes to not overlap (version 2)

### DIFF
--- a/node/_bin/munin-asyncd.in
+++ b/node/_bin/munin-asyncd.in
@@ -143,7 +143,13 @@ my $last_cleanup=0;
 MAIN: while($keepgoing) {
 	my $when = time;
 
-	my $when_next = $when + $timeout; # wake up at least every $timeout sec
+	# start the next run close to the end of a munin-node update operation
+	# (i.e. try to avoid overlapping activities)
+	my $when_next = int((int($when / $minrate) + 0.75) * $minrate);
+	while ($when_next <= $when) {
+		$when_next = $when_next + $minrate;
+	}
+
 	my $sock;
 	PLUGIN: foreach my $plugin (@plugins) {
 		# See if this plugin should be updated
@@ -155,7 +161,6 @@ MAIN: while($keepgoing) {
 
 		# Should update it
 		$last_updated{$plugin} = $when;
-		$when_next = min($when_next, $when + max($plugin_rate, $minrate));
 
 		if ($do_fork && fork()) {
 			# parent, return directly


### PR DESCRIPTION
If munin-cron and munin-asyncd are run at exactly same time for
same plugin the result is UNKNOWN status for plugin. It will change
randomly between OK and UNKNOWN, generating hundreds of warning emails
from munin-limits.

This patch adds trivial fix:

Munin-cron is run at "*/5" by cron, so run munin-asyncd
at "*/5 + 0.75 * $minrate".