### PR TITLE
Lint spelling

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -1,0 +1,14 @@
+# This file contains exact (and complete) lines of text that should be ignored by "codespell" in all files.
+# Hint for adding new lines:
+#  sed -n LINEp FILENAME >>.codespell.exclude
+
+It turns out that multigraph plugins are written to generate graphs for all network devices or all disk devices on a system. There is a definitive need to provide filtering (include) features, such as device name patterns for disk devices or media types for network boxes so that only e.g. ethernet and ppp devices are included in the graphs, and not the loopback and serial devices (unless the serial device is actually interesting since it's really a long haul WAN line). Or, on the other hand a exclude feature to drop specifically uninteresting things.
+Stig Sandbeck Mathisen, E<lt>ssm@fnord.noE<gt>
+                'info' => 'Number of packets queued in OFO queue',
+                'info' => 'packets meant to be queued in OFO but dropped because socket rcvbuf limit hit',
+                'label' => 'DSACKS for Ofo received',
+                'label' => 'DSACKs for Ofo sent',
+Copyright 2009 Tim Small <tim@seoss.co.uk>
+# Linjen som grep'es ut kan se ut som dette:
+Mo Amini, Diyar Amin and Younes Hajji, Høgskolen i Oslo/Oslo
+uses code written by Mo Amini, Diyar Amin and Younes Hajji, 

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,14 +73,14 @@ before_install:
   - cpanm --quiet --installdeps --notest .
 
 install:
-  # check for potential spelling mistakes
-  - codespell --quiet-level=3 --skip=ChangeLog,Announce-2.0,*.js,memory,jmx_,jmx_tomcat_dbpools,netstat_multi,munin_node_os.t
   - perl Build.PL
   - ./Build build
   # We want to lint first, to avoid expensive tests if code isn't clean
   - make lint-munin
   # Plugins are currently not compliant
   - make lint-plugins || true
+  # check for potential spelling mistakes
+  - make lint-spelling
 script:
   - cover -test -report coveralls
 

--- a/Announce-2.0
+++ b/Announce-2.0
@@ -32,7 +32,7 @@ Availability:
 * You can find Munin 2.0 as source tar ball at sourceforge
   (https://sourceforge.net/projects/munin/files/)
 
-* Debian Experimental. Hopefuly in the next stable release
+* Debian Experimental. Hopefully in the next stable release
 
 * Expected in EPEL (Extra Packages for (Red Hat) Enterprise Linux) within
   not too long

--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,11 @@ lint-plugins:
 	# TODO: perl plugins currently fail with perlcritic
 
 lint-spelling:
+	# codespell misdetections may be ignored by adding the full line of text to the file .codespell.exclude
 	find . -type f -print0 \
 		| grep --null-data -vE '^\./(\.git|\.pc|doc/_build|blib|.*/blib|build|sandbox|web/static/js|contrib/plugin-gallery/www/static/js)/' \
 		| grep --null-data -vE '\.(svg|png|gif|ico|css|woff|woff2|ttf|eot)$$' \
-		| xargs -0 -r codespell
+		| xargs -0 -r codespell --exclude-file=.codespell.exclude
 
 .PHONY: clean
 clean: $(BUILD_SCRIPT)

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,9 @@ apply-formatting:
 	@# format munin libraries
 	find lib/ -type f -exec perltidy {} \;
 
-.PHONY: lint lint-munin lint-plugins
+.PHONY: lint lint-munin lint-plugins lint-spelling
 
-lint: lint-munin lint-plugins
+lint: lint-munin lint-plugins lint-spelling
 lint-munin:
 	# Scanning munin code
 	perlcritic --profile .perlcriticrc lib/ script/
@@ -92,6 +92,12 @@ lint-plugins:
 		| xargs -0 grep -l --null "^#!.*python" \
 			| xargs -0 $(PYTHON_LINT_CALL)
 	# TODO: perl plugins currently fail with perlcritic
+
+lint-spelling:
+	find . -type f -print0 \
+		| grep --null-data -vE '^\./(\.git|\.pc|doc/_build|blib|.*/blib|build|sandbox|web/static/js|contrib/plugin-gallery/www/static/js)/' \
+		| grep --null-data -vE '\.(svg|png|gif|ico|css|woff|woff2|ttf|eot)$$' \
+		| xargs -0 -r codespell
 
 .PHONY: clean
 clean: $(BUILD_SCRIPT)

--- a/doc/develop/plugins/howto-write-snmp-plugins.rst
+++ b/doc/develop/plugins/howto-write-snmp-plugins.rst
@@ -108,7 +108,7 @@ You need a config section too.
         }
 
 That makes the plugin configurable. Please notice that the plugin prints a
-`host_name` line if it's not examining the locahost. This is the way Munin
+`host_name` line if it's not examining the localhost. This is the way Munin
 knows which device a non-local plugin is examining.
 
 All cool and good. Now we need it to autoconfigure for each new SNMP agent you

--- a/doc/example/graph/aggregation-combined.rst
+++ b/doc/example/graph/aggregation-combined.rst
@@ -12,7 +12,7 @@
  Loaning data combined with sum and cdef
 ========================================
 
-Different arithmetics may be combined to create the graphs you want.
+Different arithmetic operations may be combined to create the graphs you want.
 Insert appropriate lines in the Munin Master configuration file :ref:`munin.conf <munin.conf>`.
 
 The first example shows how to create a graph by loaning data from other sources, then adding an average value from five other data sources using :ref:`sum <fieldname.sum>` and :ref:`cdef <fieldname.cdef>`. The data in the example uses the following types of temperature measurements

--- a/doc/example/tips/multimaster.rst
+++ b/doc/example/tips/multimaster.rst
@@ -58,7 +58,7 @@ Exemples will consider the shared folder /nfs/munin.
 Running munin-update
 ====================
 
-Cange the ``munin-cron`` to only run ``munin-update`` (and
+Change the ``munin-cron`` to only run ``munin-update`` (and
 ``munin-limits``, if you have alerts you want to be managed directly on
 those masters).
 

--- a/doc/reference/munin-node.conf.rst
+++ b/doc/reference/munin-node.conf.rst
@@ -117,7 +117,7 @@ These are the most common Net::Server options used in
 .. option:: cidr_allow
 
    Allowed hosts given in CIDR notation (192.0.2.1/32). Replaces or
-   complements “allow”. Requires the precense of Net::Server, but is
+   complements “allow”. Requires the presence of Net::Server, but is
    not supported by old versions of this module.
 
 .. option:: cidr_deny

--- a/doc/reference/munin.conf.rst
+++ b/doc/reference/munin.conf.rst
@@ -344,7 +344,7 @@ only to that node.
 
    If set, changes the name by which the node presents itself when warning through :ref:`munin-limits`.
 
-.. note:: This directive can also be used on hiearchy level plugin to change the name by which the plugin presents itself when warning through ``munin-limits``.
+.. note:: This directive can also be used on hierarchy level plugin to change the name by which the plugin presents itself when warning through ``munin-limits``.
 
 .. option:: ignore_unknown <yes|no>
 

--- a/lib/Munin/Common/Defaults.pm.PL
+++ b/lib/Munin/Common/Defaults.pm.PL
@@ -145,7 +145,7 @@ Export all the package variables to the environment.
   $class->print_as_sed_substitutions()
 
 Output an expression suitable for "sed". This expression can be used to
-substitude placeholders (e.g. "@@SPOOLDIR") in munin's source files
+substitute placeholders (e.g. "@@SPOOLDIR") in munin's source files
 during an installation procedure.
 
 =back

--- a/lib/Munin/Master/Graph.pm
+++ b/lib/Munin/Master/Graph.pm
@@ -41,7 +41,7 @@ use Data::Dumper;
 
 # Hash of available palettes
 my %PALETTE;
-# Array of actuall colours to use
+# Array of colours to use
 my @COLOUR;
 
 {

--- a/lib/Munin/Master/Node.pm
+++ b/lib/Munin/Master/Node.pm
@@ -213,7 +213,7 @@ sub _do_close {
 
 sub negotiate_capabilities {
     my ($self) = @_;
-    # Please note: Sone of the capabilities are asymetrical.  Each
+    # Please note: Sone of the capabilities are asymmetrical.  Each
     # side simply announces which capabilities they have, and then the
     # other takes advantage of the capabilities it understands (or
     # dumbs itself down to the counterparts level of sophistication).

--- a/lib/Munin/Master/UpdateWorker.pm
+++ b/lib/Munin/Master/UpdateWorker.pm
@@ -178,7 +178,7 @@ sub do_work {
 
 		$last_timestamp = $node->fetch_service_data($plugin,
 			sub {
-				# First argument is the plugin name to be overrided when multigraphing
+				# First argument is the plugin name to be overridden when multigraphing
 				my $plugin_name = shift;
 
 				$self->uw_handle_fetch($plugin_name, $now, $update_rate, @_);
@@ -1076,7 +1076,7 @@ sub _update_rrd_file {
 		} elsif($RRDs::VERSION < 1.3){
 			WARN "[WARN] RRDCached feature ignored: perl RRDs lib version must be at least 1.3. Version found: " . $RRDs::VERSION;
 		} else {
-			# Using the RRDCACHED_ADDRESS environnement variable, as
+			# Using the RRDCACHED_ADDRESS environment variable, as
 			# it is way less intrusive than the command line args.
 			$ENV{RRDCACHED_ADDRESS} = $config->{"rrdcached_socket"};
 		}

--- a/plugins/node.d.linux/meminfo
+++ b/plugins/node.d.linux/meminfo
@@ -848,7 +848,7 @@ my $fields_source =
     'munin' =>
     {
       'label' => 'Mapped',
-      'info'  => 'Files which have been mmaped, such as libraries'
+      'info'  => 'Files which have been mapped, such as libraries'
     }
   },
   # ----------------------------------------------

--- a/plugins/node.d.sunos/memory
+++ b/plugins/node.d.sunos/memory
@@ -8,7 +8,7 @@ memory - Show memory stats based on top output
 
 =head1 Applicable systems
 
-Solaris systems with the package SUNWtop or other package containint
+Solaris systems with the package SUNWtop or other package containing
 top installed.
 
 =head1 CONFIGURATION

--- a/plugins/node.d/memcached_
+++ b/plugins/node.d/memcached_
@@ -11,7 +11,7 @@
 #
 # If multiple memcache instances are running memcached_INSTANCE_DATASET can be
 # used and INSTANCE can be any instance name that will show up in the title.
-# In thise case your config should specify a different port/host for each like
+# In this case your config should specify a different port/host for each like
 # using the following in plugin configuration file:
 #
 # [memcached_pages_*]

--- a/plugins/node.d/munin_update
+++ b/plugins/node.d/munin_update
@@ -35,7 +35,7 @@ munin-update forks one process pr. host that needs to get data
 collected, so all collection runs in parallel.
 
 Any host that is slow, for example slower than 4 miniutes, causes a
-risk that the next run of munin-update must be cancled due to the
+risk that the next run of munin-update must be canceled due to the
 lateness of the previous run.  In such cases there will be single line
 gaps in the "by day" graph.
 

--- a/plugins/node.d/smart_
+++ b/plugins/node.d/smart_
@@ -488,7 +488,7 @@ def get_hard_drive_name(plugin_name):
             # Let's see if we find a '-' in the drive name.
             if '-' in name:
                 name = name.split('-')[0]
-        # Chech that the drive exists in /dev
+        # Check that the drive exists in /dev
         if guess_full_path(name) is None:
             verboselog('/dev/(disk/by-id/)? {} not found!'.format(name))
             sys.exit(1)


### PR DESCRIPTION
* add another "lint" target "lint-spelling"
* use `make lint-spelling` in `.travis.yml`
* fix a few spelling mistakes
* add some exclusions for codespell