### PR TITLE
Only apply Perl 5.20 CGI workaround when needed

### DIFF
--- a/master/_bin/munin-cgi-html.in
+++ b/master/_bin/munin-cgi-html.in
@@ -168,7 +168,9 @@ sub get_node_service {
 
 # CGI in perl 5.20 is now seriously broken as it doesn't import into the namespace.
 # So we have to delegate explicitely. It's easier than prefixing with CGI:: each use.
-sub header { return CGI::header(@_); }
-sub path_info { return CGI::path_info(@_); }
-sub url { return CGI::url(@_); }
-sub script_name { return CGI::script_name(@_); }
+if(!defined &header){
+	*header = sub { return CGI::header(@_); };
+	*path_info = sub { return CGI::path_info(@_); };
+	*url = sub { return CGI::url(@_); };
+	*script_name = sub { return CGI::script_name(@_); };
+}


### PR DESCRIPTION
I'm running a Munin 2.0.42 server on CentOS 7, which currently bundles Perl 5.16.3.  9fabbe79671de2ab6b82c9319e69fb7f6878e921 added a workaround for Perl 5.20, but on Perl 5.16, it generates warnings:

    munin-cgi-html: Subroutine header redefined at /var/www/html/munin/cgi/munin-cgi-html line 171.
    munin-cgi-html: Subroutine path_info redefined at /var/www/html/munin/cgi/munin-cgi-html line 172.
    munin-cgi-html: Subroutine script_name redefined at /var/www/html/munin/cgi/munin-cgi-html line 174.
    munin-cgi-html: Subroutine url redefined at /var/www/html/munin/cgi/munin-cgi-html line 173.

This PR changes the local trampolines to be conditionally defined.

Tested on Perl 5.16.3, 5.18.2, and 5.28.0 — no longer generates warnings.
