### PR TITLE
Enable `lint-plugins` result during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,7 @@ install:
   - ./Build build
   # We want to lint first, to avoid expensive tests if code isn't clean
   - make lint-munin
-  # Plugins are currently not compliant
-  - make lint-plugins || true
+  - make lint-plugins
   # check for potential spelling mistakes
   - make lint-spelling
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,10 +76,9 @@ install:
   - perl Build.PL
   - ./Build build
   # We want to lint first, to avoid expensive tests if code isn't clean
-  - make lint-munin
-  - make lint-plugins
-  # check for potential spelling mistakes
-  - make lint-spelling
+  # The "PYTHON_LINT_CALL" environment variable works around an old version of python3-flake8 that
+  # is available in the travis environment.
+  - PYTHON_LINT_CALL="python3 -m flake8.main" make lint
 script:
   - cover -test -report coveralls
 

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,12 @@ lint-munin:
 	perlcritic --profile .perlcriticrc lib/ script/
 
 lint-plugins:
-
 	@# SC1008: ignore our weird shebang (substituted later)
 	@# SC1090: ignore sourcing of files with variable in path
 	@# SC2009: do not complain about "ps ... | grep" calls (may be platform specific)
 	@# SC2126: tolerate "grep | wc -l" (simple and widespread) instead of "grep -c"
+	@# SC2230: tolerate "which" instead of "command -v".  The latter does not output a full
+	#          path. Thus executable tests ("-x") would fail.  This would need a bit of work.
 	# TODO: fix the remaining shellcheck issues for the missing platforms:
 	#       aix, darwin, netbsd, sunos
 	#       (these require tests with their specific shell implementations)
@@ -84,10 +85,10 @@ lint-plugins:
 			plugins/node.d.debug/ \
 			plugins/node.d.linux/ -type f -print0 \
 		| xargs -0 grep -l --null '^#!.*/bin/sh' \
-			| xargs -0 shellcheck --exclude=SC1008,SC1090,SC2009,SC2126 --shell dash
+			| xargs -0 shellcheck --exclude=SC1008,SC1090,SC2009,SC2126,SC2230 --shell dash
 	find plugins/ -type f -print0 \
 		| xargs -0 grep -l --null "^#!.*/bin/bash" \
-			| xargs -0 shellcheck --exclude=SC1008,SC1090,SC2009,SC2126 --shell bash
+			| xargs -0 shellcheck --exclude=SC1008,SC1090,SC2009,SC2126,SC2230 --shell bash
 	find plugins/ -type f -print0 \
 		| xargs -0 grep -l --null "^#!.*python" \
 			| xargs -0 $(PYTHON_LINT_CALL)

--- a/plugins/node.d.hp-ux/gp_gbl_mem_util
+++ b/plugins/node.d.hp-ux/gp_gbl_mem_util
@@ -68,7 +68,6 @@ to avoid parsing problems on start of munin-node.
 =cut
 
 PATH=/usr/bin:/usr/sbin
-MUNIN_RUN=@@SBINDIR@@/munin-run
 PLUGIN=${0##*/}
 
 # These variables are required to run Glance

--- a/plugins/node.d.hp-ux/gp_gbl_mem_util
+++ b/plugins/node.d.hp-ux/gp_gbl_mem_util
@@ -1,6 +1,7 @@
 #!/usr/local/bin/bash
 #
 
+# shellcheck disable=SC1117
 : <<=cut
 
 =head1 NAME
@@ -71,11 +72,11 @@ PATH=/usr/bin:/usr/sbin
 PLUGIN=${0##*/}
 
 # These variables are required to run Glance
-: ${GLANCE:=/opt/perf/bin/glance}
-: ${HOME:=/home/munin}
-: ${ADVISER_INT:=4}
-: ${ADVISER_ITS:=2}
-: ${ADVISER:=@@LIBDIR@@/$PLUGIN.adv}
+: "${GLANCE:=/opt/perf/bin/glance}"
+: "${HOME:=/home/munin}"
+: "${ADVISER_INT:=4}"
+: "${ADVISER_ITS:=2}"
+: "${ADVISER:=@@LIBDIR@@/$PLUGIN.adv}"
 
 export PATH
 export HOME
@@ -86,18 +87,19 @@ if [[ $1 = autoconf ]]; then
 	exit 0
     fi
     set +u
-    if [ ! -x $GLANCE ]; then
+    if [ ! -x "$GLANCE" ]; then
 	gp_depot=$(swlist -l product|awk '{if(match(tolower($0),"glance")){print$1}}')
 	if [[ -n $gp_depot ]]; then
+	    # shellcheck disable=SC2086
 	    GLANCE=$(swlist -l file $gp_depot|awk '$NF~/bin\/glance$/{print$NF}')
-	    [[ -n $GLANCE ]] && [ -x $GLANCE ] || exit 1
+	    [ -n "$GLANCE" ] && [ -x "$GLANCE" ] || exit 1
 	else
 	    echo "no (Found no glance executable in a standard location)"
 	    exit 0
 	fi
     fi
 
-    if [ ! -f $ADVISER ]; then
+    if [ ! -f "$ADVISER" ]; then
 	echo "no (Found no adviser command file, please copy $PLUGIN.adv to $ADVISER)"
 	exit 0
     fi
@@ -130,4 +132,4 @@ fi
 
 [ -f "$ADVISER" ] || exit 1
 j=${ADVISER_INT:-4} i=${ADVISER_ITS:-2}
-/opt/perf/bin/glance -j $j -iterations $i -adviser_only -syntax $ADVISER 2>/dev/null
+/opt/perf/bin/glance -j $j -iterations $i -adviser_only -syntax "$ADVISER" 2>/dev/null

--- a/plugins/node.d.hp-ux/if_
+++ b/plugins/node.d.hp-ux/if_
@@ -17,16 +17,16 @@
 #%# capabilities=autoconf suggest
 
 PATH=/usr/bin:/usr/sbin
-INTERFACE=$(basename $0 | sed 's/^if_//g')
+INTERFACE=$(basename "$0" | sed 's/^if_//g')
 LANADMIN=/usr/sbin/lanadmin
 LANSCAN=/usr/sbin/lanscan
 
 if [[ $1 = autoconf ]]; then
-    if ! uname -s|grep -qEi hp-?ux; then
+    if ! uname -s|grep -qEi "hp-?ux"; then
         echo "no (OS doesn't seem to be HP-UX but reports as '$(uname -s)')"
         exit 0
     fi
-    if [ -x $LANADMIN ]; then
+    if [ -x "$LANADMIN" ]; then
         echo yes
         exit 0
     else
@@ -37,8 +37,8 @@ fi
 
 if [[ $1 = suggest ]]; then
     # lanscan will list all usable NICs seen by the kernel
-    if [ -x $LANSCAN ] \
-            && seen=$($LANSCAN|awk '$3~/^[0-9]+$/&&$4=="UP"{print$5}'); then
+    if [ -x "$LANSCAN" ] \
+            && seen=$("$LANSCAN" | awk '$3~/^[0-9]+$/&&$4=="UP"{print$5}'); then
         # but netstat will only list currently configured NICs
         if [[ -n $seen ]] && netstat -in|grep -q "$seen"; then
             # HP-UX names all NICs with leading string "lan" (afaik)
@@ -56,6 +56,7 @@ if [[ $1 = config ]]; then
     echo "graph_order inbound outbound"
     echo "graph_title $INTERFACE traffic"
     echo 'graph_args --base 1000'
+    # shellcheck disable=SC2016
     echo 'graph_vlabel bits per ${graph_period} in (-) / out (+)'
     echo 'graph_category network'
     echo 'inbound.label received'
@@ -71,5 +72,5 @@ if [[ $1 = config ]]; then
     exit 0
 fi
 
-/usr/sbin/lanadmin -g mibstats ${INTERFACE#lan} \
+/usr/sbin/lanadmin -g mibstats "${INTERFACE#lan}" \
     |awk '/(In|Out)bound Octets/{printf"%s.value %d\n",tolower($1),$NF}'

--- a/plugins/node.d.hp-ux/if_err_
+++ b/plugins/node.d.hp-ux/if_err_
@@ -17,12 +17,12 @@
 #%# capabilities=autoconf suggest
 
 PATH=/usr/bin:/usr/sbin
-INTERFACE=$(basename $0 | sed 's/^if_err_//g')
+INTERFACE=$(basename "$0" | sed 's/^if_err_//g')
 LANADMIN=/usr/sbin/lanadmin
 LANSCAN=/usr/sbin/lanscan
 
 if [[ $1 = autoconf ]]; then
-    if ! uname -s|grep -qEi hp-?ux; then
+    if ! uname -s|grep -qEi "hp-?ux"; then
 	echo "no (OS doesn't seem to be HP-UX but reports as '$(uname -s)')"
 	exit 0
     fi
@@ -56,6 +56,7 @@ if [[ $1 = config ]]; then
     echo "graph_order inbound outbound"
     echo "graph_title $INTERFACE errors"
     echo 'graph_args --base 1000'
+    # shellcheck disable=SC2016
     echo 'graph_vlabel packets per ${graph_period} in (-) / out (+)'
     echo 'graph_category network'
     echo 'inbound.label packets'
@@ -69,5 +70,5 @@ if [[ $1 = config ]]; then
     exit 0
 fi
 
-$LANADMIN -g mibstats ${INTERFACE#lan} \
+$LANADMIN -g mibstats "${INTERFACE#lan}" \
     |awk '/(In|Out)bound Errors/{printf"%s.value %d\n",tolower($1),$NF}'

--- a/plugins/node.d.hp-ux/netstat_rate_tcp_
+++ b/plugins/node.d.hp-ux/netstat_rate_tcp_
@@ -7,11 +7,11 @@
 #%# family=contrib
 #%# capabilities=autoconf suggest
 
-proto=$(basename $0|cut -d_ -f3)
+proto=$(basename "$0" | cut -d_ -f3)
 type=${0##*_}
 
 if [[ $1 = autoconf ]]; then
-    if uname -s|grep -qEi hp-?ux; then
+    if uname -s|grep -qEi "hp-?ux"; then
 	echo yes
 	exit 0
     else
@@ -19,7 +19,7 @@ if [[ $1 = autoconf ]]; then
 	exit 0
     fi
 fi
-[[ $1 = suggest ]] && printf "socket\nthroughput\n" && exit 0
+[[ $1 = suggest ]] && printf 'socket\nthroughput\n' && exit 0
 
 set -A SOCKET_LABELS requests accepts established closed
 
@@ -31,7 +31,8 @@ if [[ $1 = config ]]; then
 	socket)
 	    echo "graph_vlabel connections per \${graph_period}"
 	    for tag in ${SOCKET_LABELS[*]}; do
-		printf "%s.label %s\n%s.type COUNTER\n" $tag $tag $tag
+                printf '%s.label %s\n' "$tag" "$tag"
+                printf '%s.type COUNTER\n' "$tag"
 	    done
 	    ;;
 	throughput)
@@ -52,12 +53,12 @@ case $type in
 	typeset -i i=-1
 	netstat -s -p tcp \
 	    |awk '/connections? (requests|accepts|established|closed)/{print$1}' \
-    		|while read count; do
-		    printf "%s.value " ${SOCKET_LABELS[((i+=1))]}
-		    echo $count
+                | while read -r count; do
+                    printf '%s.value %s\n' "${SOCKET_LABELS[((i+=1))]}" "$count"
     		done
 	;;
     throughput)
+	# shellcheck disable=SC2046
 	set -- $(netstat -s -p tcp|awk '/packets (sent|received)$/{print$1}')
 	echo "ingress.value $2"
 	echo "egress.value $1"

--- a/plugins/node.d.hp-ux/sar_cpu
+++ b/plugins/node.d.hp-ux/sar_cpu
@@ -49,26 +49,26 @@ if [[ $1 = autoconf ]]; then
     fi
 fi
 
-: ${SYSWPCT:=30}
-: ${SYSCPCT:=50}
-: ${USRWPCT:=80}
-: ${scaleto100:=1}
+: "${SYSWPCT:=30}"
+: "${SYSCPCT:=50}"
+: "${USRWPCT:=80}"
+: "${scaleto100:=1}"
 
 graphlimit=$percent
 case $scaleto100 in (1|y*|Y*) graphlimit=100;; esac
 
 if [[ $1 = config ]]; then
     typeset -i percent=100 ncpu=$(/usr/sbin/ioscan -kd processor|grep -c processor)
-    (( $ncpu )) && ((percent*=ncpu))
+    (( ncpu )) && ((percent*=ncpu))
     cpumax=$graphlimit
 
     # Indifferently carried over these crude threshold assumptions
     # from the original cpu plugin; should better be passed as envs
     # via plugins.conf
 
-    syswarn=$(($cpumax*$SYSWPCT/100))
-    syscrit=$(($cpumax*$SYSCPCT/100))
-    usrwarn=$(($cpumax*$USRWPCT/100))
+    syswarn=$((cpumax * SYSWPCT / 100))
+    syscrit=$((cpumax * SYSCPCT / 100))
+    usrwarn=$((cpumax * USRWPCT / 100))
 
     echo 'graph_title CPU usage'
     echo 'graph_order system user waitio idle'
@@ -76,6 +76,7 @@ if [[ $1 = config ]]; then
     echo "graph_args --base 1000 --lower-limit 0 --rigid --upper-limit $graphlimit"
     echo 'graph_vlabel %'
     echo 'graph_scale no'
+    # shellcheck disable=SC2016
     echo 'graph_period ${graph_period}'
     echo 'system.label system'
     echo 'system.draw AREA'

--- a/plugins/node.d/bind9_rndc
+++ b/plugins/node.d/bind9_rndc
@@ -62,6 +62,7 @@ License not documented.
 =cut
 
 use strict;
+use Munin::Plugin;
 
 my $rndc = defined($ENV{rndc}) ? $ENV{rndc} : '/usr/sbin/rndc';
 my $rndc_options = defined($ENV{rndc_options}) ? $ENV{rndc_options} : '';
@@ -69,6 +70,8 @@ my $querystats = $ENV{querystats} || '/var/run/named.stats';
 my %IN;
 my %QUERIES;
 my %IP;
+
+need_multigraph();
 
 # attempt to create log file if it doesn't exist
 if ( ! -r $querystats ) {

--- a/plugins/node.d/ipmi_sensor_
+++ b/plugins/node.d/ipmi_sensor_
@@ -73,6 +73,7 @@ CACHEFILE = "plugin-ipmi_sensor.cache"
 CACHEAGE = 120
 CONFIG = '/etc/munin/ipmi'
 
+
 def normalize_sensor(name):
     name = name.lower().replace("-", "M").replace("+", "P")
     name = re.sub("[^a-z0-9A-Z]", "_", name)

--- a/plugins/node.d/jenkins_builds_and_jobs
+++ b/plugins/node.d/jenkins_builds_and_jobs
@@ -55,6 +55,7 @@ build_process_regex=${build_process_regex:-/tmp/hudson}
 
 plugin_name=$(basename "$0")
 
+is_multigraph
 
 if [ "${1:-}" = "autoconf" ]; then
 	if [ -d "$jenkins_job_dir" ]; then


### PR DESCRIPTION
* fix remaining style issues in a few plugins (most notable `df_abs` for Linux and many HP-UX plugins)
* enable the exitcode check of `make lint-plugins` in travis
* add missing tests for multigraph capability to some plugins
* add test for multigraph checks to the `lint-plugins` target