### PR TITLE
make Linux diskstats plugin comaptible with Linux 4.19+

### DIFF
--- a/plugins/node.d.linux/diskstats.in
+++ b/plugins/node.d.linux/diskstats.in
@@ -427,8 +427,10 @@ sub read_sysfs {
 
         my @elems = split /\s+/, $line;
 
-        croak "'$stats_file' doesn't contain exactly 11 values. Aborting"
-          if ( @elems != 11 );
+        # before linux 4.19, /sys/block/<dev>/stat had 11 fields.
+        # in 4.19, four fields for tracking DISCARDs have been added
+        croak "'$stats_file' contains the wrong amount of values. Aborting"
+          if ( @elems != 11 && @elems != 15 );
 
         # Translate the devicename back before storing the information
         $cur_device =~ tr#!#/#;


### PR DESCRIPTION
in 4.19, kernel developers added four new fields to the sysfs files
/sys/block/<dev>/stat for tracking DISCARDs. Thus, the assumption
of having always 11 values does not hold anymore and the plugin fails
  with

'/sys/block/dm-0/stat' doesn't contain exactly 11 values. Aborting at /etc/munin/plugins/diskstats line 430
    main::read_sysfs() called at /etc/munin/plugins/diskstats line 456
    main::parse_diskstats() called at /etc/munin/plugins/diskstats line 528
    main::fetch_device_counters() called at /etc/munin/plugins/diskstats line 35

The relevant kernel commit is
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v4.19&id=bdca3c87fb7ad1cc61d231d37eb0d8f90d001e0c

This patch adds support for the new fields (by ignoring them), adapts the
error message and adds a hint why the check has changed.