### PR TITLE
Narrow down voltage regex

### DIFF
--- a/plugins/node.d/nutups_.in
+++ b/plugins/node.d/nutups_.in
@@ -43,7 +43,7 @@ voltages() {
 			echo "${i}.min 0"
 		done
 	else
-		"$UPSC" "$UPS" | sed -n '/^[^ ]*volt/{
+		"$UPSC" "$UPS" | sed -n '/^[^:]*volt/{
 					s/://
 					/nominal/s/.* /nominal.value /
 					/voltage/s/\.[^ ]*/.value/
@@ -65,7 +65,7 @@ charge() {
 			echo "${i}.min 0"
 		done
 	else
-		"$UPSC" "$UPS" | sed -n '/charge/{
+		"$UPSC" "$UPS" | sed -n '/^[^:]*charge/{
 					s/^[^:]*\.//g
 					s/:/.value/
 					p
@@ -88,7 +88,7 @@ frequency() {
 		echo "acfreq.max 100"
 		echo "acfreq.min 5"
 	else
-		"$UPSC" "$UPS" | sed -n '/freq/{s/.*:/acfreq.value/;p}'
+		"$UPSC" "$UPS" | sed -n '/^[^:]*freq/{s/.*:/acfreq.value/;p}'
 	fi
 }
 
@@ -103,7 +103,7 @@ current() {
 		echo "current.max 100"
 		echo "current.min 0"
 	else
-		"$UPSC" "$UPS" | sed -n '/current/{s/.*:/current.value/;p}'
+		"$UPSC" "$UPS" | sed -n '/^[^:]*current/{s/.*:/current.value/;p}'
 	fi
 }
 

--- a/plugins/node.d/nutups_.in
+++ b/plugins/node.d/nutups_.in
@@ -43,7 +43,7 @@ voltages() {
 			echo "${i}.min 0"
 		done
 	else
-		"$UPSC" "$UPS" | sed -n '/volt/{
+		"$UPSC" "$UPS" | sed -n '/^[^ ]*volt/{
 					s/://
 					/nominal/s/.* /nominal.value /
 					/voltage/s/\.[^ ]*/.value/


### PR DESCRIPTION
The voltage regex (and actually all of the other regexes) doesn't look for the start of the line. This can cause UPS input voltage monitoring to fail because there are other fields that can contain the word "voltage" in the UPSC output.
Example: "input.transfer.reason: input voltage out of range" will match and cause the plugin to report
```
input.value input voltage out of range
input.value 230.0
```
This change narrows down the regex to only match at the beginning of the line.