### PR TITLE
Remove tests for debian reproducible

### DIFF
--- a/node/t/munin_node_configure_hostenumeration.t
+++ b/node/t/munin_node_configure_hostenumeration.t
@@ -13,9 +13,9 @@ my @slash_24 = map { "192.168.2.$_" } 0 .. 255;
 ### resolve
 {
 	my @tests = (
-		[ 'munin-monitoring.org', 'Resolve IPv4 hostname' ],
+		[ 'localhost',            'Resolve IPv4 hostname' ],
 		[ '127.0.0.1',            'Resolve IPv4 numeric address' ],
-#		[ 'ipv6.google.com',      'Resolve IPv6 hostname' ],
+#		[ 'ip6-localhost',        'Resolve IPv6 hostname' ],
 #		[ '::1',                  'Resolve IPv6 numeric address' ],
 	);
 

--- a/node/t/munin_node_os.t
+++ b/node/t/munin_node_os.t
@@ -1,7 +1,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 30;
+use Test::More tests => 28;
 use Test::LongString;
 use Config;  # for signal numbers and names
 
@@ -40,13 +40,8 @@ my $os = 'Munin::Node::OS';
 
 
 ### get_fq_hostname
-{
-	ok($os->get_fq_hostname, 'Was able to establish the FQDN');
-	SKIP: {
-		skip "autopktest environment does not set a domain for the FQDN test", 1 if ($os->get_fq_hostname =~ /^autopkgtest-/);
-		isnt(index($os->get_fq_hostname, '.'), -1, 'FQDN contains at least one dot');
-	}
-}
+# probably there is no good way to test it, since we cannot expect a certain host setup
+# (e.g. "test for a dot in the FQDN" fails in the Debian reproducibility test environment)
 
 
 ### check_perms_if_paranoid


### PR DESCRIPTION
Some of munin's tests fail within Debian reproducible test environment.
See the build log for 2.0.43-1 as an example: https://tests.reproducible-builds.org/debian/rb-pkg/unstable/i386/munin.html.

The problematic tests require network access or rely on a specific host setup. Both assumptions do not seem to be suitable for such tests.