### PR TITLE
Plugin apt_all: automatically determine 'releases'

### DIFF
--- a/plugins/node.d.linux/apt_all.in
+++ b/plugins/node.d.linux/apt_all.in
@@ -19,6 +19,12 @@ your /etc/apt.conf defaults.
 
 [apt_all]
 env.options -o Debug::pkgDepCache::AutoInstall=false -o APT::Get::Show-Versions=false
+env.releases stable experimental
+
+"options" is empty by default.
+"releases" is a space separated list of release names.  It defaults to
+the empty string.  This default triggers the automatic detection of
+available distributions from the URLs of all configured repositories.
 
 Note that apt is called with no extra options by default, so it fully honors
 your /etc/apt.conf defaults.
@@ -60,7 +66,28 @@ $ENV{'LANG'}="C";
 $ENV{'LC_ALL'}="C";
 
 my $statefile = ($ENV{MUNIN_PLUGSTATE} || '@@PLUGSTATE@@/nobody/') . "/plugin-apt.state";
-my @releases = ("stable", "testing","unstable");
+
+
+# try to determine the currently available distributions by inspecting the repository URLs
+sub guess_releases() {
+    open(my $fh, "-|", "apt-get update --print-uris")
+        or die("Failed to determine distribution releases via 'apt-get update --print-uris");
+    my %release_names;
+    my $line;
+    while ( ! eof($fh) ) {
+        defined( $line = readline $fh ) or die "Failed to read line from output of 'apt-get': $!";
+        # example line:
+        #     'http://ftp.debian.org/debian/dists/stable/InRelease' ftp.debian.org_debian_dists_stable_InRelease 0
+        if ($line =~ m'^.*/dists/([^/]+)/.*$') {
+            $release_names{$1} = 1;
+        }
+    }
+    return keys %release_names;
+}
+
+
+# use a given 'releases' environment variable (space separated names) or inspect the repository URLs
+my @releases = split(/\s/, ($ENV{releases} || "")) || guess_releases();
 
 
 sub print_state() {


### PR DESCRIPTION
Previously the list of tracked releases was hard-coded in the plugin (stable, testing, unstable).  This made the plugin unusable on almost every system unless manual changes were applied.

Now the set of releases to be tracked can be either configured via an environment setting "release" or (by default) it is determined by parsing the URLs of all configured repositories.
(see "apt-get update --print-uris")

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=715141

Closes: #489