### PR TITLE
Fix total connection count with PostgreSQL 10 (when using _ALL config)

### DIFF
--- a/plugins/node.d/postgres_connections_
+++ b/plugins/node.d/postgres_connections_
@@ -84,6 +84,17 @@ my $pg = Munin::Plugin::Pgsql->new(
                 ON tmp.mstate=tmp2.mstate
                 ORDER BY 1;
 		",
+            [ 9.6, "SELECT tmp.mstate AS state,COALESCE(count,0) FROM
+                 (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(mstate)
+                LEFT JOIN
+                 (SELECT CASE WHEN wait_event_type IS NOT NULL THEN 'waiting' WHEN state='idle' THEN 'idle' WHEN state LIKE 'idle in transaction%' THEN 'idletransaction' WHEN state='disabled' THEN 'unknown' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END AS mstate,
+                 count(*) AS count
+                 FROM pg_stat_activity WHERE pid != pg_backend_pid() %%FILTER%%
+                 GROUP BY CASE WHEN wait_event_type IS NOT NULL THEN 'waiting' WHEN state='idle' THEN 'idle' WHEN state LIKE 'idle in transaction%' THEN 'idletransaction' WHEN state='disabled' THEN 'unknown' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END
+                 ) AS tmp2
+                ON tmp.mstate=tmp2.mstate
+                ORDER BY 1;
+		" ],
             [ 9.5, "SELECT tmp.mstate AS state,COALESCE(count,0) FROM
                  (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(mstate)
                 LEFT JOIN

--- a/plugins/node.d/postgres_connections_
+++ b/plugins/node.d/postgres_connections_
@@ -78,7 +78,7 @@ my $pg = Munin::Plugin::Pgsql->new(
                 LEFT JOIN
                  (SELECT CASE WHEN wait_event_type IS NOT NULL THEN 'waiting' WHEN state='idle' THEN 'idle' WHEN state LIKE 'idle in transaction%' THEN 'idletransaction' WHEN state='disabled' THEN 'unknown' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END AS mstate,
                  count(*) AS count
-                 FROM pg_stat_activity WHERE pid != pg_backend_pid() %%FILTER%%
+                 FROM pg_stat_activity WHERE pid != pg_backend_pid() AND backend_type = 'client connection' %%FILTER%%
                  GROUP BY CASE WHEN wait_event_type IS NOT NULL THEN 'waiting' WHEN state='idle' THEN 'idle' WHEN state LIKE 'idle in transaction%' THEN 'idletransaction' WHEN state='disabled' THEN 'unknown' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END
                  ) AS tmp2
                 ON tmp.mstate=tmp2.mstate


### PR DESCRIPTION
Since PostgreSQL 10 pg_stat_activity view which is used as datasource for this plugin contains information about not just information about connections but other internal postgres processes.

As the plugin does not filter those new rows out it miscounts the connections by typically +5 (or more depending on postgres config (i.e. if streaming replication is used).

Split out query to be able to have specific PostgreSQL 10 option (as new column only exists since version 10) + then add filter for backend_type = 'client connection'

Closed: #1129  