### PR TITLE
Respect custom color for warning thresholds

### DIFF
--- a/master/lib/Munin/Master/GraphOld.pm
+++ b/master/lib/Munin/Master/GraphOld.pm
@@ -1169,26 +1169,13 @@ sub process_service {
             elsif (my $tmpwarn = munin_get($negfield, "warning")) {
 
                 my ($warn_min, $warn_max) = split(':', $tmpwarn,2);
+                my $warn_colour = $single_value ? "ff0000" : $colour;
 
                 if (defined($warn_min) and $warn_min ne '') {
-                    unshift(
-                        @rrd,
-                        "HRULE:" 
-                            . $warn_min
-                            . "#" . (
-                            $single_value
-                            ? "ff0000"
-                            : $COLOUR[($field_count - 1) % @COLOUR]));
+                    unshift(@rrd, "HRULE:$warn_min#$warn_colour");
                 }
                 if (defined($warn_max) and $warn_max ne '') {
-                    unshift(
-                        @rrd,
-                        "HRULE:" 
-                            . $warn_max
-                            . "#" . (
-                            $single_value
-                            ? "ff0000"
-                            : $COLOUR[($field_count - 1) % @COLOUR]));
+                    unshift(@rrd, "HRULE:$warn_max#$warn_colour");
                 }
             }
 


### PR DESCRIPTION
Previously the horizontal warning thresholds were indicated by the color based on the field count.  Thus any custom configured color for this field is ignored. Now we use the configured color (or the default) for the threshold lines.

Thanks to harvey637 for reporting the issue (Closes: #1135)