### PR TITLE
Remove master configuration setting "use_default_node"

### DIFF
--- a/lib/Munin/Master/Config.pm
+++ b/lib/Munin/Master/Config.pm
@@ -122,7 +122,6 @@ my %booleans = map {$_ => 1} qw(
     tls_verify_certificate
     update
     use_node_name
-    use_default_node
 );
 
 

--- a/lib/Munin/Master/Node.pm
+++ b/lib/Munin/Master/Node.pm
@@ -247,14 +247,6 @@ sub list_plugins {
         ? $self->{node_name}
         : $self->{host};
 
-    my $use_default_node = defined($self->{configref}{use_default_node})
-        ? $self->{configref}{use_default_node}
-        : $config->{use_default_node};
-
-    if (! $use_default_node && ! $host) {
-	die "[ERROR] Couldn't find out which host to list on $host.\n";
-    }
-
     my $host_list = ($use_node_name && $use_node_name eq "ignore") ? "" : $host;
     $self->_node_write_single("list $host_list\n");
     my $list = $self->_node_read_single();


### PR DESCRIPTION
The setting was introduced in 6adf38ae61a.

But somehow it partially lost its meaning in the merge commit
c8228b8e5bb (Merge branch 'sql' into devel).
Afterwards it was only used for for breaking the node communication
in case of a missing "host" attribute (which can never be empty as
it is an integral part of the node specification in the master
configuration).  Thus it is not useful anymore.

The purpose of this setting was later replaced with
"use_node_name ignore" in dd4cbb501ca.