### PR TITLE
plugins/if, ip: include "Interface" to graph_title for better grouping

### DIFF
--- a/plugins/node.d.linux/if_
+++ b/plugins/node.d.linux/if_
@@ -171,7 +171,7 @@ case $1 in
     config)
 
         echo "graph_order down up"
-        echo "graph_title $INTERFACE traffic"
+        echo "graph_title Interface $INTERFACE traffic"
         echo 'graph_args --base 1000'
         # shellcheck disable=SC2016
         echo 'graph_vlabel bits in (-) / out (+) per ${graph_period}'

--- a/plugins/node.d.linux/ip_
+++ b/plugins/node.d.linux/ip_
@@ -162,7 +162,7 @@ if [[ "$1" == "config" ]]; then
     if [[ "$hostname" ]]; then
         title="$hostname"
     fi
-    echo "graph_title $title traffic"
+    echo "graph_title Interface $title traffic"
     echo 'graph_args --base 1000'
     # shellcheck disable=SC2016
     echo 'graph_vlabel bits per ${graph_period}'


### PR DESCRIPTION
Nowadays network interfaces have names like docker0, team0, ip_vti0, eno,
wlp61s0 and so on. Including word "Interface" in beginning of
graph_title groups these graphs together in web interface, not randomly
before/after other network-graphs (ipconntrack, firewall, ...).