### PR TITLE
Update PostgreSQL plugin to work with Version 10 or higher

### DIFF
--- a/lib/Munin/Plugin/Pgsql.pm
+++ b/lib/Munin/Plugin/Pgsql.pm
@@ -521,7 +521,8 @@ sub get_version {
     my $v = $r->[0]->[0];
     die "Unable to detect PostgreSQL version\n"
         unless ($v =~ /^(\d+)\.(\d+).*\b/);
-    $self->{detected_version} = "$1.$2";
+    # from PostgreSQL 10 on only the major version is needed
+    $self->{detected_version} = $1 >= 10 ? "$1" : "$1.$2";
 }
 
 sub get_versioned_query {

--- a/plugins/node.d/postgres_connections_
+++ b/plugins/node.d/postgres_connections_
@@ -78,12 +78,23 @@ my $pg = Munin::Plugin::Pgsql->new(
                 LEFT JOIN
                  (SELECT CASE WHEN wait_event_type IS NOT NULL THEN 'waiting' WHEN state='idle' THEN 'idle' WHEN state LIKE 'idle in transaction%' THEN 'idletransaction' WHEN state='disabled' THEN 'unknown' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END AS mstate,
                  count(*) AS count
-                 FROM pg_stat_activity WHERE pid != pg_backend_pid() %%FILTER%%
+                 FROM pg_stat_activity WHERE pid != pg_backend_pid() AND backend_type = 'client backend' %%FILTER%%
                  GROUP BY CASE WHEN wait_event_type IS NOT NULL THEN 'waiting' WHEN state='idle' THEN 'idle' WHEN state LIKE 'idle in transaction%' THEN 'idletransaction' WHEN state='disabled' THEN 'unknown' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END
                  ) AS tmp2
                 ON tmp.mstate=tmp2.mstate
                 ORDER BY 1;
 		",
+            [ 9.6, "SELECT tmp.mstate AS state,COALESCE(count,0) FROM
+                 (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(mstate)
+                LEFT JOIN
+                 (SELECT CASE WHEN wait_event_type IS NOT NULL THEN 'waiting' WHEN state='idle' THEN 'idle' WHEN state LIKE 'idle in transaction%' THEN 'idletransaction' WHEN state='disabled' THEN 'unknown' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END AS mstate,
+                 count(*) AS count
+                 FROM pg_stat_activity WHERE pid != pg_backend_pid() %%FILTER%%
+                 GROUP BY CASE WHEN wait_event_type IS NOT NULL THEN 'waiting' WHEN state='idle' THEN 'idle' WHEN state LIKE 'idle in transaction%' THEN 'idletransaction' WHEN state='disabled' THEN 'unknown' WHEN query='<insufficient privilege>' THEN 'unknown' ELSE 'active' END
+                 ) AS tmp2
+                ON tmp.mstate=tmp2.mstate
+                ORDER BY 1;
+        " ],
             [ 9.5, "SELECT tmp.mstate AS state,COALESCE(count,0) FROM
                  (VALUES ('active'),('waiting'),('idle'),('idletransaction'),('unknown')) AS tmp(mstate)
                 LEFT JOIN


### PR DESCRIPTION
For postgres_connections_:
Added missing "backend_type = 'client backend'" for Version 10 or
highter

NOTE: previous it said "client connection" but this does not exist according to PostgreSQL documentation.
https://www.postgresql.org/docs/10/monitoring-stats.html#MONITORING-STATS-VIEWS
https://www.postgresql.org/docs/11/monitoring-stats.html#MONITORING-STATS-VIEWS

For perl plugin Pgsql.pm:
Updated version check to only use the major version for PostgreSQL 10
or higher