### PR TITLE
Sanitise service names

### DIFF
--- a/master/lib/Munin/Master/Node.pm
+++ b/master/lib/Munin/Master/Node.pm
@@ -329,7 +329,7 @@ sub parse_service_config {
 	if ($line =~ m{\A multigraph \s+ (.+) }xms) {
 	    push_graphorder($service);
 
-	    $service = $1;
+	    $service = $self->_sanitise_plugin_name($1);
 
 	    if ($service eq 'multigraph') {
 		ERROR "[ERROR] SERVICE can't be named \"$service\" in plugin $plugin on ".$self->{host}."/".$self->{address}."/".$self->{port};


### PR DESCRIPTION
When using munin-async, plugins are seen by the master as services (the plugin name being `__root__`), so they were not escaped as plugin names are.
This causes broken links, because they are unsanitised, while sanitised names are used when opening HTML and image files.

Possibly related: http://munin-monitoring.org/ticket/1725

---

I did not find how to run munin's automated tests. I'll look into it if needed.