### PR TITLE
Remove stray comment in postgres_connections_

### DIFF
--- a/plugins/node.d/postgres_connections_.in
+++ b/plugins/node.d/postgres_connections_.in
@@ -78,7 +78,7 @@ my $pg = Munin::Plugin::Pgsql->new(
                  count(*) AS count
                  FROM (SELECT act.state, act.wait_event_type, EXISTS (SELECT FROM pg_locks AS l WHERE l.pid = act.pid) AS locked, act.query
                        FROM pg_stat_activity AS act
-                       WHERE act.pid != pg_backend_pid() AND act.backend_type = 'client backend' /*%%FILTER%%*/)
+                       WHERE act.pid != pg_backend_pid() AND act.backend_type = 'client backend' %%FILTER%%)
                  AS a GROUP BY 1
                  ) AS tmp2
                 ON tmp.mstate=tmp2.mstate


### PR DESCRIPTION
Commit 07794c560f1a40b57109ca73a91ae811bc560708 introduced stray comment that produces problems while checking connections for individual databases.

Uncomment filter to fix querying connections for individual databases.

Closes #1168