### PR TITLE
Sanitise plugin names in munin-asyncd.

### DIFF
--- a/node/_bin/munin-asyncd.in
+++ b/node/_bin/munin-asyncd.in
@@ -125,7 +125,10 @@ my @plugins;
 			"w",
 		);
 
-		print $fh_list $plugins_line;
+		my $sanitised_plugins_line = $plugins_line;
+		$sanitised_plugins_line =~ s/[^_A-Za-z0-9 ]/_/g;
+
+		print $fh_list $sanitised_plugins_line;
 		print $fh_list "\n";
 	}
 

--- a/node/lib/Munin/Node/SpoolWriter.pm
+++ b/node/lib/Munin/Node/SpoolWriter.pm
@@ -102,6 +102,10 @@ sub write
 {
     my ($self, $timestamp, $service, $data) = @_;
 
+    # squash the $service name with the same rules as the munin-update when using plain TCP
+    # Closes D:710529
+    $service =~ s/[^_A-Za-z0-9]/_/g;
+
     my $fmtTimestamp = $self->_snap_to_epoch_boundary($timestamp);
 
     open my $fh , '>>', "$self->{spooldir}/munin-daemon.$service.$fmtTimestamp." . $self->{interval_size}
@@ -110,10 +114,7 @@ sub write
 
     print {$fh} "timestamp $timestamp\n";
 
-    # squash the $service name with the same rules as the munin-update when using plain TCP
-    # Closes D:710529
-    my $service_squashed = $service; $service_squashed =~ tr/.:/__/;
-    print {$fh} "multigraph $service_squashed\n" unless $data->[0] =~ m{^multigraph};
+    print {$fh} "multigraph $service\n" unless $data->[0] =~ m{^multigraph};
 
     foreach my $line (@$data) {
         # Ignore blank lines and "."-ones.


### PR DESCRIPTION
Follow-up on #1167

Related:
* http://munin-monitoring.org/ticket/1725
* https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=710529