### PR TITLE
Ignore malformed lines when parsing "datafile"

### DIFF
--- a/master/lib/Munin/Master/Update.pm
+++ b/master/lib/Munin/Master/Update.pm
@@ -81,7 +81,8 @@ sub _read_old_service_configs {
 	    return {};
 	}
 	eval {
-	    $oldconfig->parse_config($file);
+            # parse file but skip malformed lines
+            $oldconfig->parse_config($file, 1);
 	};
 	if ($EVAL_ERROR) {
 	    WARN "[Warning] Could not parse datafile $datafile: $EVAL_ERROR";


### PR DESCRIPTION
Previously a single malformed line in "datafile" was treated as a file
parsing error.  All subsequent lines were ignored in this case.
This could cause the immediate removal of unreachable hosts from the
HTML listing, if their old configuration lines were lost due to the
above behaviour.

Now the "parse_config" subroutine accepts an optional
"skip_line_on_error" parameter. It is enabled when parsing "datafile"
and stays disabled for all other configuration files.

Closes: #579