### PR TITLE
Allow node-specific TLS settings on the master

### DIFF
--- a/master/lib/Munin/Master/Node.pm
+++ b/master/lib/Munin/Master/Node.pm
@@ -151,13 +151,19 @@ sub _do_connect {
     return 1;
 }
 
+
+sub _get_node_or_global_setting {
+    my ($self, $key) = @_;
+    return exists $self->{configref}->{$key} ? $self->{configref}->{$key} : $config->{$key};
+}
+
+
 sub _run_starttls_if_required {
     my ($self) = @_;
 
     # TLS should only be attempted if explicitly enabled. The default
     # value is therefore "disabled" (and not "auto" as before).
-    my $tls_requirement = exists $self->{configref}->{tls} ?
-                                   $self->{configref}->{tls} : $config->{tls};
+    my $tls_requirement = $self->_get_node_or_global_setting("tls");
     DEBUG "TLS set to \"$tls_requirement\".";
     return if $tls_requirement eq 'disabled';
     my $logger = Log::Log4perl->get_logger("Munin::Master");
@@ -166,13 +172,13 @@ sub _run_starttls_if_required {
         logger       => sub { $logger->warn(@_) },
         read_fd      => fileno($self->{reader}),
         read_func    => sub { _node_read_single($self) },
-        tls_ca_cert  => $config->{tls_ca_certificate},
-        tls_cert     => $config->{tls_certificate},
-        tls_paranoia => $tls_requirement, 
-        tls_priv     => $config->{tls_private_key},
-        tls_vdepth   => $config->{tls_verify_depth},
-        tls_verify   => $config->{tls_verify_certificate},
-        tls_match    => $config->{tls_match},
+        tls_ca_cert  => $self->_get_node_or_global_setting("tls_ca_certificate"),
+        tls_cert     => $self->_get_node_or_global_setting("tls_certificate"),
+        tls_paranoia => $tls_requirement,
+        tls_priv     => $self->_get_node_or_global_setting("tls_private_key"),
+        tls_vdepth   => $self->_get_node_or_global_setting("tls_verify_depth"),
+        tls_verify   => $self->_get_node_or_global_setting("tls_verify_certificate"),
+        tls_match    => $self->_get_node_or_global_setting("tls_match"),
         write_fd     => fileno($self->{writer}),
         write_func   => sub { _node_write_single($self, @_) },
     });


### PR DESCRIPTION
Some masters may want to use different certificates or certificate
authorities for different nodes.

All settings starting with `tls` are parsed from the global master configuration, as well as from the current node section.

Closes: #1179