### PR TITLE
Sanitize async service names

### DIFF
--- a/node/_bin/munin-asyncd.in
+++ b/node/_bin/munin-asyncd.in
@@ -125,7 +125,10 @@ my @plugins;
 			"w",
 		);
 
-		print $fh_list $plugins_line;
+		my $sanitised_plugins_line = $plugins_line;
+		$sanitised_plugins_line =~ s/[^_A-Za-z0-9 ]/_/g;
+
+		print $fh_list $sanitised_plugins_line;
 		print $fh_list "\n";
 	}
 

--- a/node/lib/Munin/Node/SpoolWriter.pm
+++ b/node/lib/Munin/Node/SpoolWriter.pm
@@ -102,6 +102,10 @@ sub write
 {
     my ($self, $timestamp, $service, $data) = @_;
 
+    # squash the $service name with the same rules as the munin-update when using plain TCP
+    # Closes D:710529
+    $service =~ s/[^_A-Za-z0-9]/_/g;
+
     my $fmtTimestamp = $self->_snap_to_epoch_boundary($timestamp);
 
     open my $fh , '>>', "$self->{spooldir}/munin-daemon.$service.$fmtTimestamp." . $self->{interval_size}
@@ -110,10 +114,7 @@ sub write
 
     print {$fh} "timestamp $timestamp\n";
 
-    # squash the $service name with the same rules as the munin-update when using plain TCP
-    # Closes D:710529
-    my $service_squashed = $service; $service_squashed =~ tr/.:/__/;
-    print {$fh} "multigraph $service_squashed\n" unless $data->[0] =~ m{^multigraph};
+    print {$fh} "multigraph $service\n" unless $data->[0] =~ m{^multigraph};
 
     foreach my $line (@$data) {
         # Ignore blank lines and "."-ones.

--- a/node/t/munin_node_spoolreader.t
+++ b/node/t/munin_node_spoolreader.t
@@ -38,52 +38,52 @@ use Munin::Node::SpoolWriter;
     my $reader = Munin::Node::SpoolReader->new(spooldir => $dir);
 
     # write some data
-    $writer->write(1234567890, 'fnord', [
+    $writer->write(1234567890, 'fnord-foo', [
         'graph_title CPU usage',
         'system.label system',
         'system.value 1',
     ]);
 
-    $writer->write(1234567900, 'fnord', [
+    $writer->write(1234567900, 'fnord-foo', [
         'graph_title CPU usage',
         'system.label system',
         'system.value 2',
     ]);
 
-    $writer->write(1234567910, 'fnord', [
+    $writer->write(1234567910, 'fnord-foo', [
         'graph_title CPU usage',
         'system.label system',
         'system.value 3',
     ]);
 
     is_string($reader->fetch(1234567899), <<EOS, 'Fetched data since the write');
-multigraph fnord
+multigraph fnord_foo
 graph_title CPU usage
 system.label system
 system.value 1234567900:2
-multigraph fnord
+multigraph fnord_foo
 graph_title CPU usage
 system.label system
 system.value 1234567910:3
 EOS
 
     is_string($reader->fetch(1234567900), <<EOS, 'Start timestamp is not inclusive');
-multigraph fnord
+multigraph fnord_foo
 graph_title CPU usage
 system.label system
 system.value 1234567910:3
 EOS
 
     is_string($reader->fetch(1), <<EOS, 'Timestamp predates all result: all results are returned');
-multigraph fnord
+multigraph fnord_foo
 graph_title CPU usage
 system.label system
 system.value 1234567890:1
-multigraph fnord
+multigraph fnord_foo
 graph_title CPU usage
 system.label system
 system.value 1234567900:2
-multigraph fnord
+multigraph fnord_foo
 graph_title CPU usage
 system.label system
 system.value 1234567910:3
@@ -97,7 +97,7 @@ EOS
     my $reader = Munin::Node::SpoolReader->new(spooldir => $dir);
 
     # write some data
-    $writer->write(1234567890, 'fnord', [
+    $writer->write(1234567890, 'fnord-foo', [
         'graph_title CPU usage',
         'system.label system',
         '',
@@ -106,7 +106,7 @@ EOS
     ]);
 
     is_string($reader->fetch(1), <<EOS, 'Blank lines are ignored');
-multigraph fnord
+multigraph fnord_foo
 graph_title CPU usage
 system.label system
 system.value 1234567890:1
@@ -119,7 +119,7 @@ EOS
     my $reader = Munin::Node::SpoolReader->new(spooldir => $dir);
 
     # write results for two different plugins
-    $writer->write(1234567890, 'fnord', [
+    $writer->write(1234567890, 'fnord-foo', [
         'graph_title CPU usage',
         'system.label system',
         'system.value 3',
@@ -134,7 +134,7 @@ EOS
     ok(my $fetched = $reader->fetch(1234567800), 'Several services to fetch');
 
     my $f1 = <<EOT;
-multigraph fnord
+multigraph fnord_foo
 graph_title CPU usage
 system.label system
 system.value 1234567890:3
@@ -162,13 +162,13 @@ EOS
     my $reader = Munin::Node::SpoolReader->new(spooldir => $dir);
 
     # write two sets of results, with a slightly different config
-    $writer->write(1234567890, 'fnord', [
+    $writer->write(1234567890, 'fnord-foo', [
         'graph_title CPU usage',
         'system.label system',
         'system.value 3',
     ]);
 
-    $writer->write(1234567990, 'fnord', [
+    $writer->write(1234567990, 'fnord-foo', [
         'graph_title CPU usage!',  # this line has changed
         'system.label system',
         'system.value 4',
@@ -177,13 +177,13 @@ EOS
     ok(my $fetched = $reader->fetch(1234567800), 'Several sets of results to fetch');
 
     my $f1 = <<EOT;
-multigraph fnord
+multigraph fnord_foo
 graph_title CPU usage
 system.label system
 system.value 1234567890:3
 EOT
     my $f2 = <<EOT;
-multigraph fnord
+multigraph fnord_foo
 graph_title CPU usage!
 system.label system
 system.value 1234567990:4
@@ -203,7 +203,7 @@ EOT
     is($reader->list, "\n", 'No spooled plugins to list');
 
     # write "results" for several plugins
-    $writer->write(1234567890, 'fnord', [
+    $writer->write(1234567890, 'fnord-foo', [
         'graph_title CPU usage',
         'system.label system',
         'system.value 1',
@@ -228,7 +228,7 @@ EOT
     print $cruft "rubbish\n";
     close $cruft;
 
-    is_deeply([ sort $reader->_get_spooled_plugins ], [ sort qw( fnord floop blort ) ], 'Retrieved list of spooled plugins');
-    is($reader->list, "blort floop fnord\n", 'Retrieved stringified list of spooled plugins');
+    is_deeply([ sort $reader->_get_spooled_plugins ], [ sort qw( fnord_foo floop blort ) ], 'Retrieved list of spooled plugins');
+    is($reader->list, "blort floop fnord_foo\n", 'Retrieved stringified list of spooled plugins');
 }
 

--- a/node/t/munin_node_spoolwriter.t
+++ b/node/t/munin_node_spoolwriter.t
@@ -144,7 +144,7 @@ EOC
     my $dir = tempdir( CLEANUP => 1 );
     my $writer = Munin::Node::SpoolWriter->new(spooldir => $dir);
 
-    $writer->write(1234567890, 'fnord', [
+    $writer->write(1234567890, 'fnord-foo', [
         'multigraph fnord',
         'graph_title CPU usage',
         'system.label system',
@@ -155,7 +155,7 @@ EOC
         'subsystem.value 123',
     ]);
 
-    my $data_file = "$dir/munin-daemon.fnord.1234483200" . "." . Munin::Node::SpoolWriter::DEFAULT_TIME;
+    my $data_file = "$dir/munin-daemon.fnord_foo.1234483200" . "." . Munin::Node::SpoolWriter::DEFAULT_TIME;
     ok( -r $data_file, 'spool file is readable') or last;
 
     my $data = read_file($data_file);


### PR DESCRIPTION
Plugin names may contain characters that are forbidden for multigraph names.  Thus we need to munge these names before storing the data.

The following details of munin's internal processing are changed:
* `munin-asyncd` stores plugin data in munged filenames: data for a plugin named `fnord-foo` is stored in `fnord_foo`
* the `multigraph` names retrieved by `munin-async` are munged: `multigraph fnord-foo` is retrieved as `multigraph fnord_foo`

This change is supposed to solve the problem of transferring data of remote plugins (whose names contain characters that are illegal for service names) via the async protocol.

Thanks to Valentin Lorentz for implementing the necessary changes.