### PR TITLE
Add support for the Net::Server option "reverse_lookups"

### DIFF
--- a/node/lib/Munin/Node/Config.pm
+++ b/node/lib/Munin/Node/Config.pm
@@ -138,6 +138,7 @@ sub _parse_line {
           deny
           cidr_allow
           cidr_deny
+          reverse_lookups
      );
 
     sub _handled_by_net_server {


### PR DESCRIPTION
This allows the specification of "allow" directives with hostnames
instead of IP addresses.

The new behaviour is in line with the current documentation of the
munin-node configuration:

> [..] All other directives in munin-node.conf are passed through to
> the Perl module Net::Server.

But sadly there are two external issues complicating the usage of the
this feature:
* reverse lookups do not work if munin-node is bound to an IPv6 socket
  (see https://rt.cpan.org/Ticket/Display.html?id=129377)
* Net::Server does not properly check, if the resolved reverse name is
  valid (i.e. belongs to the IP of the client).
  See https://rt.cpan.org/Public/Bug/Display.html?id=83909

Closes: #1175