### PR TITLE
Add plugin for PostgreSQL checksum failures

### DIFF
--- a/lib/Munin/Plugin/Pgsql.pm
+++ b/lib/Munin/Plugin/Pgsql.pm
@@ -149,6 +149,8 @@ use Munin::Plugin;
                 if the plugin should be run on this machine. Must return a single
                 row, two columns columns. The first one is a boolean field
                 representing yes or no, the second one a reason for "no".
+ warning        The warning low and/or high thresholds.
+ critical       The critical low and/or high thresholds.
  graphdraw      The draw parameter for the graph. The default is LINE1. This
                 can be an array, see "Specifying graphdraw" section for details.
  graphtype      The type parameter for the graph. The default is GAUGE.
@@ -234,6 +236,8 @@ sub new {
         title          => $args{title},
         info           => $args{info},
         vlabel         => $args{vlabel},
+        warning        => $args{warning},
+        critical       => $args{critical},
         graphdraw      => $args{graphdraw},
         graphtype      => $args{graphtype},
         graphperiod    => $args{graphperiod},
@@ -323,6 +327,8 @@ sub Config {
         }
         print "$l.min $self->{graphmin}\n" if (defined $self->{graphmin});
         print "$l.max $self->{graphmax}\n" if (defined $self->{graphmax});
+        print "$l.warning $self->{warning}\n" if (defined $self->{warning});
+        print "$l.critical $self->{critical}\n" if (defined $self->{critical});
         $firstrow = 0;
     }
 }

--- a/plugins/node.d/postgres_checksums
+++ b/plugins/node.d/postgres_checksums
@@ -1,0 +1,76 @@
+#!/usr/bin/perl
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; version 2 dated June,
+# 1991.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.
+
+=head1 NAME
+
+postgres_checksum - Plugin to monitor for PostgreSQL checksum failures.
+
+=head1 CONFIGURATION
+
+Configuration is done through libpq environment variables, for example
+PGUSER, PGDATABASE, etc. For more information, see L<Munin::Plugin::Pgsql>.
+
+To monitor several instances, link to postgres_<tag>_checksums
+The <tag> can be what you want but without "_". It allows you to define several
+database configuration.
+
+Example :
+  [postgres_pg91_*]
+  env.PGPORT 5432
+  [postgres_pg92_*]
+  env.PGPORT 5432
+
+=head1 SEE ALSO
+
+L<Munin::Plugin::Pgsql>
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf
+
+=head1 COPYRIGHT/License.
+
+All rights reserved. This program is free software; you can
+redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation; version 2
+dated June, 1991.
+
+=cut
+
+use strict;
+use warnings;
+
+use Munin::Plugin::Pgsql;
+
+my $pg = Munin::Plugin::Pgsql->new(
+    title  => 'PostgreSQL checksum failures',
+    info   => 'Data checksum failures per database',
+    vlabel => 'Checksum failures',
+    minversion => '12',
+    basequery =>
+        "SELECT '_'||coalesce(datname,''),checksum_failures FROM pg_stat_database ORDER BY 1",
+    configquery =>
+        "SELECT '_'||coalesce(datname,''),coalesce(datname,'Global') FROM pg_stat_database ORDER BY 1",
+    autoconfquery =>
+        "SELECT setting::bool,'Data checksums are not enabled' FROM pg_settings WHERE name='data_checksums'",
+    graphtype => 'DERIVE',
+    graphmin  => 0,
+    critical  => '0:0',
+);
+
+$pg->Process();


### PR DESCRIPTION
PostgreSQL 12 adds a per database counter for data checksum failures
which is something which is interesting for Munin to monitor. The
plugin has its critical thresholds configured to 0:0 by default since
any checksum failure is almost guaranteed to be bad news.

PostgreSQL 12 beta1 will soon be released and PostgreSQL 12 itself is scheduled to be released this autumn.