### PR TITLE
doc: fix example apache virtualhost RewriteRule

### DIFF
--- a/doc/example/webserver/apache-virtualhost.rst
+++ b/doc/example/webserver/apache-virtualhost.rst
@@ -56,7 +56,7 @@ Add a new virtualhost, using the following example:
      RewriteRule ^/(.*)          /usr/lib/munin/cgi/munin-cgi-html/$1 [L]
 
      # Images
-     RewriteRule ^/(.*) /usr/lib/munin/cgi/munin-cgi-graph/$1 [L]
+     RewriteRule ^/munin-cgi/munin-cgi-graph/(.*) /usr/lib/munin/cgi/munin-cgi-graph/$1 [L]
 
      # Ensure we can run (fast)cgi scripts
      <Directory "/usr/lib/munin/cgi">


### PR DESCRIPTION
I just recently built a new munin master with 2.0.49 on Debian with Apache, and found that the example was wrong here. Not sure why it was changed like this in commit fa0dfe596afcc4dfef9168e15e1f40d70e7eec4f.