### PR TITLE
Don't "exit 1"

### DIFF
--- a/plugins/node.d/postfix_mailvolume
+++ b/plugins/node.d/postfix_mailvolume
@@ -145,7 +145,7 @@ my $logfile = "$LOGDIR/$LOGFILE";
 
 if (! -f $logfile) {
     print "volume.value U\n";
-    exit 1;
+    exit 0;
 }
 
 # load the stored data


### PR DESCRIPTION
Postfix does not make the log file until there is anything to log.  So on low-volume hosts this makes unneeded noise.