### PR TITLE
Fix default port in install.rst.

### DIFF
--- a/doc/installation/install.rst
+++ b/doc/installation/install.rst
@@ -13,7 +13,7 @@ collect data from all nodes, and graph the results. When starting with
 Munin, it should be enough to install the Munin master on one server.
 
 The munin master runs :ref:`munin-httpd` which is a basic webserver
-which provides the munin web interface on port 4948/tcp.
+which provides the munin web interface on port 4949/tcp.
 
 Install "munin-node" on the machines that shall be monitored by Munin.
 


### PR DESCRIPTION
I was installing Munin today based on the instructions here: http://guide.munin-monitoring.org/en/latest/installation/install.html

The docs say that `munin-http` will be running on port 4948, but it is running on 4949 on my system. Maybe just a typo in the docs? Or is there something else I'm unaware of that explains it?