### PR TITLE
Update apt_all

### DIFF
--- a/plugins/node.d.linux/apt_all
+++ b/plugins/node.d.linux/apt_all
@@ -118,8 +118,11 @@ sub print_state() {
         foreach my $release (@releases) {
             my $release_cleaned = clean_fieldname($release);
             # print only lines that are exected for the currently requested releases
-            print $line if ($line =~ /^(hold|pending)_$release_cleaned\.(value|extinfo)/);
-            last;
+	    
+            if ($line =~ /^(hold|pending)_$release_cleaned\.(value|extinfo)/) {
+	    	print $line ;
+            	last;
+	    }
         }
     }
     close STATE;


### PR DESCRIPTION
"last" was triggered at each iteration of the @releases array.  So the print was only executed if current line of state file is the first entry of @releases.