### PR TITLE
[plugins/ping_] Add support for ping4

### DIFF
--- a/plugins/node.d/ping_
+++ b/plugins/node.d/ping_
@@ -58,6 +58,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 . "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 case $0 in
+    *ping4_*)
+        PING=ping4
+        file_host=${0##*/ping4_}
+        V=IPv4
+        ;;
     *ping6_*)
         PING=ping6
         file_host=${0##*/ping6_}


### PR DESCRIPTION
ping(8) from iputils handles both IPv4 and IPv6 when called as `ping`.
It is however possible to pin the address family with symlinks named
`ping4` and `ping6`.

This commit introduces support for \`ping4\` to force IPv4 pings with
iputils.

Signed-off-by: Olivier Mehani <shtrom@ssji.net>