### PR TITLE
Prevent duplicate timestamps in async spool data

### DIFF
--- a/node/lib/Munin/Node/SpoolReader.pm
+++ b/node/lib/Munin/Node/SpoolReader.pm
@@ -148,7 +148,12 @@ sub _cat_multigraph_file
                 next;
             }
 
-            if (m/^(\w+)\.value\s+(?:N:)?(.+)$/) {
+            # Prepend the currently active timestamp, if neither a specific (numeric) nor an
+            # undefined ("N") epoch is included in the value line.  The regular expression is
+            # supposed to match the following types of content:
+            #     foo.value 12.3
+            #     bar.value N:45.7
+            if (m/^(\w+)\.value\s+(?:N:)?([^:]+)$/) {
                 $_ = "$1.value $epoch:$2";
             }
 


### PR DESCRIPTION
Since 700d08a297 the spooled "value" lines may contain duplicate
timestamps, if the original data emitted by the plugin already contained
a timestamp.

The commit 700d08a297 changed a regular expression in a way, that mistakenly
matched not only lines without timestamps, but also lines containing a
timestamp.  Thus erroneously timestamped values were prefixed with yet
another timestamp (based on the spooling session).

The new expression enforces, that the epoch is only prepended, if the
value line does not contain a colon.