### PR TITLE
Visualize warning thresholds as dashed line

### DIFF
--- a/master/lib/Munin/Master/GraphOld.pm
+++ b/master/lib/Munin/Master/GraphOld.pm
@@ -1172,10 +1172,10 @@ sub process_service {
                 my ($warn_min, $warn_max) = split(':', $tmpwarn,2);
 
                 if (defined($warn_min) and $warn_min ne '') {
-                    unshift(@rrd, "HRULE:$warn_min#$warn_colour");
+                    unshift(@rrd, "HRULE:${warn_min}#${warn_colour}:dashes");
                 }
                 if (defined($warn_max) and $warn_max ne '') {
-                    unshift(@rrd, "HRULE:$warn_max#$warn_colour");
+                    unshift(@rrd, "HRULE:${warn_max}#${warn_colour}:dashes");
                 }
             }
 
@@ -1236,10 +1236,10 @@ sub process_service {
             my ($warn_min, $warn_max) = split(':', $tmpwarn,2);
 
             if (defined($warn_min) and $warn_min ne '') {
-                unshift(@rrd, "HRULE:$warn_min#$warn_colour");
+                unshift(@rrd, "HRULE:${warn_min}#${warn_colour}:dashes");
             }
             if (defined($warn_max) and $warn_max ne '') {
-                unshift(@rrd, "HRULE:$warn_max#$warn_colour");
+                unshift(@rrd, "HRULE:${warn_max}#${warn_colour}:dashes");
             }
         }
     }


### PR DESCRIPTION
Previously warning lines used the same color, as the original.
The code also refers to a red default color in case of "single value"
graphs, but this distinction was disabled before munin 2.0 (02ff349a).

Thus currently warning threshold lines are visually hard to distinguish
from their corresponding data graph (e.g. for the "df" plugin in case of
constant space usage for read-only hosts).

This changeset introduces the formatting of warning threshold lines with
dashes.  This eases the visual distinction between data lines and
threshold lines.