### PR TITLE
munin-node: add "sd_notify" interface

### DIFF
--- a/common/lib/Munin/Common/Daemon.pm
+++ b/common/lib/Munin/Common/Daemon.pm
@@ -1,0 +1,90 @@
+package Munin::Common::Daemon;
+
+
+use warnings;
+use strict;
+
+use English;
+use IO::Socket;
+
+use Munin::Node::Logger qw(logger);
+
+
+sub emit_sd_notify_message {
+    eval {
+        logger("sd_notify: looking for NOTIFY_SOCKET environment variable");
+        my $socket_path = $ENV{NOTIFY_SOCKET};
+        if (defined $socket_path) {
+            logger("sd_notify: preparing connection to '$socket_path'");
+            # Prevent children from talking to the socket provided solely for us.
+            delete $ENV{NOTIFY_SOCKET};
+            # A socket path starting with "@" is interpreted as a Linux abstract namespace socket.
+            # This can be indicated by the socket path starting with a null byte.
+            # See "Address format: abstract" in "man 7 unix".
+            $socket_path =~ s/^@/\0/;
+            my $socket = IO::Socket::UNIX->new(Type => SOCK_DGRAM, Peer => $socket_path);
+            logger("sd_notify: connected to socket '$socket_path'");
+            if (defined $socket) {
+                logger("sd_notify: sending READY signal to '$socket_path'");
+                print($socket "READY=1\n");
+                close($socket);
+            } else {
+                logger("sd_notify: failed to connect to socket '$socket_path'");
+            }
+        }
+    }
+}
+
+
+1;
+
+
+__END__
+
+=head1 NAME
+
+Munin::Common::Daemon - utilities for daemons.
+
+=head1 SYNOPSIS
+
+The following daemon-related features are supported:
+
+=over
+=item sd_notify: signal readiness of the daemon
+=back
+
+
+=head1 SUBROUTINES
+
+=over
+
+=item B<emit_sd_notify_message>
+
+ emit_sd_notify_message();
+
+Send a "ready" signal according to the C<sd_notify> interface:
+
+=over
+=item 1. check whether the environment variable "NOTIFY_SOCKET" is defined
+=item 2. remove this variable from the environment (this interface is not propagated to children)
+=item 3. send the string "READY=1" to the socket
+=back
+
+The function returns silently, if something fails.
+
+The function should be called as soon as the service is ready to accept
+requests.
+Calling this function is always safe - independent of the caller supporting the
+C<sd_notify> interface or not.
+
+Examples for callers supporting the C<sd_notify> interface:
+
+=over
+=item systemd: see C<Type=Notify> in L<systemd.exec/5>
+=item start-stop-daemon: see C<--notify-await> in L<start-stop-daemon/8>
+=back
+
+See L<text|https://www.freedesktop.org/software/systemd/man/sd_notify.html> for
+details of this interface.
+
+=back

--- a/node/_bin/munin-asyncd.in
+++ b/node/_bin/munin-asyncd.in
@@ -30,6 +30,7 @@ use Pod::Usage;
 
 use List::Util qw(min max);
 
+use Munin::Common::Daemon;
 use Munin::Node::SpoolWriter;
 
 my $host = "localhost:4949";
@@ -151,6 +152,8 @@ $SIG{TERM} = 'termhandler';
 # ... but each plugin in its own process to avoid delay-leaking
 my %last_updated;
 my $last_cleanup=0;
+# all preparations are finished: we can notify our caller, that we are ready
+Munin::Common::Daemon::emit_sd_notify_message();
 MAIN: while($keepgoing) {
 	my $when = time;
 

--- a/node/lib/Munin/Node/Server.pm
+++ b/node/lib/Munin/Node/Server.pm
@@ -10,6 +10,7 @@ use warnings;
 use English qw(-no_match_vars);
 
 use Munin::Node::Config;
+use Munin::Common::Daemon;
 use Munin::Common::Defaults;
 use Munin::Common::Timeout;
 use Munin::Common::TLSServer;
@@ -52,6 +53,8 @@ sub pre_loop_hook {
 
     $services->prepare_plugin_environment(keys %services);
     _add_services_to_nodes(keys %services);
+    # the port is bound, the service is prepared: we can start accepting requests
+    Munin::Common::Daemon::emit_sd_notify_message();
     return $self->SUPER::pre_loop_hook();
 }
 

--- a/node/sbin/munin-node
+++ b/node/sbin/munin-node
@@ -41,6 +41,7 @@ my $conffile = "$Munin::Common::Defaults::MUNIN_CONFDIR/munin-node.conf";
 my $DEBUG    = 0;
 my $PIDEBUG  = 0;
 my $paranoia = 0;
+my $foreground = 0;
 
 sub main
 {
@@ -81,10 +82,21 @@ sub main
         paranoia => $paranoia,
     });
 
-    Munin::Node::Server->run(
+    my %server_params = (
         syslog_ident => 'munin-node',
         conf_file    => $conffile,
     );
+    # Optionally force foreground mode (overriding settings in the configuration file).
+    # This is necessary for using the optional "sd_notify" feature:
+    #     * Net::Server::Fork goes into background before the socket is ready.  Thus we need to
+    #       prevent it from daemonizing.
+    #     * start-stop-daemon supports '--notify-await' only combined with '--background'. Thus
+    #       munin-node may not daemonize on its own.
+    if ($foreground) {
+        $server_params{background} = 0;
+        $server_params{setsid} = 0;
+    }
+    Munin::Node::Server->run(%server_params);
 
     # Untaint $0 after Munin::Node::Server has had a chance of getting
     # the original value
@@ -103,6 +115,7 @@ sub parse_args
         "config=s"     => \$conffile,
         "debug!"       => \$DEBUG,
         "pidebug!"     => \$PIDEBUG,
+        "foreground!"  => \$foreground,
         "paranoia!"    => \$paranoia,
         "version"      => \&print_version_and_exit,
         "help"         => \&print_usage_and_exit,


### PR DESCRIPTION
The [sd_notify](https://www.freedesktop.org/software/systemd/man/sd_notify.html) interface can be used to signal the readiness of a service to its caller.

This feature can be used with `systemd` and `start-stop-daemon` in order to avoid timing issues during service startup.