### PR TITLE
Plugin cpuspeed: ensure value is not in scientific notation

### DIFF
--- a/plugins/node.d.linux/cpuspeed
+++ b/plugins/node.d.linux/cpuspeed
@@ -147,7 +147,7 @@ fi
 for c in /sys/devices/system/cpu/cpu[0-9]*; do
     N=${c##*/cpu}
     if [ -r "$ACPI_CPUFREQ_INDICATOR_FILENAME" ]; then
-        value=$(awk '{ cycles += $1 * $2 } END { print(cycles / 100); }' "$c/cpufreq/stats/time_in_state")
+        value=$(awk '{ cycles += $1 * $2 } END { printf("%.0f", cycles / 100); }' "$c/cpufreq/stats/time_in_state")
     elif [ -r "$INTEL_PSTATE_INDICATOR_FILENAME" ]; then
         value=$(cat "$c/cpufreq/scaling_cur_freq")
     else


### PR DESCRIPTION
In my rpi4 I get values like 3.43989e+09 and munin doesn't like that.
`2020/02/19 17:25:08 [ERROR] In RRD: Error updating /var/lib/munin/.../...-cpuspeed-cpu3-d.rrd: /var/lib/munin/.../...-cpuspeed-cpu3-d.rrd: not a simple signed integer: '3538340000.0000'`

This forces awk to print it as a full integer.