### PR TITLE
Proc plugin: Allow monitoring of processes with empty cmdline

### DIFF
--- a/plugins/node.d.linux/proc
+++ b/plugins/node.d.linux/proc
@@ -354,12 +354,14 @@ sub populate_stats
         foreach my $line(`fgrep -h '($procname[$i])' /proc/[0-9]*/stat`) {
             my ($pid) = $line =~ /^(\d+)/;
 
-            my $cmdline = slurp("/proc/$pid/cmdline") or next STATLINE;
-            $cmdline =~ tr{\0}{ };
-
             my $cmduid = (lstat("/proc/$pid"))[4];
 
-            next STATLINE if $procargs[$i] and $cmdline !~ /$procargs[$i]/;
+            if ( $procargs[$i] ) {
+              my $cmdline = slurp("/proc/$pid/cmdline") or next STATLINE;
+              $cmdline =~ tr{\0}{ };
+
+              next STATLINE if $procargs[$i] and $cmdline !~ /$procargs[$i]/;
+            }
             next STATLINE if defined $procuid and $cmduid != $procuid;
 
             if ($line =~ /^\d+ \(.*\) . \-?\d+ \-?\d+ \-?\d+ \-?\d+ \-?\d+ \d+ \d+ \d+ \d+ \d+ (\d+) (\d+) \d+ \d+ \-?\d+ \-?\d+ (\d+) \-?\d+ \d+ (\d+) (\d+)/) {


### PR DESCRIPTION
If /proc/pid/cmdline contains nothing, the plugin would not use the counters.

cmdline should only be needed if one have specified command line arguments,
and some processes (like kswapd0 for example) do not have any contents in its
cmdline.

This patch allows kswapd0 and friends to be monitored with this plugin.