### PR TITLE
Plugin cpu (linux): emit timestamp along with the values

### DIFF
--- a/plugins/node.d.linux/cpu.in
+++ b/plugins/node.d.linux/cpu.in
@@ -233,6 +233,7 @@ fi
 # Note: Counters/derive need to report integer values.  Also we need
 # to avoid 10e+09 and the like %.0f should do this.
 
+timestamp=$(date +%s)
 if [ -n "$extextextinfo" ]; then
 	awk -v "hz=$HZ" '/^cpu / { printf "user.value %.0f\nnice.value %.0f\nsystem.value %.0f\nidle.value %.0f\niowait.value %.0f\nirq.value %.0f\nsoftirq.value %.0f\nsteal.value %.0f\nguest.value %.0f\n", $2*100/hz, $3*100/hz, $4*100/hz, $5*100/hz, $6*100/hz, $7*100/hz, $8*100/hz, $9*100/hz, $10*100/hz }' < /proc/stat
 elif [ -n "$extextinfo" ]; then
@@ -241,4 +242,4 @@ elif [ -n "$extinfo" ]; then
 	awk -v "hz=$HZ" '/^cpu / { printf "user.value %.0f\nnice.value %.0f\nsystem.value %.0f\nidle.value %.0f\niowait.value %.0f\nirq.value %.0f\nsoftirq.value %.0f\n", $2*100/hz, $3*100/hz, $4*100/hz, $5*100/hz, $6*100/hz, $7*100/hz, $8*100/hz }' < /proc/stat
 else
 	awk -v "hz=$HZ" '/^cpu / { printf "user.value %.0f\nnice.value %.0f\nsystem.value %.0f\nidle.value %.0f\n", $2*100/hz, $3*100/hz, $4*100/hz, $5*100/hz }' < /proc/stat
-fi
+fi | sed "s/\.value /.value $timestamp:/"


### PR DESCRIPTION
This allows rrdtool to properly calculate the "usage by time" values for
the different categories.
Previously a slightly non-constant polling period would lead to minor
bumps in the CPU usage graphs.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=767100