### PR TITLE
make Linux diskstats plugin comaptible with Linux 5.5+

### DIFF
--- a/plugins/node.d.linux/diskstats
+++ b/plugins/node.d.linux/diskstats
@@ -435,8 +435,9 @@ sub read_sysfs {
 
         # before linux 4.19, /sys/block/<dev>/stat had 11 fields.
         # in 4.19, four fields for tracking DISCARDs have been added
+        # in 5.5, two fields for tracking flush requests have been added
         croak "'$stats_file' contains the wrong amount of values. Aborting"
-          if ( @elems != 11 && @elems != 15 );
+          if ( @elems != 11 && @elems != 15 && @elems != 17 );
 
         # Translate the devicename back before storing the information
         $cur_device =~ tr#!#/#;


### PR DESCRIPTION
in 5.5, kernel developers added four new fields to the sysfs files
/sys/block/<dev>/stat for tracking flush requests. Thus, the assumption
of having always 11 or 15 values does not hold anymore and the plugin fails
with

'/sys/block/md127/stat' contains the wrong amount of values. Aborting at /etc/munin/plugins/diskstats line 432.
    main::read_sysfs() called at /etc/munin/plugins/diskstats line 458
    main::parse_diskstats() called at /etc/munin/plugins/diskstats line 530
    main::fetch_device_counters() called at /etc/munin/plugins/diskstats line 35

The relevant kernel commit is
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v5.5&id=b6866318657717c8914673a6394894d12bc9ff5e

This patch adds support for the new fields (by ignoring them), adapts the
error message and adds a hint why the check has changed.