### PR TITLE
Plugin mysql_innodb: pass argument to mysql_exec

### DIFF
--- a/plugins/node.d/mysql_innodb.in
+++ b/plugins/node.d/mysql_innodb.in
@@ -102,7 +102,7 @@ CRITICAL=${critical:-1073741824} # 1GB
 
 mysql_exec() {
     # shellcheck disable=SC2086
-    "$MYSQL" $MYSQLOPTS --batch --skip-column-names --database=information_schema --execute
+    "$MYSQL" $MYSQLOPTS --batch --skip-column-names --database=information_schema --execute "$1"
 }
 
 


### PR DESCRIPTION
The argument to mysql_exec should be passed to the mysql invocation
command. Without this the plugin shows errors like:

  /usr/bin/mysql: option '--execute' requires an argument
  /etc/munin/plugins/mysql_innodb: line 188: [: : integer expression expected