### PR TITLE
add start and stop log for munin-graph

### DIFF
--- a/master/_bin/munin-graph.in
+++ b/master/_bin/munin-graph.in
@@ -82,6 +82,9 @@ if (! graph_check_cron() ) {
 	exit 0;
 }
 
+INFO "Starting munin-graph"; 
+my $graph_time = Time::HiRes::time;
+
 # BEGIN FAST-CGI LOOP:
 my $nb_request = 0;
 my $nb_request_max = 0;
@@ -102,7 +105,7 @@ while (my $path = <$graph_fh>) {
     # Case 2:
     # http://localhost:8080/munin-cgi/munin-cgi-graph/client/\
     #    Backend/dafnes.client.example.com/diskstats_iops/sda-week.png
-    # path should be
+    #Â path should be
     #    client/Backend/dafnes.client.example.com/diskstats_iops/\
     #    sda-week.png
     #
@@ -173,6 +176,9 @@ while (my $path = <$graph_fh>) {
 	}
 }
 # END FAST-CGI LOOP - Time to die.  Nicely.
+
+$graph_time = sprintf("%.2f", (Time::HiRes::time - $graph_time));
+INFO "Munin-graph finished ($graph_time sec)";
 
 exit 0;
 


### PR DESCRIPTION
This patch is the same as in [d5a150fdaf0e3c0eee55a5230e17743add44fef8](http://munin-monitoring.org/changeset/d5a150fdaf0e3c0eee55a5230e17743add44fef8/munin)
It adds two additional INFO log lines to the munin-graph logfile which is used by the munin-node plugin [munin_stats](https://github.com/munin-monitoring/munin/blob/stable-2.0/plugins/node.d/munin_stats.in)

**Original commit message:**
As Christoph Biedl suggested, we should at least log the start and stop of the
cron part for munin-graph if enabled. That part was remove in 2.0.12, as commit
[4372cdf24935b45f62a93b8f55e6ccacc4b6a687](http://munin-monitoring.org/changeset/4372cdf24935b45f62a93b8f55e6ccacc4b6a687/munin)