### PR TITLE
Allow snmp iface by name

### DIFF
--- a/lib/Munin/Node/Service.pm
+++ b/lib/Munin/Node/Service.pm
@@ -50,7 +50,7 @@ sub is_a_runnable_service
     return if $file =~ m/^\./;      # Hidden files
     return if $file =~ m/\.conf$/;  # Config files
 
-    return if $file !~ m/^[-\w.:]+$/;  # Skip if any weird chars
+    return if $file !~ m/^[-\w\@.:]+$/;  # Skip if any weird chars
 
     foreach my $regex (@{$config->{ignores}}) {
         return if $file =~ /$regex/;

--- a/plugins/node.d/snmp__if_
+++ b/plugins/node.d/snmp__if_
@@ -125,9 +125,22 @@ if (defined $ARGV[0] and $ARGV[0] eq "snmpconf") {
 	exit 0;
 }
 
+my ($session, $error);
+
+# SNMP needed for both config and fetch.
+$session = Munin::Plugin::SNMP->session();
+$session->translate([-nosuchinstance => 0]);
+
 if ($Munin::Plugin::me =~ /_if_(\d+)$/) {
     # Also accept leading 0 like (snmp_router_if_01 .. snmp_router_if_24)
     $iface = int $1;
+} elsif ($Munin::Plugin::me =~ /_if_([\w\@.-]+)$/) {
+    my $ifAliasContainer = "1.3.6.1.2.1.31.1.1.1.18.";
+    my $if_alias = $session->get_by_regex($ifAliasContainer, "^$1\$");
+    if (keys(%{$if_alias}) != 1) {
+	die "Could not determine interface number from ".$Munin::Plugin::me."\n";
+    }
+    $iface = (keys %{$if_alias})[0];
 } else {
     die "Could not determine interface number from ".$Munin::Plugin::me."\n";
 }
@@ -143,12 +156,6 @@ my $ifEntryOutOctets   = "1.3.6.1.2.1.2.2.1.16.$iface";
 my $ifEntryAlias       = "1.3.6.1.2.1.31.1.1.1.18.$iface";
 my $ifEntryIn64Octets  = "1.3.6.1.2.1.31.1.1.1.6.$iface";
 my $ifEntryOut64Octets = "1.3.6.1.2.1.31.1.1.1.10.$iface";
-
-my ($session, $error);
-
-# SNMP needed for both config and fetch.
-$session = Munin::Plugin::SNMP->session();
-$session->translate([-nosuchinstance => 0]);
 
 if ($ARGV[0] and $ARGV[0] eq "config") {
     my ($host,undef,$version) = Munin::Plugin::SNMP->config_session();

--- a/plugins/node.d/snmp__if_err_
+++ b/plugins/node.d/snmp__if_err_
@@ -82,8 +82,17 @@ my ($host) = Munin::Plugin::SNMP->config_session();
 
 my $iface;
 
+my $session = Munin::Plugin::SNMP->session();
+
 if ($Munin::Plugin::me =~ /if_err_(\d+)$/) {
     $iface = $1;
+} elsif ($Munin::Plugin::me =~ /_if_err_([\w\@.-]+)$/) {
+    my $ifAliasContainer = "1.3.6.1.2.1.31.1.1.1.18.";
+    my $if_alias = $session->get_by_regex($ifAliasContainer, "^$1\$");
+    if (keys(%{$if_alias}) != 1) {
+	die "Could not determine interface number from ".$Munin::Plugin::me."\n";
+    }
+    $iface = (keys %{$if_alias})[0];
 } else {
     die "Could not determine interface number from ".$Munin::Plugin::me."\n";
 }
@@ -98,8 +107,6 @@ my $ifInErrors       = "1.3.6.1.2.1.2.2.1.14.$iface";
 my $ifInUnknownProtos= "1.3.6.1.2.1.2.2.1.15.$iface";
 my $ifOutDiscards    = "1.3.6.1.2.1.2.2.1.19.$iface";
 my $ifOutErrors      = "1.3.6.1.2.1.2.2.1.20.$iface";
-
-my $session = Munin::Plugin::SNMP->session();
 
 if ($ARGV[0] and $ARGV[0] eq "config") {
     my ($host) = Munin::Plugin::SNMP->config_session();


### PR DESCRIPTION
As discussed in #1201 , this pull request adds support for matching network interfaces from SNMP by name, rather than index, which is useful for devices where the index changes (such as on linux based routers like the UniFi Security Gateway).

Tested working correctly for my environment. Patch includes a small fix to allow the matching of interfaces with and `@` character, such as vlans (`ethN.VID@ethN`)