### PR TITLE
Allow overriding of network interface alias from SNMP

### DIFF
--- a/plugins/node.d/snmp__if_
+++ b/plugins/node.d/snmp__if_
@@ -155,11 +155,12 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
 
     print "host_name $host\n" unless $host eq 'localhost';
 
-    my $alias = $session->get_single($ifEntryAlias) ||
+    my $alias = $ENV{alias} ||
+      $session->get_single($ifEntryAlias) ||
       $session->get_single($ifEntryDescr) ||
 	"Interface $iface";
 
-    if (! ($alias =~ /\d+/) ) {
+    if (! ($alias =~ /\d+/ or defined($ENV{alias})) ) {
 	# If there are no numbers in the $alias add the if index
 	$alias .=" (if $iface)";
     }

--- a/plugins/node.d/snmp__if_err_
+++ b/plugins/node.d/snmp__if_err_
@@ -106,11 +106,12 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
 
     print "host_name $host\n" unless $host eq 'localhost';
 
-    my $alias = $session->get_single($ifEntryAlias) ||
+    my $alias = $ENV{alias} ||
+      $session->get_single($ifEntryAlias) ||
       $session->get_single($ifEntryDescr) ||
 	"Interface $iface";
 
-    if (! ($alias =~ /\d+/) ) {
+    if (! ($alias =~ /\d+/ or defined($ENV{alias})) ) {
 	# If there are no numbers in the $alias add the if index
 	$alias .=" (if $iface)";
     }


### PR DESCRIPTION
A small PR to add support for overriding the interface alias from SNMP.

An example would be a plugin config file like this:

    [snmp_hostname.fqdn_if_2]
    env.alias WAN
