### PR TITLE
Plugin apc_nis: add UPS load in watt and hide frequency

### DIFF
--- a/plugins/node.d/apc_nis
+++ b/plugins/node.d/apc_nis
@@ -21,6 +21,7 @@ The following configuration parameters are used by this plugin
 =head1 MAGIC MARKERS
 
  #%# family=contrib
+ #%# capabilities=autoconf
 
 =cut
 
@@ -56,6 +57,8 @@ print $sock "status\n";
 if($ARGV[0] and $ARGV[0] eq "config") {
     # Test for some capabilities.
     my $has_temperature = 0, my $line_volt_min, my $line_volt_max;
+    my $has_freq = 0;
+    my $nom_power = 0;
     my $line;
     do {
         $line = <$sock>;
@@ -68,6 +71,12 @@ if($ARGV[0] and $ARGV[0] eq "config") {
         } elsif ($line =~ /\WHITRANS /) {
             $line =~ s/.* (\d+.\d+).*/$1/;
             $line_volt_max = $line;
+        } elsif($line =~ /\WLINEFREQ /) {
+            $line =~ s/.* (\d+.\d+).*/$1/;
+            $has_freq = 1;
+        } elsif($line =~ /\WNOMPOWER /) {
+            $line =~ s/.* (\d+.\d+).*/$1/;
+            $nom_power = $line;
         }
     } while(!($line =~ /END APC/));
 
@@ -75,7 +84,7 @@ if($ARGV[0] and $ARGV[0] eq "config") {
 
     print "graph_title APC UPS measurements\n";
     print "graph_args -l 0 --base 1000\n";
-    print "graph_vlabel A bit of all (Volt, time, %)\n";
+    print "graph_vlabel A bit of all (Volt, time, %, Watt)\n";
     print "graph_info Values received for apcupsd available at $host:$port\n";
     print "graph_category sensors\n";
     print "battery_volt.label batt volt (V)\n";
@@ -88,11 +97,18 @@ if($ARGV[0] and $ARGV[0] eq "config") {
     print "line_volt.type GAUGE\n";
     print "line_volt.max 300\n";
     print "line_volt.warning ${line_volt_min}:${line_volt_max}\n";
-    print "line_freq.label line (Hz)\n";
-    print "line_freq.type GAUGE\n";
-    print "line_freq.max 65\n";
+    if ($has_freq) {
+        print "line_freq.label line (Hz)\n";
+        print "line_freq.type GAUGE\n";
+        print "line_freq.max 65\n";
+    }
     print "load.label ups load (%)\n";
     print "load.type GAUGE\n";
+    if ($nom_power) {
+        print "load_watt.label ups load (W)\n";
+        print "load_watt.type GAUGE\n";
+        print "load_watt.max $nom_power\n";
+    }
     print "time_left.label time left (min)\n";
     print "time_left.type GAUGE\n";
     if ($has_temperature) {
@@ -102,6 +118,7 @@ if($ARGV[0] and $ARGV[0] eq "config") {
     exit 0;
 }
 
+my $load_percent, my $nom_power = 0;
 my $line;
 do {
     $line = <$sock>;
@@ -118,6 +135,10 @@ do {
     } elsif($line =~ /\WLOADPCT /) {
         $line =~ s/.* (\d+.\d+).*/$1/;
         print "load.value $line\n";
+        $load_percent = $line;
+    } elsif($line =~ /\WNOMPOWER /) {
+        $line =~ s/.* (\d+.\d+).*/$1/;
+        $nom_power = $line;
     } elsif($line =~ /\WBCHARGE /) {
         $line =~ s/.* (\d+.\d+).*/$1/;
         print "battery_charge.value $line\n";
@@ -129,5 +150,9 @@ do {
         print "temperature.value $line\n";
     }
 } while(!($line =~ /END APC/));
+
+if ($nom_power) {
+    print "load_watt.value " . ($nom_power / 100 * $load_percent) . "\n";
+}
 
 close($sock);


### PR DESCRIPTION
I've improved the apc_nis plugin disabling the print of frequency when the UPS doesn't report line frequency (like my one) and adding the UPS load in watt when the nominal power is reported by the UPS.