### PR TITLE
[snmp] Update snmp__if_err_ and snmp__if_multi titles to better match…

### DIFF
--- a/doc/plugin/multigraphing.rst
+++ b/doc/plugin/multigraphing.rst
@@ -37,7 +37,7 @@ The setup is done in the usual way, with graph_title and other configuration ite
 ::
 
    multigraph if_bytes
-   graph_title $host interface traffic
+   graph_title All interfaces traffic
    graph_order recv send
    graph_args --base 1000
    graph_vlabel bits in (-) / out (+) per \${graph_period}
@@ -57,7 +57,7 @@ The setup is done in the usual way, with graph_title and other configuration ite
    send.min 0
 
    multigraph if_errors
-   graph_title $host interface errors
+   graph_title All interfaces errors
    graph_order recv send
    graph_args --base 1000
    graph_vlabel errors in (-) / out (+) per \${graph_period}
@@ -82,7 +82,7 @@ Then for each of the interfaces the plugin emits these configuration items (inte
 
    multigraph if_bytes.if_$if
 
-   graph_title Interface $alias traffic
+   graph_title $alias traffic
    graph_order recv send
    graph_args --base 1000
    graph_vlabel bits in (-) / out (+) per \${graph_period}
@@ -106,7 +106,7 @@ Then for each of the interfaces the plugin emits these configuration items (inte
 
    multigraph if_errors.if_$if
 
-   graph_title Interface $alias errors
+   graph_title $alias errors
    graph_order recv send
    graph_args --base 1000
    graph_vlabel bits in (-) / out (+) per \${graph_period}

--- a/plugins/node.d/snmp__if_err_
+++ b/plugins/node.d/snmp__if_err_
@@ -108,7 +108,7 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
 
     my $alias = $session->get_single($ifEntryAlias) ||
       $session->get_single($ifEntryDescr) ||
-	"Interface $iface";
+	"$iface";
 
     if (! ($alias =~ /\d+/) ) {
 	# If there are no numbers in the $alias add the if index
@@ -127,7 +127,7 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
     # Any error is too many
     my $warn = 1;
 
-    print "graph_title Interface $alias errors\n";
+    print "graph_title $alias errors\n";
     print "graph_order recv send\n";
     print "graph_args --base 1000\n";
     print "graph_vlabel Errors in (-) / out (+) per \${graph_period}\n";

--- a/plugins/node.d/snmp__if_multi
+++ b/plugins/node.d/snmp__if_multi
@@ -545,7 +545,7 @@ sub do_config_root {
     my ($host) = @_;
 
     print "multigraph if_bytes\n";
-    print "graph_title $host interface traffic\n";
+    print "graph_title All interfaces traffic\n";
     print "graph_order recv send\n";
     print "graph_args --base 1000\n";
     print "graph_vlabel bits in (-) / out (+) per \${graph_period}\n";
@@ -565,7 +565,7 @@ sub do_config_root {
     print "send.min 0\n";
 
     print "multigraph if_errors\n";
-    print "graph_title $host interface errors\n";
+    print "graph_title All interfaces errors\n";
     print "graph_order recv send\n";
     print "graph_scale no\n";
     print "graph_args --base 1000\n";
@@ -646,7 +646,7 @@ sub do_config_if {
 
     print "multigraph if_bytes.if_$if\n";
 
-    print "graph_title Interface $alias traffic\n";
+    print "graph_title $alias traffic\n";
     print "graph_order recv send\n";
     print "graph_args --base 1000\n";
     print "graph_vlabel bits in (-) / out (+) per \${graph_period}\n";
@@ -670,7 +670,7 @@ sub do_config_if {
 
     print "multigraph if_errors.if_$if\n";
 
-    print "graph_title Interface $alias errors\n";
+    print "graph_title $alias errors\n";
     print "graph_order recv send\n";
     print "graph_args --base 1000\n";
     print "graph_scale no\n";


### PR DESCRIPTION
… other plugins

This allows for better grouping, and more unified look, of graphs
showing the same metric collected by either SNMP and non-SNMP plugins
across different hosts (e.g., if_ and if_err_).

Signed-off-by: Olivier Mehani <shtrom@ssji.net>