### PR TITLE
Munin thresholds support for http_loadtime

### DIFF
--- a/plugins/node.d/http_loadtime
+++ b/plugins/node.d/http_loadtime
@@ -17,6 +17,8 @@ The following environment variables are used by this plugin
    env.requisites true
    env.username user
    env.password opensesame
+   env.warning 5
+   env.critical 30
 
  Do not enable the download of page requisites (env.requisites) for https
  sites since wget needs incredible long to perform this on big sites...
@@ -41,6 +43,8 @@ GPLv2
  #%# capabilities=autoconf
 
 =cut
+
+. "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 target=${target:-"http://localhost/"}
 requisites=${requisites:-"false"}
@@ -108,6 +112,7 @@ if [ "$1" = "config" ]; then
         if [ "$uri_short" != "$uri" ]; then uri_short="${uri_short}..."; fi
         echo "$(escapeUri "$uri").label $uri_short"
         echo "$(escapeUri "$uri").info page load time"
+        print_thresholds "$(escapeUri "$uri")"
     done
     exit 0
 fi


### PR DESCRIPTION
This fix delivers feature to use munin-node configuration file to set user defined warning and critical thresholds.