### PR TITLE
adjust_threshold: strings indexes are 1 based in AWK

### DIFF
--- a/plugins/plugin.sh
+++ b/plugins/plugin.sh
@@ -98,8 +98,8 @@ adjust_threshold () {
 
     if [ -n "$1" ] && [ -n "$2" ]; then
         echo "$1" | awk "BEGIN { FS=\":\"; OFS=\":\" }
-        \$1 ~ /.*%/ {\$1 = $2 * substr(\$1, 0, length(\$1) - 1) / 100}
-        \$2 ~ /.*%/ {\$2 = $2 * substr(\$2, 0, length(\$2) - 1) / 100}
+        \$1 ~ /.*%/ {\$1 = $2 * substr(\$1, 1, length(\$1) - 1) / 100}
+        \$2 ~ /.*%/ {\$2 = $2 * substr(\$2, 1, length(\$2) - 1) / 100}
 
         { print }"
     fi


### PR DESCRIPTION
GAWK accepts index 0 as an alias for index 1 in substr(), but mawk
does not.  no reason to rely on undefined behaviour.

this fixes issue #1350