### PR TITLE
Make sensors_ temperature plugin work on musl libc

### DIFF
--- a/plugins/node.d.linux/sensors_.in
+++ b/plugins/node.d.linux/sensors_.in
@@ -137,7 +137,7 @@ my %config = (
 
             (?:\.\d+)?)# Zero or one match of '.' char followed by one or more
                        # digits. '?:' means it is not a numbered capture group.
-            [°\s]      # Match degree char or space char
+            [°\s*]     # Match degree, space, or asterisk char
             C          # Match 'C' char
 
             (?:        # >>>>Match the following statement zero or one time.
@@ -154,7 +154,7 @@ my %config = (
 
             (?:\.\d+)?)# Zero or one match of '.' char followed by one or more
                        # digits. '?:' means it is not a numbered capture group.
-            [°\s]      # Match degree char or space char
+            [°\s*]     # Match degree, space, or asterisk char
             C,?\s*     # 'C' followed by optional comma and zero or more spaces
             (?:        # >>>Match the following non-capture group zero or more times
             (?:crit|hyst(?:eresis)?) # 'crit' or 'hyst' string followed by optional 'eresis' string.
@@ -166,7 +166,7 @@ my %config = (
                        # (Match hyst value) followed by
             (?:\.\d+)?)# Zero or one match of '.' char followed by one or more
                        # digits. '?:' means it is not a numbered capture group.
-            [°\s]C     # Match degree char or space char, and then 'C' char
+            [°\s*]C    # Match degree, space, or asterisk char, and then 'C' char
             )?         # >>>end of group
             \)         # ')' char
             )?         # >>>>end of group
@@ -279,7 +279,7 @@ if ( defined $ARGV[0] and $ARGV[0] eq 'autoconf' ) {
     exit 0;
   }
 
-  unless ($text =~ /[° ]C/) {
+  unless ($text =~ /[°\s*]C/) {
     print "no (no temperature readings)\n";
     exit 0;
   }


### PR DESCRIPTION
musl libc (e.g. Alpine Linux, OpenWrt) behaves slightly differently than
glibc when LC_ALL=C is passed to the sensors command. Instead of
substituting the degree symbol for a space, it replaces it with an
asterisk. Adjust the regexes accordingly.

Also, change the autoconf regex to be consistent with the ones used to
actually parse the 'sensors' output.