### PR TITLE
Spoolfetch: process spooled content lines separately

### DIFF
--- a/node/_bin/munin-async.in
+++ b/node/_bin/munin-async.in
@@ -98,7 +98,7 @@ while (my $line = <>) {
 		print ".\n";
 	} elsif ($line =~ m/^spoolfetch (\d+)/) {
 		my $last_epoch = $1;
-		print $spoolreader->fetch($last_epoch);
+		$spoolreader->fetch($1, sub { print shift(); });
 		print ".\n";
 	} elsif ($spoolfetch && $line =~ m/^cap/) {
 		print "cap spool\n";

--- a/node/lib/Munin/Node/Server.pm
+++ b/node/lib/Munin/Node/Server.pm
@@ -200,7 +200,7 @@ sub _process_command_line {
         _print_service($session, _run_service($1, 'config'));
     }
     elsif (/^spoolfetch (\d+)/ and $spool) {
-        _net_write($session, $spool->fetch($1));
+        $spool->fetch($1, sub { _net_write($session, shift()); });
         _net_write($session, ".\n");
     }
     elsif (/^starttls\s*$/i) {

--- a/node/lib/Munin/Node/SpoolReader.pm
+++ b/node/lib/Munin/Node/SpoolReader.pm
@@ -125,7 +125,12 @@ sub _cat_multigraph_file
 
     my $nb_samples_sent = 0;
     foreach my $file (sort readdir $self->{spooldirhandle}) {
-        next unless $file =~ m/^munin-daemon\.$service\.(\d+)\.(\d+)$/;
+        # squash the $service name with the same rules as the munin-update when using plain TCP
+        # Closes D:710529
+        my $service_clean = $service;
+        $service_clean =~ s/[^_A-Za-z0-9]/_/g;
+
+        next unless $file =~ m/^munin-daemon\.$service_clean\.(\d+)\.(\d+)$/;
         next unless $1+$2 >= $timestamp;
 
         open my $fh, '<', "$self->{spooldir}/$file"

--- a/node/lib/Munin/Node/SpoolReader.pm
+++ b/node/lib/Munin/Node/SpoolReader.pm
@@ -124,7 +124,7 @@ sub _cat_multigraph_file
         or die "Unable to reset the spool directory handle: $!";
 
     my $nb_samples_sent = 0;
-    foreach my $file (readdir $self->{spooldirhandle}) {
+    foreach my $file (sort readdir $self->{spooldirhandle}) {
         next unless $file =~ m/^munin-daemon\.$service\.(\d+)\.(\d+)$/;
         next unless $1+$2 >= $timestamp;
 

--- a/node/lib/Munin/Node/SpoolReader.pm
+++ b/node/lib/Munin/Node/SpoolReader.pm
@@ -71,16 +71,25 @@ sub set_metadata
 
 
 # returns all output for all services since $timestamp.
+# The third argument ($submission_function) is optional: it is used for processing partial results,
+# in order to avoid slurping the full data content into RAM.  The result is empty, if this function
+# is given.
 sub fetch
 {
-    my ($self, $timestamp) = @_;
+    my ($self, $timestamp, $submission_function) = @_;
 
     my $return_str = '';
 
     my @plugins = $self->_get_spooled_plugins();
     logger("timestamp:$timestamp, plugins:@plugins") if $config->{DEBUG};
     foreach my $plugin (@plugins) {
-        $return_str .= $self->_cat_multigraph_file($plugin, $timestamp);
+        my $new_content = $self->_cat_multigraph_file(
+            $plugin, $timestamp, undef, $submission_function);
+        if (defined $submission_function) {
+            $submission_function->($new_content);
+        } else {
+            $return_str .= $new_content;
+        }
     }
 
     return $return_str;
@@ -96,9 +105,12 @@ sub list
 }
 
 
+# The last argument ($submission_function) is optional: it is used for processing partial results,
+# in order to avoid slurping the full data content into RAM.  The result is empty, if this function
+# is given.
 sub _cat_multigraph_file
 {
-    my ($self, $service, $timestamp, $max_samples_per_service) = @_;
+    my ($self, $service, $timestamp, $max_samples_per_service, $submission_function) = @_;
 
     # Default $max_samples_per_service is 5, in order to have a 5x time
     # increase in catchup.  This enables to not overwhelm the munin-update when
@@ -155,7 +167,11 @@ sub _cat_multigraph_file
                 $_ = "$1.value $epoch:$2";
             }
 
-            $data .= $_ . "\n";
+            if (defined $submission_function) {
+                $submission_function->($_ . "\n");
+            } else {
+                $data .= $_ . "\n";
+            }
         }
 
 	# We just emitted something

--- a/node/lib/Munin/Node/SpoolReader.pm
+++ b/node/lib/Munin/Node/SpoolReader.pm
@@ -131,7 +131,10 @@ sub _cat_multigraph_file
         $service_clean =~ s/[^_A-Za-z0-9]/_/g;
 
         next unless $file =~ m/^munin-daemon\.$service_clean\.(\d+)\.(\d+)$/;
-        next unless $1+$2 >= $timestamp;
+        my $interval_start = $1;
+        my $interval_size = $2;
+        # skip the file if its newest value is older than the minimum wanted timestamp
+        next if $interval_start + $interval_size < $timestamp;
 
         open my $fh, '<', "$self->{spooldir}/$file"
             or die "Unable to open spool file: $!";


### PR DESCRIPTION
Previously the full content of the spool data was handled in memory, before it was printed at once.
Now every line is printed directly, when it is processed.
Thus the munin-async process does not consume a relevant amount of memory anymore.
    
The issue was reported and tested by Marbug via IRC, thanks!
