### PR TITLE
fix reporting on URL in the munin-update log (stable-2.0)

### DIFF
--- a/master/lib/Munin/Master/UpdateWorker.pm
+++ b/master/lib/Munin/Master/UpdateWorker.pm
@@ -56,8 +56,20 @@ sub do_work {
     my $path = $self->{host}->get_full_path;
     $path =~ s{[:;]}{-}g;
 
-    my $nodedesignation = $host."/".
-	$self->{host}{address}.":".$self->{host}{port};
+    # Parameters are space-separated from the main address
+    my ($url, $params) = split(/ +/, $self->{host}{address}, 2);
+    my $uri = new URI($url);
+
+    # If the scheme is not defined, it's a plain host.
+    # Prefix it with munin:// to be able to parse it like others
+    $uri = new URI("munin://" . $url) unless $uri->scheme;
+
+    my $nodedesignation;
+    if ($uri->scheme eq "ssh" || $uri->scheme eq "cmd") {
+      $nodedesignation = $host." (".$self->{host}{address}.")";
+    }else{
+      $nodedesignation = $host." (".$self->{host}{address}.":".$self->{host}{port}.")";
+    }
 
     my $lock_file = sprintf ('%s/munin-%s.lock',
 			     $config->{rundir},


### PR DESCRIPTION
This will fix the reporting of the URL in munin-update.log in function of the protocol used.

Previously ssh and cmd reported a port at the end in the logs which was confusing. This will report the address how we expect it to be used.

Replacing PR of https://github.com/munin-monitoring/munin/pull/1366 to master