### PR TITLE
Make netstat human and high connection friendly

### DIFF
--- a/plugins/node.d.linux/netstat.in
+++ b/plugins/node.d.linux/netstat.in
@@ -65,8 +65,9 @@ fi
 
 if [ "$1" = "config" ]; then
 
-	echo 'graph_title Netstat'
-	echo 'graph_args --base 1000 --logarithmic'
+	echo 'multigraph netstat'
+	echo 'graph_title Netstat, combined'
+	echo 'graph_args --units=si -l 1 --base 1000 --logarithmic'
 	echo 'graph_vlabel TCP connections'
 	echo 'graph_category network'
 	echo 'graph_period second'
@@ -101,10 +102,25 @@ if [ "$1" = "config" ]; then
 	print_critical resets
 	echo 'established.label established'
 	echo 'established.type GAUGE'
-	echo 'established.max 50000'
 	echo 'established.info The number of currently open connections.'
 	print_warning established
 	print_critical established
+
+	echo ''
+
+	echo 'multigraph netstat_established'
+	echo 'graph_title Netstat, established only'
+	echo 'graph_args --lower-limit 0'
+	echo 'graph_vlabel TCP connections'
+	echo 'graph_category network'
+	echo 'graph_period second'
+	echo 'graph_info This graph shows the TCP activity of all the network interfaces combined.'
+	echo 'established.label established'
+	echo 'established.type GAUGE'
+	echo 'established.info The number of currently open connections.'
+	print_warning established
+	print_critical established
+
 	exit 0
 fi
 
@@ -112,9 +128,16 @@ fi
 # openings' string from plural connections to singular. The match hereby is for
 # both cases.
 #
+echo 'multigraph netstat'
 "$NETSTAT_CMD" -s | awk '
 /active connection(s)? ope/  { print "active.value " $1 }
 /passive connection ope/  { print "passive.value " $1 }
 /failed connection/       { print "failed.value " $1 }
 /connection resets/       { print "resets.value " $1 }
+/connections established/ { print "established.value " $1 }'
+
+echo
+
+echo 'multigraph netstat_established'
+"$NETSTAT_CMD" -s | awk '
 /connections established/ { print "established.value " $1 }'


### PR DESCRIPTION
Changes Y-axis to use SI units instead of 5e-02 till 1e+02 and such.

Makes it multigraph with a second linear graph for 'established',
because that number can be very much higher and natural variations will
just be a flat line in log scale.

Remove the arbitrary limit of 50000 max established connections.

Before:

![Munin-original-netstat](https://user-images.githubusercontent.com/6682400/104570034-b7261c80-5651-11eb-8961-e86ab2f4f6f6.png)

After example 1:

![MuninNetstatFixed1](https://user-images.githubusercontent.com/6682400/104570057-bf7e5780-5651-11eb-9148-85772415add5.png)

After example 2:

![MuninNetstatFixed2](https://user-images.githubusercontent.com/6682400/104570072-c2794800-5651-11eb-9f42-1b9903384d64.png)
