### PR TITLE
use dedicated munin SNMP plugin

### DIFF
--- a/plugins/node.d/snmp__df.in
+++ b/plugins/node.d/snmp__df.in
@@ -47,13 +47,10 @@ script.
 =cut
 
 use strict;
-use Net::SNMP;
+use Munin::Plugin::SNMP;
 
 my $MAXLABEL = 20;
 
-my $host      = $ENV{host}      || undef;
-my $port      = $ENV{port}      || 161;
-my $community = $ENV{community} || "public";
 my $iface     = $ENV{interface} || undef;
 
 my $response;
@@ -64,21 +61,6 @@ if (defined $ARGV[0] and $ARGV[0] eq "snmpconf")
 	print "require 1.3.6.1.2.1.25.2.3.1.2. 1.3.6.1.2.1.25.2.1.4\n"; # Type=fixed disk
 	print "require 1.3.6.1.2.1.25.2.3.1.5. [1-9]\n"; # Size > 0
 	exit 0;
-}
-
-if ($0 =~ /^(?:|.*\/)snmp_([^_]+)_df$/)
-{
-	$host  = $1;
-	if ($host =~ /^([^:]+):(\d+)$/)
-	{
-		$host = $1;
-		$port = $2;
-	}
-}
-elsif (!defined($host))
-{
-	print "# Debug: $0 -- $1\n" if $Munin::Plugin::SNMP::DEBUG;
-	die "# Error: couldn't understand what I'm supposed to monitor.";
 }
 
 # Partition level
@@ -93,16 +75,7 @@ my $hrStorageSize          = "1.3.6.1.2.1.25.2.3.1.5."; # Data point 1
 my $hrStorageUsed          = "1.3.6.1.2.1.25.2.3.1.6."; # Data point 2
 
 
-my ($session, $error) = Net::SNMP->session(
-		-hostname  => $host,
-		-community => $community,
-		-port      => $port
-	);
-
-if (!defined ($session))
-{
-	die "Croaking: $error";
-}
+my $session = Munin::Plugin::SNMP->session();
 # Take a look at the partitions...
 
 my %partitions;
@@ -188,6 +161,7 @@ foreach my $part (keys %partitions)
 
 if (defined $ARGV[0] and $ARGV[0] eq "config")
 {
+	my ($host) = Munin::Plugin::SNMP->config_session();
 	print "host_name $host\n" unless $host eq 'localhost';
 	print "graph_title Disk usage in percent\n";
 	print "graph_args --upper-limit 100 -l 0\n";

--- a/plugins/node.d/snmp__df_ram.in
+++ b/plugins/node.d/snmp__df_ram.in
@@ -45,13 +45,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 =cut
 
 use strict;
-use Net::SNMP;
+use Munin::Plugin::SNMP;
 
 my $MAXLABEL = 20;
-
-my $host      = $ENV{host}      || undef;
-my $port      = $ENV{port}      || 161;
-my $community = $ENV{community} || "public";
 
 my $response;
 
@@ -61,21 +57,6 @@ if (defined $ARGV[0] and $ARGV[0] eq "snmpconf")
 	print "require 1.3.6.1.2.1.25.2.3.1.2. 1.3.6.1.2.1.25.2.1.(1|2|3|9)\n"; # Type=Other/Ram/VirtualMemory/FlashMemory
 	print "require 1.3.6.1.2.1.25.2.3.1.5. [1-9]\n"; # Size > 0
 	exit 0;
-}
-
-if ($0 =~ /^(?:|.*\/)snmp_([^_]+)_df_ram$/)
-{
-	$host  = $1;
-	if ($host =~ /^([^:]+):(\d+)$/)
-	{
-		$host = $1;
-		$port = $2;
-	}
-}
-elsif (!defined($host))
-{
-	print "# Debug: $0 -- $1\n" if $Munin::Plugin::SNMP::DEBUG;
-	die "# Error: couldn't understand what I'm supposed to monitor.";
 }
 
 # Disk level
@@ -95,16 +76,7 @@ my $hrStorageSize          = "1.3.6.1.2.1.25.2.3.1.5."; # Data point 1
 my $hrStorageUsed          = "1.3.6.1.2.1.25.2.3.1.6."; # Data point 2
 
 
-my ($session, $error) = Net::SNMP->session(
-		-hostname  => $host,
-		-community => $community,
-		-port      => $port
-	);
-
-if (!defined ($session))
-{
-	die "Croaking: $error";
-}
+my $session = Munin::Plugin::SNMP->session();
 
 # First we want to find the harddisks...
 my $correct_capacity  = get_by_regex ($session, $hrDiskStorageCapacity, "[1-9]");
@@ -170,6 +142,7 @@ if ($foundpartitions == 0 or defined $partitions{""})
 
 if (defined $ARGV[0] and $ARGV[0] eq "config")
 {
+	my ($host) = Munin::Plugin::SNMP->config_session();
 	print "host_name $host\n" unless $host eq 'localhost';
 	print "graph_title Memory usage in percent\n";
 	print "graph_args --upper-limit 100 -l 0\n";


### PR DESCRIPTION
This reduce code duplication, and honour configuration variables, such
as SNMP version to use.