### PR TITLE
threads: Use short xargs arguments for busybox compatibility

### DIFF
--- a/plugins/node.d.linux/threads
+++ b/plugins/node.d.linux/threads
@@ -49,7 +49,7 @@ fi
 # read.  It isn't entirely portable, but GNU grep should be a given on Linux.
 # Sadly awk has no such equivalent option or we could skip grep altogether.
 find /proc/ -mindepth 2 -maxdepth 2 -type f -name status -print0 2>/dev/null \
-    | xargs -0 --no-run-if-empty --max-args=1000 grep -sh '^Threads:' \
+    | xargs -0 -r -n 1000 grep -sh '^Threads:' \
     | awk 'BEGIN { sum = 0; }
            { sum += $2; }
            END { print "threads.value", sum; }'


### PR DESCRIPTION
The xargs command included in busybox only knows short args. (I recently installed munin on alpine linux, which is based on busybox)