### PR TITLE
munin-run: allow to pass additional arguments to the plugin

### DIFF
--- a/node/lib/Munin/Node/Service.pm
+++ b/node/lib/Munin/Node/Service.pm
@@ -244,7 +244,7 @@ sub change_real_and_effective_user_and_group
 
 sub exec_service
 {
-    my ($self, $service, $arg) = @_;
+    my ($self, $service, @args) = @_;
 
     # XXX - Create the statedir for the user
     my $uid = $self->_resolve_uid($service);
@@ -261,7 +261,7 @@ sub exec_service
 
     Munin::Node::OS::set_umask();
 
-    my @command = grep defined, _service_command($self->{servicedir}, $service, $arg);
+    my @command = grep defined, _service_command($self->{servicedir}, $service, @args);
     print STDERR "# About to run '", join (' ', @command), "'\n"
         if $config->{DEBUG};
 
@@ -269,12 +269,12 @@ sub exec_service
 }
 
 
-# Returns the command for the service and (optional) argument, expanding '%c'
+# Returns the command for the service and (optional) arguments, expanding '%c'
 # as the original command (see 'command' directive in
 # <http://munin-monitoring.org/wiki/plugin-conf.d>).
 sub _service_command
 {
-    my ($dir, $service, $argument) = @_;
+    my ($dir, $service, @arguments) = @_;
 
     my @run;
     my $sconf = $config->{sconf};
@@ -282,14 +282,14 @@ sub _service_command
     if ($sconf->{$service}{command}) {
         for my $t (@{ $sconf->{$service}{command} }) {
             if ($t eq '%c') {
-                push @run, ("$dir/$service", $argument);
+                push @run, ("$dir/$service", @arguments);
             } else {
                 push @run, ($t);
             }
         }
     }
     else {
-        @run = ("$dir/$service", $argument);
+        @run = ("$dir/$service", @arguments);
     }
 
     return @run;
@@ -400,7 +400,7 @@ On failure, causes the process to exit.
 
 =item B<exec_service>
 
- $service->exec_service($service, [$argument]);
+ $service->exec_service($service, [@arguments]);
 
 Replaces the current process with an instance of service $service in
 $directory, running with the correct environment and privileges.

--- a/node/sbin/munin-run
+++ b/node/sbin/munin-run
@@ -123,7 +123,7 @@ sub main
     $0 = $1;
 
     my @original_argv = @ARGV;
-    my ($plugin, $arg) = parse_args();
+    my ($plugin, @args) = parse_args();
 
     # Loads the settings from munin-node.conf.
     # Ensures that, where options can be set both in the config and in
@@ -135,15 +135,15 @@ sub main
 
     # Run directly or execute recursively via "systemd-run".
     if (($ignore_systemd_properties) || (! -d "/run/systemd/system")) {
-        return execute_plugin($plugin, $arg);
+        return execute_plugin($plugin, @args);
     } elsif (!check_systemd_run_permissions()) {
         print STDERR "# Skipping systemd properties simulation due to lack of permissions.\n" if $config->{DEBUG};
-        return execute_plugin($plugin, $arg);
+        return execute_plugin($plugin, @args);
     } else {
         my $systemd_version = get_systemd_version();
         if ((not defined $systemd_version) or ($systemd_version < $REQUIRED_SYSTEMD_VERSION)) {
             print STDERR "# Skipping systemd properties simulation due to required systemd version ($REQUIRED_SYSTEMD_VERSION)\n" if $config->{DEBUG};
-            return execute_plugin($plugin, $arg);
+            return execute_plugin($plugin, @args);
         } else {
             my @munin_node_hardening_flags;
             my $parse_flags_success = 0;
@@ -158,7 +158,7 @@ sub main
                 # Failed to retrieve systemd properties of munin-node service.
                 # Probable causes: systemd is not installed/enabled or the
                 # service unit does not exist.
-                return execute_plugin($plugin, $arg);
+                return execute_plugin($plugin, @args);
             }
         }
     }
@@ -307,7 +307,7 @@ sub run_via_systemd {
 
 
 sub execute_plugin {
-    my ($plugin, $arg) = @_;
+    my ($plugin, @args) = @_;
 
     $services = Munin::Node::Service->new(
         servicedir => $servicedir,
@@ -330,7 +330,7 @@ sub execute_plugin {
 
     # no need for a timeout -- the user can kill this process any
     # time they want.
-    $services->exec_service($plugin, $arg);
+    $services->exec_service($plugin, @args);
 
     # Never reached, but just in case...
     print STDERR "# FATAL: Failed to exec.\n";
@@ -344,7 +344,7 @@ sub parse_args
     my $sconfdir   = "$Munin::Common::Defaults::MUNIN_CONFDIR/plugin-conf.d";
     my $sconffile;
 
-    my ($plugin, $arg);
+    my ($plugin, $arg, @extra_args);
 
     print_usage_and_exit() unless GetOptions(
             "config=s"     => \$conffile,
@@ -367,6 +367,8 @@ sub parse_args
         ($arg) = ($ARGV[1] =~ m/^(\w+)$/)
             or die "# ERROR: Invalid characters in argument '$ARGV[1]'.\n";
     }
+    # all remaining arguments are handed over to the plugin without further checks
+    @extra_args = map {m/^(.*)$/} @ARGV[2..$#ARGV];
 
     # Detaint service directory.  FIXME: do more strict detainting?
     if ($servicedir) {
@@ -385,7 +387,7 @@ sub parse_args
         paranoia   => $paranoia,
     });
 
-    return ($plugin, $arg);
+    return ($plugin, $arg, @extra_args);
 }
 
 


### PR DESCRIPTION
The plugin "apt_all" offers a special action "update" (to be used in a
cron job) with two mandatory arguments.
But munin-run previously provided no way to send more than one argument
to the plugin.

Now more than one argument is accepted.
The arguments are not verified - the plugin is responsible for checking
their validity.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=720275#47