### PR TITLE
apt_all: remove reference to "update" argument for cron job

### DIFF
--- a/plugins/node.d.linux/apt_all
+++ b/plugins/node.d.linux/apt_all
@@ -34,25 +34,26 @@ your /etc/apt.conf defaults.
 
 =head1 USAGE
 
-This plugin needs a cronjob that runs apt-get update every hour or so
+The plugin depends on a periodic update of apt's package cache.
 
-Example cronjob
+This can be accomplished by using systemd's timer for periodic updates or via
+apt's compatibility helper (/etc/cron.daily/apt-compat).
+
+The relevant apt configuration setting for daily updates is:
+
+ APT::Periodic::Update-Package-Lists "1";
+
+(the numeric value defines the number of days between updates)
+
+
+Alternatively you can also configure a simple cron job for updating the cache
+more frequently:
 
  /etc/cron.d/munin-plugin-apt
- 53  * * * *	root	apt-get update > /dev/null 2>&1
- 23 08 * * * 	root	apt-get update > /dev/null
+ 53  * * * *	root	perl -e 'sleep(3600);' && apt-get update >/dev/null 2>&1
 
-Remember to randomize when these cronjobs are run on your servers
+Remember to randomize the starting hour for this cron job on your servers.
 
-This plugin can also be called with the argument "update", which will
-run apt-get update
-
- update <maxinterval> <probability>
-
- Updates the APT database randomly, guaranteeing there
- won't be more than <maxinterval> seconds between each
- update.  Otherwise, there is a a 1 in <probability>
- chance that an update will occur.
 
 =head1 MAGIC MARKERS
 


### PR DESCRIPTION
Before commit 904a84e392ed2 the plugin allowed to be called with an
"update" argument in order to trigger a package cache update.

The plugin does not support this anymore.
Instead the infrastructure provided by the system ("APT::Periodic")
should be used instead.
This is now clarified in the plugin documentation.