### PR TITLE
postgres_querylength: catch real statements only

### DIFF
--- a/plugins/node.d/postgres_querylength_.in
+++ b/plugins/node.d/postgres_querylength_.in
@@ -65,9 +65,15 @@ my $pg = Munin::Plugin::Pgsql->new(
     info      => 'Most long-running queries and transactions',
     vlabel    => 'Age (seconds)',
     basequery => [
-        "SELECT 'query',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-query_start)),0) FROM pg_stat_activity WHERE state NOT LIKE 'idle%' %%FILTER%%
+        "SELECT 'query',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-query_start)),0) FROM pg_stat_activity WHERE (state NOT LIKE 'idle%' AND xact_start IS NOT NULL) %%FILTER%%
                      UNION ALL
                     SELECT 'transaction',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-xact_start)),0) FROM pg_stat_activity WHERE 1=1 %%FILTER%%",
+        [
+            9.6,
+            "SELECT 'query',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-query_start)),0) FROM pg_stat_activity WHERE state NOT LIKE 'idle%' %%FILTER%%
+                     UNION ALL
+                    SELECT 'transaction',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-xact_start)),0) FROM pg_stat_activity WHERE 1=1 %%FILTER%%",
+        ],
         [
             9.1,
             "SELECT 'query',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-query_start)),0) FROM pg_stat_activity WHERE query NOT LIKE '<IDLE%' %%FILTER%%


### PR DESCRIPTION
As of the last set of PostgreSQL bugfix releases (13.4/12.8/11.13/10.18),
pg_stat_activity shows the latest replication command of a walsender
backend as "query":
  https://www.postgresql.org/docs/13/release-13-4.html
    Make walsenders show their latest replication commands in pg_stat_activity (Tom Lane)
    Previously, a walsender would show its latest SQL command, [...]
In most cases, "replication commands" are only sent at the start of an
replication, which then runs for a very long time (weeks to months are
completely normal here), while still showing the "START_REPLICATION"
command and it's query_start in pg_stat_activity. This is not helpful,
as we are mostly interested in "real" queries.
Luckily enough, any "real" query has an xact_start, but with a replication
command, that field remains NULL - so we can use that to filter out
the replication commands. I am not using the backend_type for that
purpose, as a walsender can also run (some) SQL commands, as the
release notes state, and those might be relevant here.

PostgreSQL 9.6 was not affected by this change, and there have been
changes to pg_stat_statements between 9.6 and 10: I'll let 9.6 have
the old query but set a new one for versions 10 and above. The new
query works with PostgreSQL servers before and after that bugfix,
which saves us from additional complexities.