### PR TITLE
Handle NVME drives in the Linux iostat plugin (2.0 branch)

### DIFF
--- a/plugins/node.d.linux/iostat.in
+++ b/plugins/node.d.linux/iostat.in
@@ -167,9 +167,9 @@ sub fetch_detailed() {
 		my $tmpnam = $2;
 		my $major  = $1;
 		if ($tmpnam =~ /\d+$/ and !$include_numbered) {
-		    # Special case for devices like cXdXpX,
-		    # like the cciss driver
-		    next unless $tmpnam =~ /\/c\d+d\d+$/
+			# Special case for devices like cXdXpX, like the cciss driver,
+			# or nvmeXnXpX for nvme.
+			next unless ($tmpnam =~ /\/c\d+d\d+$/ || $tmpnam =~ /nvme\d+n\d+$/)
 		}
 		next unless grep { $_ } @fields;
 


### PR DESCRIPTION
Fix NVME drives not being detected by iostat plugin, because the device names end in digits. See #1424 and #1427.