### PR TITLE
ntp_: do not mask required variable from Net::IP

### DIFF
--- a/plugins/node.d/ntp_.in
+++ b/plugins/node.d/ntp_.in
@@ -53,15 +53,17 @@ Same as munin.
 use English qw( -no_match_vars );
 use strict;
 use warnings;
+# work around "strict" check for this variable exported by "Net::IP"
+my $ip_identical;
 eval {
+    no warnings "once";
     require Net::DNS;
     Net::DNS->import();
     require Net::IP;
     Net::IP->import();
+    $ip_identical = $Net::IP::IP_IDENTICAL;
 };
 my $has_requirements = $EVAL_ERROR ? 0 : 1;
-# work around "strict" check for this variable exported by "Net::IP"
-my $IP_IDENTICAL unless $has_requirements;
 
 
 if ($ARGV[0] and $ARGV[0] eq "autoconf") {
@@ -172,7 +174,7 @@ if (lc($srcadr) ne lc($name)) {
                         ($srcadr) = new Net::IP($srcadr);
 
                         ADDRS: foreach my $addr (@addresses) {
-                                if (defined($srcadr->overlaps($addr)) and $srcadr->overlaps($addr) == $IP_IDENTICAL) {
+                                if (defined($srcadr->overlaps($addr)) and $srcadr->overlaps($addr) == $ip_identical) {
                                         $matched = 1;
                                         last ASSOCS;
                                 }


### PR DESCRIPTION
Using "my" will declare a new variable at (perl) compile time, effectively
masking $IP_IDENTICAL from Net::IP which is used later. When executed
on the shell, that will look like this:

```
Use of uninitialized value $IP_IDENTICAL in numeric eq (==) at ./ntp_XXX line 175.
delay.value 0.000
offset.value +0.000
jitter.value 0.000
```

Instead we need to make sure to reference $Net::IP::IP_IDENTICAL if
available (if it is not available, it's no problem: plugin net_ will
refuse to autoconfigure and fail hard anyways if configured manually).
The easy way for this would be to use "our", but that is rather inelegant
and sets a bad example (the scoping with "our" is more complex than with
"my").
This patch copies $Net::IP::IP_IDENTICAL to a true local variable if
available - if not, the eval block bombs out anyways. As $IP_IDENTICAL
is used exactly once, that would result in a warning, which is surpressed
in that block only.