### PR TITLE
Use `grep -F` instead of `fgrep`

### DIFF
--- a/Checklist
+++ b/Checklist
@@ -13,12 +13,12 @@ This is a pre-release checklist for the maintainer.
 
    2. Figure out which r the previous tag was at and do this (r910 was
 	  1.3.2 and r1234 is head)
-      svn --verbose log -r910:1234 | fgrep node.d | grep -w A | 
+      svn --verbose log -r910:1234 | grep -F node.d | grep -w A |
          cut -d/ -f 4- | sed 's/^node\.d\.//'
 
    3. Check if the listed plugins are still present (or moved):
 
-      svn --verbose log -r910:1234 | fgrep node.d | grep -w A |
+      svn --verbose log -r910:1234 | grep -F node.d | grep -w A |
           cut -d/ -f 4- | sed s'/(.*//' | xargs ls -ld >/dev/null
 
 

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ unconfig:
 
 tags:
 	-rm -f TAGS
-	find master common -type f | egrep -v '/(build/|_build/|blib/|\.svn/)' | grep -v '\.t$$' | fgrep -v '~' | xargs etags -l perl -a
+	find master common -type f | grep -Ev '/(build/|_build/|blib/|\.svn/)' | grep -v '\.t$$' | grep -Fv '~' | xargs etags -l perl -a
 
 ######################################################################
 

--- a/UPGRADING-1.4
+++ b/UPGRADING-1.4
@@ -95,10 +95,10 @@ how to set these levels.
 
 Too audit the differences in warning and critical levels you can make
 a copy of the munin file called "datafile" before upgrading (or get
-one from backup), and use egrep to get a listing of the settings prior
+one from backup), and use grep -E to get a listing of the settings prior
 to update:
 
-  egrep '(warning|critical)' datafile.old
+  grep -E '(warning|critical)' datafile.old
 
 and again on the post-upgrade datafile to compare the lists so you can
 specify the ones you need.

--- a/plugins/node.d.linux/proc.in
+++ b/plugins/node.d.linux/proc.in
@@ -327,7 +327,7 @@ sub populate_stats
         my $procuid = getpwnam($procuser[$i]); # may return undef
 
     STATLINE:
-        foreach my $line(`fgrep -h '($procname[$i])' /proc/[0-9]*/stat`) {
+        foreach my $line(`grep -Fh '($procname[$i])' /proc/[0-9]*/stat`) {
             my ($pid) = $line =~ /^(\d+)/;
 
             my $cmduid = (lstat("/proc/$pid"))[4];

--- a/plugins/node.d/multips.in
+++ b/plugins/node.d/multips.in
@@ -28,7 +28,7 @@ used to grep with directly.
 
 This plugin simply counts the total number of processes matching the
 configured regular expressions.  The regular expressions are
-interpreted by "grep" (and not egrep or perl).
+interpreted by "grep" (and not grep -E or perl).
 
 =head1 MAGIC MARKERS
 


### PR DESCRIPTION
`fgrep` has been deprecated in GNU grep since 2007, and in current post
3.7 Git it has been made to emit obsolescence warnings:
https://git.savannah.gnu.org/cgit/grep.git/commit/?id=a9515624709865d480e3142fd959bccd1c9372d1