### PR TITLE
Exclude msdosfs as there is no inode on that filesystem

### DIFF
--- a/plugins/node.d.freebsd/df_inode.in
+++ b/plugins/node.d.freebsd/df_inode.in
@@ -13,7 +13,7 @@
 #%# family=auto
 #%# capabilities=autoconf
 
-EXCLUDEDFS="-t noprocfs,devfs,fdescfs,linprocfs,linsysfs,sysfs,nfs,nullfs,cd9660"
+EXCLUDEDFS="-t noprocfs,devfs,fdescfs,linprocfs,linsysfs,sysfs,nfs,nullfs,cd9660,msdosfs"
 
 if [ $(uname -s) = "GNU/kFreeBSD" ]; then
 	# Debian ships df from GNU coreutils


### PR DESCRIPTION
It makes no sense to try to report the inode usage for a msdosfs filesystem, so I've just added this type to the list of excluded ones.