### PR TITLE
plugins/postgres_querylength_: do not treat replication as "long query"

### DIFF
--- a/plugins/node.d/postgres_querylength_.in
+++ b/plugins/node.d/postgres_querylength_.in
@@ -65,7 +65,7 @@ my $pg = Munin::Plugin::Pgsql->new(
     info      => 'Most long-running queries and transactions',
     vlabel    => 'Age (seconds)',
     basequery => [
-        "SELECT 'query',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-query_start)),0) FROM pg_stat_activity WHERE (state NOT LIKE 'idle%' AND xact_start IS NOT NULL) %%FILTER%%
+        "SELECT 'query',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-query_start)),0) FROM pg_stat_activity WHERE (backend_type = 'client backend' AND state NOT LIKE 'idle%' AND xact_start IS NOT NULL) %%FILTER%%
                      UNION ALL
                     SELECT 'transaction',COALESCE(max(extract(epoch FROM CURRENT_TIMESTAMP-xact_start)),0) FROM pg_stat_activity WHERE 1=1 %%FILTER%%",
         [


### PR DESCRIPTION
PostgreSQL 14 shows replication's slots in pg_stat_activity - like
`START_REPLICATION SLOT "readonly02" 6DA6/E9000000 TIMELINE 1`.
The state is active.
The column `backend_type = walsender` can be used for filtering
replication activity.

Thanks, Pavel Stehule!

Closes: #1465