### PR TITLE
Possible fix for #1474

### DIFF
--- a/dev_scripts/disable_taint
+++ b/dev_scripts/disable_taint
@@ -8,3 +8,6 @@ FINDBIN=$(cd -- "$(dirname "$0")" && pwd)
 
 find "${SANDBOX}/bin" -type f -perm -a-rx -print0 \
 	| xargs -0 -n 1 -t perl -pi -e "s,bin/perl -T,bin/perl,"
+
+echo "perl -pi -e 's,bin/perl -T,bin/perl,' ${FINDBIN}/run"
+perl -pi -e 's,bin/perl -T,bin/perl,' ${FINDBIN}/run


### PR DESCRIPTION
That's what allowed me running plugin in sandbox.

Since taint is disabled inside sandbox, I assume it's okay disabling it in the calling script as well.
