### PR TITLE
Fixed error when query_cache_size doesn't exist

### DIFF
--- a/plugins/node.d/mysql_
+++ b/plugins/node.d/mysql_
@@ -1946,7 +1946,7 @@ sub update_variables {
     }
 
     $data->{'mysql_base_memory'} = $data->{'key_buffer_size'}
-                                         + $data->{'query_cache_size'}
+                                         + ( $data->{'query_cache_size'} || 0 )
                                          + $data->{'innodb_buffer_pool_size'}
                                          + ( $data->{'innodb_additional_mem_pool_size'} || 0 )
                                          + $data->{'innodb_log_buffer_size'}


### PR DESCRIPTION
Fixed "Use of uninitialized value in addition (+) at
/etc/munin/plugins/mysql_ line 1953."

MySQL 8 has removed the query_cache_size variable so this sets it to 0
if not present.