### PR TITLE
fix html_strategy to point to munin-cgi-html

### DIFF
--- a/doc/reference/munin.conf.rst
+++ b/doc/reference/munin.conf.rst
@@ -99,7 +99,7 @@ otherwise.
 
    If set to "cgi", :ref:`munin-html` will do nothing. To generate
    html pages you must configure a web server to run
-   :ref:`munin-cgi-graph` instead.
+   :ref:`munin-cgi-html` instead.
 
 .. option:: ssh_command <command>
 


### PR DESCRIPTION
html_strategy cgi needs munin-cgi-html not munin-cgi-graph

info @wt-io-it