### PR TITLE
lib/pgsql: fix labels containing #, /, \r or \n

### DIFF
--- a/lib/Munin/Plugin.pm
+++ b/lib/Munin/Plugin.pm
@@ -178,6 +178,28 @@ sub clean_fieldname ($) {
     return $name;
 }
 
+=head3 $label = clean_label($input_label)
+
+Munin plugin field labels are restricted with regards to what
+characters they may use: They cannot contain a
+# (would start a comment),
+\ (no escaping allowed/supported)
+or \r nor \n (as those would start a new line).
+To satisfy these demands the function replaces illegal characters with a ' ' (space).
+
+See also
+L<http://guide.munin-monitoring.org/en/latest/reference/plugin.html>
+
+=cut
+
+sub clean_label ($) {
+    my $label = shift;
+
+    # Replace all illegal characters with space
+    $label =~ s/[#\\\r\n]/ /g;
+
+    return $label;
+}
 
 =head3 set_state_name($statefile_name)
 

--- a/lib/Munin/Plugin/Pgsql.pm
+++ b/lib/Munin/Plugin/Pgsql.pm
@@ -316,7 +316,8 @@ sub Config {
     for (0 .. scalar(@$r) - 1) {
         my $row = @$r[$_];
         my $l = Munin::Plugin::clean_fieldname($row->[0]);
-        print "$l.label $row->[1]\n";
+        my $label = Munin::Plugin::clean_label($row->[1]);
+        print "$l.label $label\n";
         print "$l.info $row->[2]\n" if (defined $row->[2]);
         print "$l.type $self->{graphtype}\n";
         if ($self->{stack} && !$firstrow) {


### PR DESCRIPTION
in postgres_size_ it is possible for the datname to contain all
characters supported by postgres. however as per documentation
http://guide.munin-monitoring.org/en/latest/reference/plugin.html
the {fieldname}.label cannot contain # or /. if the label would contain
\r or \n the output of the plugins label would be cut of and or give a
missing label warning and or give lines had errors warning.

Had this issue on one of our servers and currently running the fix there.

Info @wt-io-it