### PR TITLE
Provide ssh:// examples

### DIFF
--- a/doc/example/transport/ssh.rst
+++ b/doc/example/transport/ssh.rst
@@ -4,8 +4,30 @@
 Examples for ssh transport
 ==========================
 
+Using the ssh transport for munin is a very powerful way to reach hard to reach nodes in a secure and well understood way.
+
 .. index::
    triple: ssh transport; munin.conf; example
+   
+Using SSH transport
+===================
+
+For a host that you can only reach via ssh (becasue firewall, or because you don't want to expose munin-node on the network, only to localhost) Munin can use SSH directly like this:
+
+  [mail.site2.example.org]
+     address ssh://mail.site2.example.org/bin/nc localhost 4949
+     
+This makes munin use the ssh terminal connection as a network socket.  The "address" line bunces the ssh terminal connection via the netcat ('nc') program to the munin-node port on the remote host.
+
+If you can reach the node via some bastion or bounce host a similar command can be used:
+
+  [mail.site2.example.org]
+     address ssh://bastion.site2.example.org/bin/nc mail.site2.example.org 4949
+     
+This will make munin first ssh into bastion.site2.example.org, then use netcat to reach the munin-node port (4949) on mail.site2.example.org.
+
+You will need to configure ssh to allow these connections.
+
 
 SSH options
 ===========
@@ -66,3 +88,5 @@ This will keep a long-lived SSH connection open to
 `proxy.customer.example.com`, it will be re-used for all
 connections. The SSH options `TCPKeepAlive` and `ServerAliveInterval`
 are added to detect and restart a dropped connection on demand.
+
+


### PR DESCRIPTION
This section needed examples on how to actually configure the use of ssh transport.  The link to the munin web site did not work.