### PR TITLE
cpuspeed: fix average clock frequency calculation

### DIFF
--- a/plugins/node.d.linux/cpuspeed
+++ b/plugins/node.d.linux/cpuspeed
@@ -147,7 +147,7 @@ fi
 for c in /sys/devices/system/cpu/cpu[0-9]*; do
     N=${c##*/cpu}
     if [ -r "$ACPI_CPUFREQ_INDICATOR_FILENAME" ]; then
-        value=$(awk '{ cycles += $1 * $2 } END { printf("%.0f", cycles / 100); }' "$c/cpufreq/stats/time_in_state")
+        value=$(awk '{ total += $1 * $2; time += $2 } END { printf "%.0f", total / time }' "$c/cpufreq/stats/time_in_state")
     elif [ -r "$INTEL_PSTATE_INDICATOR_FILENAME" ]; then
         value=$(cat "$c/cpufreq/scaling_cur_freq")
     else


### PR DESCRIPTION
The previous code had the formula for the weighted mathematical average
wrong. It added up all `frequency*time` values, then divided by 100. For long
uptimes, this yielded obviously bogus frequency values. The correct formula
is to add up all `frequency*time` values, then divide by the sum of all time
values.

TODO: instead of reporting (only) a running average since the last boot,
save the stats on each run and compute the average for the period since the
last run.