### PR TITLE
Fix meminfo plugin output for slab_reclaim

### DIFF
--- a/plugins/node.d.linux/meminfo
+++ b/plugins/node.d.linux/meminfo
@@ -352,7 +352,7 @@ my $graphs_source =
     'fields' => [qw(active_slabs:AREASTACK:- inactive_slabs:AREASTACK:FFFFCCCC shared_slabs:LINE1:- total_slabs:LINE1:000000)]
   },
   # ----------------------------------------------
-  'slab.reclaim' =>
+  'slab_reclaim' =>
   {
     'munin' =>
     {


### PR DESCRIPTION
I'm not actually sure that this is a bug or that this is the correct fix.  When running this plugin on a raspberry pi, the plugin generates an invalid field name, causing an erroneous graph to be created:

![screenshot of Munin interface showing invalid slab "node" with reclaim plugin](https://user-images.githubusercontent.com/1888809/200107511-37e0c459-d4d4-401e-a07b-d6311ef5aa86.png)

Because this is not generating a rrd file in the expected location, munin-graph.log is littered with this:

<details><summary>show munin-graph log</summary>
```plain
2022/11/04 00:02:32 [RRD ERROR] Unable to graph /var/cache/munin/www/hostname/hostname/slab/reclaim-week.png : opening '/var/lib/munin/hostname/hostname/slab-reclaim-slab_unreclaimable-g.rrd': No such file or directory
2022/11/04 00:02:32 [RRD ERROR] rrdtool 'graph' '/var/cache/munin/www/hostname/hostname/slab/reclaim-week.png' \
        '--title' \
        'Reclaim - by week' \
        '--start' \
        '-12000m' \
        '--base' \
        '1024' \
        '--vertical-label' \
        'bytes' \
        '--slope-mode' \
        '--height' \
        '334' \
        '--width' \
        '511' \
        '--imgformat' \
        'PNG' \
        '--lazy' \
        '--font' \
        'DEFAULT:0:DejaVuSans,DejaVu Sans,DejaVu LGC Sans,Bitstream Vera Sans' \
        '--font' \
        'LEGEND:7:DejaVuSansMono,DejaVu Sans Mono,DejaVu LGC Sans Mono,Bitstream Vera Sans Mono,monospace' \
        '--color' \
        'BACK#F0F0F0' \
        '--color' \
        'FRAME#F0F0F0' \
        '--color' \
        'CANVAS#FFFFFF' \
        '--color' \
        'FONT#666666' \
        '--color' \
        'AXIS#CFD6F8' \
        '--color' \
        'ARROW#CFD6F8' \
        '--border' \
        '0' \
        '-W' \
        'Munin 2.0.56' \
        'DEF:a165c718cebb0b56=/var/lib/munin/hostname/hostname/slab-reclaim-slab_unreclaimable-g.rrd:42:MAX' \
        'DEF:i165c718cebb0b56=/var/lib/munin/hostname/hostname/slab-reclaim-slab_unreclaimable-g.rrd:42:MIN' \
        'DEF:g165c718cebb0b56=/var/lib/munin/hostname/hostname/slab-reclaim-slab_unreclaimable-g.rrd:42:AVERAGE' \
        'DEF:a399db9eeec37595=/var/lib/munin/hostname/hostname/slab-reclaim-slab_reclaimable-g.rrd:42:MAX' \
        'DEF:i399db9eeec37595=/var/lib/munin/hostname/hostname/slab-reclaim-slab_reclaimable-g.rrd:42:MIN' \
        'DEF:g399db9eeec37595=/var/lib/munin/hostname/hostname/slab-reclaim-slab_reclaimable-g.rrd:42:AVERAGE' \
        'CDEF:c399db9eeec37595=g399db9eeec37595,POP,UNKN' \
        'COMMENT:                  ' \
        'COMMENT: Cur\:' \
        'COMMENT:Min\:' \
        'COMMENT:Avg\:' \
        'COMMENT:Max\:  \j' \
        'AREA:g399db9eeec37595#00CC00:Slab reclaimable   ' \
        'GPRINT:c399db9eeec37595:LAST:%7.2lf%s' \
        'GPRINT:i399db9eeec37595:MIN:%7.2lf%s' \
        'GPRINT:g399db9eeec37595:AVERAGE:%7.2lf%s' \
        'GPRINT:a399db9eeec37595:MAX:%7.2lf%s\j' \
        'CDEF:c165c718cebb0b56=g165c718cebb0b56,POP,UNKN' \
        'STACK:g165c718cebb0b56#0066B3:Slab unreclaimable ' \
        'GPRINT:c165c718cebb0b56:LAST:%7.2lf%s' \
        'GPRINT:i165c718cebb0b56:MIN:%7.2lf%s' \
        'GPRINT:g165c718cebb0b56:AVERAGE:%7.2lf%s' \
        'GPRINT:a165c718cebb0b56:MAX:%7.2lf%s\j' \
        'CDEF:ipostotal=i399db9eeec37595,i165c718cebb0b56,ADDNAN' \
        'CDEF:gpostotal=g399db9eeec37595,g165c718cebb0b56,ADDNAN' \
        'CDEF:apostotal=a399db9eeec37595,a165c718cebb0b56,ADDNAN' \
        'LINE1:gpostotal#000000:Total              ' \
        'GPRINT:gpostotal:LAST:%7.2lf%s' \
        'GPRINT:ipostotal:MIN:%7.2lf%s' \
        'GPRINT:gpostotal:AVERAGE:%7.2lf%s' \
        'GPRINT:apostotal:MAX:%7.2lf%s\j' \
        'VRULE:0#999999' \
        'COMMENT:Last update\: Wed Dec 31 16\:00\:00 1969\r' \
        '--end' \
        '1667544000'
2022/11/04 00:02:32 [WARNING] Could not draw graph "/var/cache/munin/www/hostname/hostname/slab/reclaim-week.png": /var/cache/munin/www/hostname/hostname/slab/reclaim-week.png
```
</details>


[Per the docs](https://guide.munin-monitoring.org/en/latest/reference/plugin.html?#notes-on-field-names) field names cannot contain periods.  So I made this change to the copy of the plugin on this node, and on the next update on the master I saw this:
```plain
munin-update.log:2022/11/04 23:50:11 [INFO] creating rrd-file for slab_reclaim->slab_unreclaimable: '/var/lib/munin/hostname/hostname-slab_reclaim-slab_unreclaimable-g.rrd'
munin-update.log:2022/11/04 23:50:11 [INFO] creating rrd-file for slab_reclaim->slab_reclaimable: '/var/lib/munin/hostname/hostname-slab_reclaim-slab_reclaimable-g.rrd'
```
...and the graphs started working.  In addition, the slab "node" disappeared and the slab reclaim graphs appeared in the memory section for this host.  Previously, data was collected and stored in `hostname-slab-reclaim-slab_reclaimable-g.rrd` (note `-` instead of `_` between slab and reclaim) which is why munin-graph was unable to produce graphs.

There are 15 other labels in this plugin that contain a `.`.  But none of them are relevant on my system.  Hence why I'm not sure if this is a bug or an environmental issue.