### PR TITLE
doc: Use square bracket notation for IPv6 address.

### DIFF
--- a/doc/installation/configuration.rst
+++ b/doc/installation/configuration.rst
@@ -77,4 +77,4 @@ Add some nodes to CONFDIR/munin.conf
   address node2.example.com
 
 [node3.example.com]
-  address 2001:db8::de:caf:bad
+  address [2001:db8::de:caf:bad]


### PR DESCRIPTION
Related to: https://github.com/munin-monitoring/munin/issues/1508

This is to disambiguate IPv6 ending with only digits currently being interpreted as being a port.

In my case:

    address 2001:4b98:dc0:43:f816:3eff:fed8:3222

gets wrongly parsed, looks like munin though 3222 was a port maybe.