### PR TITLE
Doc: Linting with sphinx-lint.

### DIFF
--- a/doc/architecture/index.rst
+++ b/doc/architecture/index.rst
@@ -26,7 +26,7 @@ The master is responsible for all central Munin-related tasks.
 
 
 It regularly connects to the various nodes, and then :ref:`synchronously <protocol-index>`
-asks for the various metrics configuration and values and stores the data in `RRD <https://oss.oetiker.ch/rrdtool/>` files.
+asks for the various metrics configuration and values and stores the data in `RRD <https://oss.oetiker.ch/rrdtool/>`_ files.
 
 On the fly the values are checked against limits (that you may set)
 and the Munin-Master will croak, if values go above or below the given thresholds.

--- a/doc/example/transport/ssh.rst
+++ b/doc/example/transport/ssh.rst
@@ -8,7 +8,7 @@ Using the ssh transport for munin is a very powerful way to reach hard to reach 
 
 .. index::
    triple: ssh transport; munin.conf; example
-   
+
 Using SSH transport
 ===================
 
@@ -16,14 +16,14 @@ For a host that you can only reach via ssh (because firewall, or because you don
 
   [mail.site2.example.org]
      address ssh://mail.site2.example.org -W localhost:4949
-     
+
 This makes munin use the ssh terminal connection as a network socket.  The "address" line bunces the ssh terminal connection to the munin-node port on the remote host.
 
 If you can reach the node via some bastion or bounce host a similar command can be used:
 
   [mail.site2.example.org]
      address ssh://bastion.site2.example.org -W mail.site2.example.org:4949
-     
+
 This will make munin first ssh into bastion.site2.example.org, and then from there connect the munin-node port (4949) on mail.site2.example.org.
 
 You will need to configure ssh to allow these connections.
@@ -88,5 +88,3 @@ This will keep a long-lived SSH connection open to
 `proxy.customer.example.com`, it will be re-used for all
 connections. The SSH options `TCPKeepAlive` and `ServerAliveInterval`
 are added to detect and restart a dropped connection on demand.
-
-


### PR DESCRIPTION
Found an issue with [sphinx-lint](https://pypi.org/p/sphinx-lint/).

The only error found was a broken link:

![Screenshot 2023-02-13 at 10-14-39 Munin’s Architecture — Munin 2 999 10-detached-2018-12-16-c13-g47debb5 documentation](https://user-images.githubusercontent.com/239510/218417799-e1652253-ea5b-411d-823d-e97e80b5a2e1.png)

Ran sphinx-lint as:

    sphinx-lint --disable horizontal-tab

sphinx-lint repoted it as:

    doc/architecture/index.rst:29: missing underscore after closing backtick in hyperlink (missing-underscore-after-hyperlink)

I don't know if you want to add sphinx-lint in your `make test` or somewhere else (it's a Python dependency).