### PR TITLE
Switch to rewrite-repeat-if-not-file

### DIFF
--- a/doc/example/webserver/lighttpd.rst
+++ b/doc/example/webserver/lighttpd.rst
@@ -51,6 +51,5 @@ Webserver configuration
 
   url.rewrite-repeat-if-not-file += (
                      "/munin/(.*)" => "/munin-cgi/munin-cgi-html/$1",
-                     "/munin-cgi/munin-cgi-html$" => "/munin-cgi/munin-cgi-html/",
-                     #"/munin-cgi/munin-cgi-html/static/(.*)" => "/munin-static/$1"
+                     "/munin-cgi/munin-cgi-html$" => "/munin-cgi/munin-cgi-html/"
                      )

--- a/doc/example/webserver/lighttpd.rst
+++ b/doc/example/webserver/lighttpd.rst
@@ -49,8 +49,8 @@ Webserver configuration
                      ))
                    )
 
-  url.rewrite-repeat += (
+  url.rewrite-repeat-if-not-file += (
                      "/munin/(.*)" => "/munin-cgi/munin-cgi-html/$1",
                      "/munin-cgi/munin-cgi-html$" => "/munin-cgi/munin-cgi-html/",
-                     "/munin-cgi/munin-cgi-html/static/(.*)" => "/munin-static/$1"
+                     #"/munin-cgi/munin-cgi-html/static/(.*)" => "/munin-static/$1"
                      )

--- a/doc/example/webserver/lighttpd.rst
+++ b/doc/example/webserver/lighttpd.rst
@@ -51,5 +51,5 @@ Webserver configuration
 
   url.rewrite-repeat-if-not-file += (
                      "/munin/(.*)" => "/munin-cgi/munin-cgi-html/$1",
-                     "/munin-cgi/munin-cgi-html$" => "/munin-cgi/munin-cgi-html/"
+                     "/munin-cgi/munin-cgi-html$" => "/munin-cgi/munin-cgi-html/",
                      )


### PR DESCRIPTION
Leverage new functionality of mod_rewrite to ensure static content is delivered more reliably. Works on Munin 2.0.57 and lighttpd 1.4.63 under Ubunutu 22.04 x86_64. See also https://redmine.lighttpd.net/projects/lighttpd/wiki/Mod_rewrite#urlrewrite-repeat-if-not-file