### PR TITLE
cpuspeed: fix to show correct values in systems with Ryzen CPUs

### DIFF
--- a/plugins/node.d.linux/cpuspeed
+++ b/plugins/node.d.linux/cpuspeed
@@ -54,6 +54,7 @@ Nah.
 =head1 AUTHOR
 
 Nicolai Langfeldt
+Jiyong Youn
 
 =head1 LICENSE
 
@@ -71,10 +72,18 @@ GPLv2
 scaleto100=${scaleto100:-no}
 ACPI_CPUFREQ_INDICATOR_FILENAME=/sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state
 INTEL_PSTATE_INDICATOR_FILENAME=/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq
+if cat /proc/cpuinfo | grep -e ^model\ name | sort -u | grep -q Ryzen; then
+    IS_RYZEN=1
+else
+    IS_RYZEN=0
+fi
 
 
 if [ "$1" = "autoconf" ]; then
-    if [ -r "$ACPI_CPUFREQ_INDICATOR_FILENAME" ]; then
+    if [ IS_RYZEN ] && [ -r "$INTEL_PSTATE_INDICATOR_FILENAME" ]; then
+        # Ryzen CPUs does not show proper boost clock in acpi-cpufreq, therefore use pstate
+        echo yes
+    elif [ -r "$ACPI_CPUFREQ_INDICATOR_FILENAME" ]; then
         # "acpi-cpufreq" is available
         echo yes
     elif [ -r "$INTEL_PSTATE_INDICATOR_FILENAME" ]; then
@@ -99,7 +108,11 @@ if [ "$1" = "config" ]; then
         echo "graph_vlabel Hz"
     fi
     # the visualized data depends on the available data source
-    if [ -r "$ACPI_CPUFREQ_INDICATOR_FILENAME" ]; then
+    if [ IS_RYZEN ] && [ -r "$INTEL_PSTATE_INDICATOR_FILENAME" ]; then
+        # use intel_pstate in Ryzen
+        graph_info="This graph shows the current speed of the CPU at the time of the data retrieval (not its average). This is a limitation of the 'intel_pstate' driver."
+        field_type="GAUGE"
+    elif [ -r "$ACPI_CPUFREQ_INDICATOR_FILENAME" ]; then
         graph_info="This graph shows the average running speed of each CPU."
         field_type="DERIVE"
     elif [ -r "$INTEL_PSTATE_INDICATOR_FILENAME" ]; then
@@ -132,7 +145,11 @@ if [ "$1" = "config" ]; then
             fi
         fi
 
-        if [ -r "$c/cpufreq/cpuinfo_min_freq" ]; then
+        if [ IS_RYZEN ]; then
+            # cpuinfo_min_freq does not correctly reflect the actual minimum clock of Ryzen CPU.
+            # Therefore, return 0
+            echo "cpu$N.min 0"
+        elif [ -r "$c/cpufreq/cpuinfo_min_freq" ]; then
             MINHZ=$(cat "$c/cpufreq/cpuinfo_min_freq")
             echo "cpu$N.min $MINHZ"
         fi
@@ -146,7 +163,9 @@ fi
 
 for c in /sys/devices/system/cpu/cpu[0-9]*; do
     N=${c##*/cpu}
-    if [ -r "$ACPI_CPUFREQ_INDICATOR_FILENAME" ]; then
+    if [ IS_RYZEN ] && [ -r "$INTEL_PSTATE_INDICATOR_FILENAME" ]; then
+        value=$(cat "$c/cpufreq/scaling_cur_freq")
+    elif [ -r "$ACPI_CPUFREQ_INDICATOR_FILENAME" ]; then
         value=$(awk '{ cycles += $1 * $2 } END { printf("%.0f", cycles / 100); }' "$c/cpufreq/stats/time_in_state")
     elif [ -r "$INTEL_PSTATE_INDICATOR_FILENAME" ]; then
         value=$(cat "$c/cpufreq/scaling_cur_freq")


### PR DESCRIPTION
Currently, ```cpuspeed``` uses ```acpi-cpufreq``` if supported, or intel pstate to read current CPU clock. However, in AMD Ryzen CPUs, scaling governor only switches base clock, and only the base clocks are the one being displayed in cpufreq/stats, in Linux kernel 5.15 and 6.2.11. (which is the latest stable version) Therefore, to get correct current CPU clock in AMD Ryzen CPUs, we should read ```scaling_cur_freq``` value instead, which correctly reflect the realtime clock with C-State boost employed.

To fix the issue, I updated the script to use ```intel_pstate``` in prior to```acpi-cpufreq``` in Ryzen based systems. The code is tested for Ryzen 5000 series desktop processors(codenamed Vermeer), Ryzen 7000 series desktop processors(codenamed Raphael), Ryzen Threadripper 2000 series(codenamed Corfax), Ryzen Threadripper 5000 series(codenamed Chagall), and Ryzen Embedded V1000 series.