### PR TITLE
Use big 64 bit numbers

### DIFF
--- a/plugins/node.d/mysql_
+++ b/plugins/node.d/mysql_
@@ -2133,7 +2133,7 @@ sub innodb_bigint {
 
     return defined $y
 	? Math::BigInt->new($x)->blsft(32) + $y
-	: Math::BigInt->new("0x$x");
+	: Math::BigInt->new($x);
 }
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
In modern SHOW ENGINE INNODB STATUS results MariDB is using long 64 bit numbers. Not  hex.