### PR TITLE
Add update order to nodes

### DIFF
--- a/doc/reference/munin.conf.rst
+++ b/doc/reference/munin.conf.rst
@@ -375,6 +375,13 @@ only to that node.
    If you make a virtual node which borrow data from real nodes for aggregate graphs, set this to
    "no" for that node.
 
+.. option:: update_order <number>
+
+   Manually define the order that nodes will be handled.  Lower numbers are run first.
+
+   For highest overall throughput, slow running nodes should be run first.  Numbers do not have
+   to be unique, and unspecified nodes are placed at the end of the list.
+
 .. _master-conf-plugin-directives:
 
 PLUGIN DIRECTIVES

--- a/doc/reference/munin.conf.rst
+++ b/doc/reference/munin.conf.rst
@@ -375,9 +375,9 @@ only to that node.
    If you make a virtual node which borrow data from real nodes for aggregate graphs, set this to
    "no" for that node.
 
-.. option:: update_order <number>
+.. option:: update_priority <number>
 
-   Manually define the order that nodes will be handled.  Lower numbers are run first.
+   Manually define the priority that nodes will be handled.  Lower numbers are run first.
 
    For highest overall throughput, slow running nodes should be run first.  Numbers do not have
    to be unique, and unspecified nodes are placed at the end of the list.

--- a/lib/Munin/Common/Config.pm
+++ b/lib/Munin/Common/Config.pm
@@ -138,6 +138,7 @@ my %legal = map { $_ => 1 } qw(
 	unknown
 	unknown_limit
 	update
+	update_order
 	update_rate
 	use_default_name
 	use_node_name

--- a/lib/Munin/Common/Config.pm
+++ b/lib/Munin/Common/Config.pm
@@ -138,7 +138,7 @@ my %legal = map { $_ => 1 } qw(
 	unknown
 	unknown_limit
 	update
-	update_order
+	update_priority
 	update_rate
 	use_default_name
 	use_node_name

--- a/lib/Munin/Master/Host.pm
+++ b/lib/Munin/Master/Host.pm
@@ -20,6 +20,7 @@ sub new {
         port          => 4949,
         update        => 1,
         use_node_name => 0,
+        update_order  => 'Infinity',
 
         %$attributes,
     };

--- a/lib/Munin/Master/Host.pm
+++ b/lib/Munin/Master/Host.pm
@@ -17,10 +17,10 @@ sub new {
         host_name => $host_name,
         group     => $group,
 
-        port          => 4949,
-        update        => 1,
-        use_node_name => 0,
-        update_order  => 'Infinity',
+        port            => 4949,
+        update          => 1,
+        use_node_name   => 0,
+        update_priority => 'Infinity',
 
         %$attributes,
     };

--- a/lib/Munin/Master/Update.pm
+++ b/lib/Munin/Master/Update.pm
@@ -109,11 +109,11 @@ sub _create_workers {
 
     my @hosts = $self->{group_repository}->get_all_hosts();
 
-    # Shuffle @hosts to avoid always having the same ordering
-    # XXX - It might be best to preorder them on the TIMETAKEN ASC
-    #       in order that statistically fast hosts are done first to increase
-    #       the global throughtput
+    # Use user-defined ordering, slow hosts should run first for
+    # better global throughput, keep shuffle() to shuffle hosts within
+    # same update_order
     @hosts = shuffle(@hosts);
+    @hosts = sort { $a->{update_order} <=> $b->{update_order} } @hosts;
 
     if (defined $config->{limit_hosts} && %{$config->{limit_hosts}}) {
         @hosts = grep { $config->{limit_hosts}{$_->{host_name}} } @hosts

--- a/lib/Munin/Master/Update.pm
+++ b/lib/Munin/Master/Update.pm
@@ -113,7 +113,7 @@ sub _create_workers {
     # better global throughput, keep shuffle() to shuffle hosts within
     # same update_order
     @hosts = shuffle(@hosts);
-    @hosts = sort { $a->{update_order} <=> $b->{update_order} } @hosts;
+    @hosts = sort { $a->{update_priority} <=> $b->{update_priority} } @hosts;
 
     if (defined $config->{limit_hosts} && %{$config->{limit_hosts}}) {
         @hosts = grep { $config->{limit_hosts}{$_->{host_name}} } @hosts

--- a/plugins/node.d/munin_update
+++ b/plugins/node.d/munin_update
@@ -101,6 +101,7 @@ if [ "$1" = "config" ]; then
 	echo 'graph_vlabel seconds'
 	echo 'graph_category munin'
 	echo 'graph_info This graph shows the time it takes to collect data from each hosts that munin collects data on. Munin-master is run from cron every 5 minutes and we want each of the munin-update runs to complete before the next one starts.  If munin-update uses too long time to run on one host run it with --debug to determine which plugin(s) are slow and solve the problem with them if possible.'
+	echo 'UT.label Total'
 	sed '/^UD|/!d; s/.*;//; s/|/ /;' < "$UPDATE_STATSFILE" | sort |
 	while read -r i j; do
             name="$(clean_fieldname "$i")"
@@ -116,7 +117,7 @@ fi
     exit 0
 }
 
-sed '/^UD|/!d; s/.*;//; s/|/ /;' < "$UPDATE_STATSFILE" | sort |
+sed '/^U[DT]|/!d; s/.*;//; s/|/ /;' < "$UPDATE_STATSFILE" | sort |
 while read -r i j; do
         name="$(clean_fieldname "$i")"
 	echo "$name.value $j"


### PR DESCRIPTION
Add an update_order option to nodes to allow users to specify the order for accessing nodes. 

Nodes should be visited with the longest running nodes first, to minimize the overall munin_update runtime.  I've also included a change to the munin_update plugin to add total runtime so this can be verified.   This is an optional setting, and will have no effect if not used by users.