### PR TITLE
fix rrd options for lower/upper limit

### DIFF
--- a/lib/Munin/Master/Graph.pm
+++ b/lib/Munin/Master/Graph.pm
@@ -670,8 +670,8 @@ sub handle_request
 	{
 		my $lower_limit  = $cgi->url_param("lower_limit");
 		my $upper_limit  = $cgi->url_param("upper_limit");
-		push @rrd_header, "--lower" , $lower_limit if defined $lower_limit;
-		push @rrd_header, "--upper" , $upper_limit if defined $upper_limit;
+		push @rrd_header, "--lower-limit" , $lower_limit if defined $lower_limit;
+		push @rrd_header, "--upper-limit" , $upper_limit if defined $upper_limit;
 
 		# Adding --rigid, otherwise the limits are not taken into account.
 		push @rrd_header, "--rigid" if defined $lower_limit || defined $upper_limit;


### PR DESCRIPTION
Use --lower-limit and --upper-limit args to rrd for lower/upper limits.  Also confirmed that config defined limits in graph_args are overridden by CGI param limits, although both are passed to rrd.

