### PR TITLE
Support running docker tasks via podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,19 +209,23 @@ tar-upload: tar tar-signed
 	} | sftp -b - "$(UPLOAD_HOST)"
 
 .PHONY: docker
+
+# Run with `DOCKER=podman` to build with podman instead of docker.
+DOCKER ?= docker
+
 docker-base:
-	docker build -t munin:base -f Dockerfile.base .
+	$(DOCKER) build -t munin:base -f Dockerfile.base .
 docker: docker-base
 	./getversion > RELEASE.docker
-	docker build -t munin:latest .
-	docker rm -f munin || true
+	$(DOCKER) build -t munin:latest .
+	$(DOCKER) rm -f munin || true
 	# Add the following to enable strace in the container
 	# --security-opt seccomp:unconfined
-	docker run --name munin --shm-size=256M -p 4948:4948 -itd munin:latest dev_scripts/noop
+	$(DOCKER) run --name munin --shm-size=256M -p 4948:4948 -itd munin:latest dev_scripts/noop
 
 docker-connect:
-	docker exec -it munin bash
+	$(DOCKER) exec -it munin bash
 
 docker-dev: docker-base
-	docker build -t munin:dev -f Dockerfile.dev .
-	docker run --rm --name munin-dev -v $(shell pwd):/munin -p 8000:8000 -p 14947:4947 -p 14948:4948 -it munin:dev
+	$(DOCKER) build -t munin:dev -f Dockerfile.dev .
+	$(DOCKER) run --rm --name munin-dev -v $(shell pwd):/munin -p 8000:8000 -p 14947:4947 -p 14948:4948 -it munin:dev


### PR DESCRIPTION
Specifying `DOCKER=podman` as a variable to `make` will now allow to use `podman` (or other `docker`-compatible CLIs) for testing the project.