### PR TITLE
prevent malicious config lines

### DIFF
--- a/lib/Munin/Master/UpdateWorker.pm
+++ b/lib/Munin/Master/UpdateWorker.pm
@@ -647,6 +647,12 @@ sub uw_handle_config {
 			next; # Handled
 		}
 
+		# Prevent plugins from trying to set rrd:* attrs
+		if ($arg2 =~ /^rrd:/) {
+			WARN "Invalid line: $line";
+			next;
+		}
+
 		$fields{$arg1}{$arg2} = $value;
 
 		# Adding the $field if not present.


### PR DESCRIPTION
Filters out config lines that are like:

field.rrd:file /dev/null

I don't think this is a security issue, in testing this causes a unique index violation.  A stricter regex on the line may be a better solution. 