### PR TITLE
Sed in the blib directory before install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,12 @@ doc:
 
 .PHONY: install
 install: $(BUILD_SCRIPT)
-	"$(BUILD_SCRIPT)" install --destdir="$(DESTDIR)" --verbose
 	@# various directory placeholders (e.g. "@@SPOOLDIR@@") need to be replaced
-	grep -rl --null "@@" "$(or $(DESTDIR),.)" | xargs -0 sed -i \
+	grep -Irl --null "@@" blib | xargs -0 sed -i \
 		-e "$$(perl -I lib -M"Munin::Common::Defaults" \
-			-e "Munin::Common::Defaults->print_as_sed_substitutions();")"
+		   -e "Munin::Common::Defaults->print_as_sed_substitutions();")"	
+	"$(BUILD_SCRIPT)" install --destdir="$(DESTDIR)" --verbose
+
 
 .PHONY: apply-formatting
 apply-formatting:


### PR DESCRIPTION
Sed when not making packages resulted in `grep -rl --null "@@" .` which includes _everything_ also the .git directory and one of the git .pack files contained a match for the sed expression thereby corrupting the git checkout.  And also not making any substitutions in the installed files in /usr/local...  So sed has to be done prior to install in the blib directory.