### PR TITLE
plugins/cpuspeed: fix for Linux kernels with SMT disabled

### DIFF
--- a/plugins/node.d.linux/cpuspeed.in
+++ b/plugins/node.d.linux/cpuspeed.in
@@ -113,6 +113,10 @@ if [ "$1" = "config" ]; then
     echo "graph_info $graph_info"
 
     for c in /sys/devices/system/cpu/cpu[0-9]*; do
+        if [ ! -r "$c/cpufreq/stats/time_in_state" -a ! -r "$c/cpufreq/scaling_cur_freq" ]; then
+            continue
+        fi
+
         N=${c##*/cpu}
 
         echo "cpu$N.label CPU $N"
@@ -147,12 +151,12 @@ fi
 
 for c in /sys/devices/system/cpu/cpu[0-9]*; do
     N=${c##*/cpu}
-    if [ -r "$ACPI_CPUFREQ_INDICATOR_FILENAME" ]; then
+    if [ -r "$c/cpufreq/stats/time_in_state" ]; then
         value=$(awk '{ cycles += $1 * $2 } END { printf("%.0f", cycles / 100); }' "$c/cpufreq/stats/time_in_state")
-    elif [ -r "$INTEL_PSTATE_INDICATOR_FILENAME" ]; then
+    elif [ -r "$c/cpufreq/scaling_cur_freq" ]; then
         value=$(cat "$c/cpufreq/scaling_cur_freq")
     else
-        value="U"
+        continue
     fi
     printf 'cpu%d.value %s\n' "$N" "$value"
 done


### PR DESCRIPTION
If SMT is disabled there can be 16 cpuXX directories but only first 8 of them have statistic files. Fix config and fetch to check cpuNN's files instead of cpu0's files.