### PR TITLE
plugins/ipmi_: handle "0.000" as "na" in temperature upper critical/warning

### DIFF
--- a/plugins/node.d/ipmi_
+++ b/plugins/node.d/ipmi_
@@ -121,11 +121,11 @@ BEGIN {
 	TEMPS = sprintf("%s%s.value %s\n",TEMPS,NAME,TEMP);
 	CTEMPS = sprintf("%s%s.label %s\n",CTEMPS,NAME,THING);
 
-	if (CRIT !~ /na/) {
+	if (CRIT !~ /na/ && CRIT != /^0.000/) {
 		CTEMPS = sprintf("%s%s.critical 0:%s\n",CTEMPS,NAME,CRIT);
 	}
 
-	if (WARN !~ /na/) {
+	if (WARN !~ /na/ && WARN != /^0.000/) {
 		CTEMPS = sprintf("%s%s.warning 0:%s\n",CTEMPS,NAME,WARN);
 	}
 }


### PR DESCRIPTION
HPE ilo 5 Firmware Version 2.95 returns value "0.000" instead of "na" in some temperature critical/warning limits. This results "critical 0:0.000" in Munin, resulting critical-email every 5 minute from munin-limits.