### PR TITLE
linux: add workaround for /proc/interrupts

### DIFF
--- a/plugins/node.d.linux/irqstats.in
+++ b/plugins/node.d.linux/irqstats.in
@@ -101,6 +101,10 @@ while (my $line = <$in>) {
 	@data = split (' ', $line, $cpus + 2);
     } else {
 	@data = split(' ', $line, $cpus + 3);
+	# workaround for glued field
+	if ($data[0] =~ /^(.*:)(\d+)$/) {
+	    splice(@data, 0, 1, $1, $2);
+	}
     }
     chomp @data;
     $irq = shift @data;


### PR DESCRIPTION
on some environment, there may be no whitespace between IRQ name and interrupt count in `/proc/interrupts`
for example:

```console
$ uname -a
Linux mai 5.4.0-1018-raspi #20-Ubuntu SMP Sun Sep 6 05:11:16 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
$ cat /proc/interrupts
           CPU0       CPU1       CPU2       CPU3
  1:          0          0          0          0     GICv2  25 Level     vgic
  3: 3491437221 1482323420 1476887876 1359922900     GICv2  30 Level     arch_timer
  4:          0          0          0          0     GICv2  27 Level     kvm guest vtimer
(snip)
IPI4:         0          0          0          0       Timer broadcast interrupts
IPI5:1832994294  356298973  370391406  307321362       IRQ work interrupts
IPI6:         0          0          0          0       CPU wake-up interrupts
Err:          0
```

results `irqstats` plugin cause broken output like: (and thousands of .rrd files created on munin server)

```console
$ /usr/share/munin/plugins/irqstats
Argument "IRQ" isn't numeric in addition (+) at ./irqstats line 97, <$in> line 27.
i1.value 0
i3.value 7810591374
i4.value 0
(snip)
iIPI4.value 0
iIPI5:183299818.value 1034014139
iIPI6.value 0
iErr.value 0
```

this PR adds workaround for such `/proc/interrupt`.