### PR TITLE
Update sunos iostat to cast values to integer

### DIFF
--- a/plugins/node.d.sunos/iostat
+++ b/plugins/node.d.sunos/iostat
@@ -107,8 +107,8 @@ while(<IOSTAT>){
     }
     $nri{$dev} += $nri;
     $nwi{$dev} += $nwi;
-    $bri{$dev} += ($bri*1024); # The header says kr/i, and we want bytes
-    $bwi{$dev} += ($bwi*1024); # Ditto.
+    $bri{$dev} += int($bri*1024); # The header says kr/i, and we want bytes
+    $bwi{$dev} += int($bwi*1024); # Ditto.
 }
 
 close(IOSTAT);


### PR DESCRIPTION
For my SunOS/OpenSolaris/Illumos systems, I'm seeing error messages like this:

> Error updating /var/lib/munin/…-iostat-diskr-d.rrd: /var/lib/munin/…-iostat-diskr-d.rrd: not a simple signed integer: '5769245279641.6'

Casting to integer enables this Munin plugin to correctly record data.