### PR TITLE
linux irqstats: avoid complaints about empty strings

### DIFF
--- a/plugins/node.d.linux/irqstats.in
+++ b/plugins/node.d.linux/irqstats.in
@@ -49,6 +49,8 @@ GPLv2
 =cut
 
 use Munin::Plugin;
+use Scalar::Util qw(looks_like_number);
+use strict;
 
 if (defined $ARGV[0] && $ARGV[0] eq 'autoconf') {
     if(-r '/proc/interrupts') {
@@ -90,7 +92,7 @@ my @irqs;
 
 sub sum (@) {
     my $sum = 0;
-    $sum += $_ || 0 for @_;	# Avoid complaints about empty strings
+    $sum += (looks_like_number($_) ? $_ : 0) || 0 for @_;	# Avoid complaints about empty strings
     return $sum;
 }
 


### PR DESCRIPTION
Cherry pick of #144 from `master` to `stable-2.0`.