### PR TITLE
Update `ipmi_sensor_` to handle ipmitool `Unable to read sensor` errors

### DIFF
--- a/plugins/node.d/ipmi_sensor_
+++ b/plugins/node.d/ipmi_sensor_
@@ -100,6 +100,9 @@ def parse_data(data):
      Assertions Enabled    : lcr-
      Deassertions Enabled  : lcr-
 
+    When a sensor reading is unavailable, ipmitool outputs:
+     Sensor Reading        :  Unable to read sensor: Device Not Present
+
     """
     sensors = {}
     cur_sensor = None
@@ -290,6 +293,8 @@ def report_unit(unit):
         nname = normalize_sensor(lbl)
         try:
             value = data[lbl]["sensor reading"].split()[0]
+            if 'Unable to read sensor' in data[lbl]["sensor reading"]:
+                value = 'U'
         except KeyError:
             continue
         print("%s.value %s" % (nname, value))


### PR DESCRIPTION
Occasionally (once every few days) `ipmitool` will output a reading like this:
```
Sensor Reading        :  Unable to read sensor: Device Not Present
```

Currently, Munin's `ipmi_sensor_` produces the following output in that situation:
```
fan1.value Unable
```
…which causes Munin to log:
```
Failed to interpret expected numeric value of field 'fan1' (host 'palo.kosada.com'): 'Unable'
Argument "Unable" isn't numeric in sprintf
```
…and issue alerts as though the reading had a value of `0`.

This PR modifies `ipmi_sensor_` to omit the invalid value, which should avoid the unnecessary alerts.