### PR TITLE
Allow using unix sockets in the form unix:///run/muninnode.sock as address

### DIFF
--- a/lib/Munin/Master/Node.pm
+++ b/lib/Munin/Master/Node.pm
@@ -97,6 +97,16 @@ sub _do_connect {
 		ERROR "Failed to connect to node $self->{address}:$self->{port}/tcp : $!";
 		return 0;
 	}
+    } elsif ($uri->scheme eq "unix") {
+        $self->{reader} = $self->{writer} = IO::Socket::UNIX->new(
+		Type    => SOCK_STREAM(),
+		Peer    => $uri->path,
+		Timeout => $config->{timeout}
+	);
+	unless ($self->{reader} && defined $self->{reader}->connected()) {
+		ERROR "Failed to connect to unix socket ".$uri->path." : $!";
+		return 0;
+	}
     } elsif ($uri->scheme eq "ssh") {
 	    my $ssh_command = sprintf("%s %s", $config->{ssh_command}, $config->{ssh_options});
 	    my $user_part = ($uri->user) ? ($uri->user . "@") : "";

--- a/lib/Munin/Master/UpdateWorker.pm
+++ b/lib/Munin/Master/UpdateWorker.pm
@@ -73,7 +73,7 @@ sub do_work {
     $uri = new URI("munin://" . $url) unless $uri->scheme;
 
     my $nodedesignation;
-    if ($uri->scheme eq "ssh" || $uri->scheme eq "cmd") {
+    if ($uri->scheme eq "ssh" || $uri->scheme eq "cmd" || $uri->scheme eq "unix") {
         $nodedesignation = $host . " (" . $self->{host}{address} . ")";
     } else {
         $nodedesignation = $host . " (" . $self->{host}{address} . ":" . $self->{host}{port} . ")";


### PR DESCRIPTION
Allow using unix sockets in the form unix:///run/muninnode.sock as address

On a normal host with lots of docker containers, they can easily connect to the host's port 4949 and reveal a lof of information about internal structures. This patch allows munin to connect to unix sockets instead which are much easier to protect. Munin node so far doesn't support unix sockets, but [muninlite](https://github.com/munin-monitoring/muninlite) can be configured (using inetd/xinetd) to do this.