### PR TITLE
Misc consistency with munin-node example config

### DIFF
--- a/etc/munin-node.conf.PL
+++ b/etc/munin-node.conf.PL
@@ -15,35 +15,40 @@ open my $fh, ">", $output_file or die "Can't open $output_file: $!";
 print $fh <<'EOF';
 #
 # Example config-file for munin-node
+# For more examples and information see:
+# http://guide.munin-monitoring.org/en/latest/reference/munin-node.conf.html
 #
 
+# 0=err, 1=warning, 2=notice, 3=info, 4=debug
 log_level 4
 EOF
 
 print $fh <<"EOF";
+# Where the munin-node logs its activity.
+# If the value is Sys::Syslog, logging is sent to syslog.
 log_file $log_file
 pid_file $pid_file
 EOF
 
 print $fh <<'EOF';
 
+# Run munin-node in background and forks after binding.
 background 1
 setsid 1
 
+# The user/group munin-node will runs as.
 user root
 group root
 
 # This is the timeout for the whole transaction.
-# Units are in sec. Default is 15 min
-#
-# global_timeout 900
+# Units are in sec.  Default is 15 min.
+#global_timeout 900
 
 # This is the timeout for each plugin.
-# Units are in sec. Default is 1 min
-#
-# timeout 60
+# Units are in sec.  Default is 1 min.
+#timeout 60
 
-# Regexps for files to ignore
+# Regexps for files to ignore.
 ignore_file [\#~]$
 ignore_file DEADJOE$
 ignore_file \.bak$
@@ -53,34 +58,29 @@ ignore_file \.rpm(save|new)$
 ignore_file \.pod$
 
 # Set this if the client doesn't report the correct hostname when
-# telnetting to localhost, port 4949
-#
+# telnetting to localhost, port 4949.
 #host_name myhostname.example.com
 
 # A list of addresses that are allowed to connect.  This must be a
 # regular expression, since Net::Server does not understand CIDR-style
 # network notation unless the perl module Net::CIDR is installed.  You
-# may repeat the allow line as many times as you'd like
-
+# may repeat the allow line as many times as you'd like.
 allow ^127\.0\.0\.1$
 allow ^::1$
 
 # If you have installed the Net::CIDR perl module, you can use one or more
 # cidr_allow and cidr_deny address/mask patterns.  A connecting client must
-# match any cidr_allow, and not match any cidr_deny.  Note that a netmask
-# *must* be provided, even if it's /32
-#
-# Example:
-#
-# cidr_allow 127.0.0.1/32
-# cidr_allow 192.0.2.0/24
-# cidr_deny  192.0.2.42/32
+# match any cidr_allow, and not match any cidr_deny.
+# Note that a netmask *must* be provided, even if it's /32.
+#cidr_allow 127.0.0.1/32
+#cidr_allow 192.0.2.0/24
+#cidr_deny  192.0.2.42/32
 
-# Which address to bind to;
+# Which address to bind to.
+#host 127.0.0.1
 host *
-# host 127.0.0.1
 
-# And which port
+# The TCP port the munin-node listens on
 port 4949
 
 EOF

--- a/etc/munin-node.conf.PL
+++ b/etc/munin-node.conf.PL
@@ -80,7 +80,7 @@ allow ^::1$
 #host 127.0.0.1
 host *
 
-# The TCP port the munin-node listens on
+# The TCP port the munin-node listens on.
 port 4949
 
 EOF


### PR DESCRIPTION
- Added a link to the documentation
- Some sections do not have any comments
- More verbose about some comments
- Made sure double spacing after periods
- Remove space between hash and variable
- Remove empty link between commend and variable
- Fix line breaks
- All comments end with a period