### PR TITLE
Fix for undefined DAEMON_ARGS warning fixes munin-monitoring/munin#1612

### DIFF
--- a/doc/example/service/linux/systemd/munin-node.service
+++ b/doc/example/service/linux/systemd/munin-node.service
@@ -6,7 +6,7 @@ Documentation=man:munin-node(8) http://guide.munin-monitoring.org/en/latest/refe
 EnvironmentFile=-/etc/default/munin-node
 Type=forking
 Restart=always
-ExecStart=/usr/sbin/munin-node $DAEMON_ARGS
+ExecStart=/usr/sbin/munin-node ${DAEMON_ARGS- }
 PIDFile=/run/munin/munin-node.pid
 
 [Install]


### PR DESCRIPTION
If DAEMON_ARGS isn't set in the environment file or the file doesn't exist on systemd will output a warning see
https://github.com/systemd/systemd/commit/f331434d13488425ccd8485327085d15f8f92aea

This sets DAEMON_ARGS to an empty value if not set.