### PR TITLE
Change default PLUGINUSER to match documentation

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -125,7 +125,7 @@ USER       := munin
 GROUP      := munin
 
 # Default user to run the plugins as
-PLUGINUSER := nobody
+PLUGINUSER := munin
 
 # Default user to run the cgi as
 CGIUSER := nobody


### PR DESCRIPTION
The most [recent](https://guide.munin-monitoring.org/en/latest/plugin/use.html#configuring) [documentation](https://guide.munin-monitoring.org/en/stable-2.0/plugin/use.html#configuring) for plugin configuration specifies that the default plugin user is `munin`. Source releases do not currently reflect this. Modify the provided `Makefile.config` so that source releases do reflect this change by default.

This should be back-ported to `stable-2.0` as well.