### PR TITLE
Prevent log spam with nut plugins

### DIFF
--- a/plugins/node.d/nut_misc.in
+++ b/plugins/node.d/nut_misc.in
@@ -89,6 +89,8 @@ if ( defined $ARGV[0] and $ARGV[0] eq 'config' ) {
 }
 
 sub fetch_values {
+	local $ENV{NUT_QUIET_INIT_SSL} = 1;
+
 	my $data = `$config{upsc} $config{upsname}`;
 	while ($data =~ /([a-z.]+): (.+)\b/g) {
 		my $label = $1;

--- a/plugins/node.d/nut_volts.in
+++ b/plugins/node.d/nut_volts.in
@@ -55,6 +55,8 @@ if ( defined $ARGV[0] and $ARGV[0] eq 'config' ) {
 }
 
 sub fetch_values {
+	local $ENV{NUT_QUIET_INIT_SSL} = 1;
+
 	my $data = `$config{upsc} $config{upsname}`;
 	while ($data =~ /([a-z.]+): (.+)\b/g) {
 		my $label = $1;

--- a/plugins/node.d/nutups_.in
+++ b/plugins/node.d/nutups_.in
@@ -13,6 +13,7 @@
 UPS=$(basename "$0" | cut -d_ -f2)
 FUNCTION=$(basename "$0" | cut -d_ -f3)
 UPSC=$(command -v upsc)
+export NUT_QUIET_INIT_SSL=1
 
 if [ "$1" = "autoconf" ]; then
 	[ -x "$UPSC" ] && [ -r /etc/nut/ups.conf ] && echo yes && exit 0


### PR DESCRIPTION
On Debian / Ubuntu, nut is linked against libnss3 which causes a warning message to be emitted when upsc is run if SSL isn't being used. This leads to errors during every poll like:

2024/09/04-21:05:07 [299208] Error output from nut_misc:
2024/09/04-21:05:07 [299208]         Init SSL without certificate database

nut 2.8.1, which has started making its way to distros, adds a new NUT_QUIET_INIT_SSL environment variable (specifically designed for uses such as this) which allows silencing this warning.

Add it to the nut plugins. It's a no-op for older nut versions.