### PR TITLE
hddtemp_smartctl: support /dev/disk/by-id/* name translation

### DIFF
--- a/plugins/node.d/hddtemp_smartctl
+++ b/plugins/node.d/hddtemp_smartctl
@@ -29,6 +29,9 @@ The following environment variables are used
  temp_critical     - override hard-coded default of 60
  temp_sda_warning  - override both hard-coded default and, if set also temp_warning, for device sda
  temp_sdb_critical - override both hard-coded default and, if set also temp_critical, for device sdb
+ translate_names   - translate simple block device names like sda to udev by-id
+                     names, useful if the order of simple device names is
+                     unstable between reboots, defaults to 0
 
 If the "smartctl" environment variable is not set the plugin will
 search your $PATH, /usr/bin, /usr/sbin, /usr/local/bin and
@@ -161,6 +164,7 @@ my $sdparm = `sh -c 'command -v sdparm'`;
 chomp $sdparm;
 
 my @drives;
+my %drives_by_id;
 
 # Try to get a default set of drives
 if ($^O eq 'linux') {
@@ -190,6 +194,20 @@ if ($^O eq 'linux') {
 
   # Get list of all drives we found
   @drives=(@drivesIDE,@drivesSCSI,@drivesNVME);
+
+  my $byid_dir = '/dev/disk/by-id/';
+  if ($ENV{'translate_names'} && -d $byid_dir) {
+    opendir(BYID, $byid_dir);
+    # grep: filter device-mapper and world-wide-name entries
+    my @byid_devs = grep /^(?!(dm|wwn)-)/, readdir BYID;
+    foreach my $byid_dev (@byid_devs) {
+      my $link = readlink($byid_dir . $byid_dev);
+      next if not $link; # filter "." and ".."
+
+      $link =~ s/^.*\///;
+      $drives_by_id{$link} = $byid_dev;
+    }
+  }
 
 } elsif ($^O eq 'freebsd') {
   opendir(DEV, '/dev');
@@ -227,6 +245,7 @@ if (defined $ARGV[0]) {
     print "graph_category sensors\n";
     print "graph_info This graph shows the temperature in degrees Celsius of the hard drives in the machine.\n";
     foreach (@drives) {
+        $_ = $drives_by_id{$_} if $drives_by_id{$_};
         my $d = clean_fieldname($_);
         my @dirs = splitdir($_);
         my $temp_warning = 57;
@@ -247,8 +266,10 @@ if (defined $ARGV[0]) {
 }
 
 foreach my $drive (@drives) {
-  warn "[DEBUG] Processing $drive\n" if $DEBUG;
   my $fulldev = device_for_drive($drive);
+  $drive = $fulldev;
+  $drive =~ s/.*\///;
+  warn "[DEBUG] Processing $drive\n" if $DEBUG;
   
   # Don't wake up SCSI drives!
   next if (check_scsi_low_power($fulldev));
@@ -316,6 +337,8 @@ foreach my $drive (@drives) {
 
 sub device_for_drive {
     my ($drive) = @_;
+
+    return '/dev/disk/by-id/' . $drives_by_id{$drive} if $drives_by_id{$drive};
 
     # The purpose of the following regular expression (removing a numeric suffix starting with an
     # underscore) is a mystery.  But it is probably meant to detect a partition and select the


### PR DESCRIPTION
If translate_names is set, for each drive walk the symlinks created by udev below /dev/disk/by-id/ and replace the simple device name sdX by its correspondent.

That way, graphs won't jump around between devices if the simple device names are unstable between reboots.