### PR TITLE
Fix IPv6 node connections

### DIFF
--- a/lib/Munin/Master/Config.pm
+++ b/lib/Munin/Master/Config.pm
@@ -153,7 +153,7 @@ my %booleans = map {$_ => 1} qw(
 		graph_data_size  => 'normal',
 		graph_strategy   => 'cron',
 		groups           => {},
-		local_address    => 0,
+		local_address    => '::',
 		logdir           => $Munin::Common::Defaults::MUNIN_LOGDIR,
 		logoutput        => 'syslog',
 		max_processes    => 16,


### PR DESCRIPTION
Commit 012b33a702155ba7c96fd62028a3559364693c7e changed `from IO::Socket::INET6` to `IO::Socket::IP` but that silently changed the meaning of our default `local_address 0` from `::` to `0.0.0.0`
which made IPv6-connections fail by default.

By explicitly defaulting to `::` we fix IPv6 connections to munin-node.

Fixes #1402