### PR TITLE
Enable wget --no-check-certificate option in http_loadtime plugin

### DIFF
--- a/plugins/node.d/http_loadtime
+++ b/plugins/node.d/http_loadtime
@@ -66,7 +66,7 @@ request_url() {
         wget_auth_opt="--config $wget_config_file"
     fi
     # shellcheck disable=SC2086
-    wget $wget_auth_opt --user-agent "Munin - http_loadtime" --no-cache --quiet --output-document=/dev/null "$@" 2>/dev/null
+    wget $wget_auth_opt --user-agent "Munin - http_loadtime" --no-cache --no-check-certificate --quiet --output-document=/dev/null "$@" 2>/dev/null
     rm -f "$wget_config_file"
 }
 


### PR DESCRIPTION
This patch disables SSL/TLS certificate validation in the http_loadtime plugin when wget establishes an HTTPS connection. This prevents the plugin from considering an untrusted certificate a failure. Which allows the plugin to work with HTTPS protocol servers, even when they supply a self-signed, expired, or otherwise invalid certificate.

### My case
I am using munin's http_loadtime plugin to monitor a [pi-hole](https://pi-hole.net/) server. Which creates a self-signed TLS certificate to support HTTPS. The certificate is created and managed by 3rd-party software. I have enabled automatic redirection of HTTP to HTTPS in the web server configuration.

### Problem
The wget program will attempt to verify certificates by default. So wget will exit with an error when the http_loadtime plugin tries to establish an HTTPS connection with a server providing an untrusted certificate. Which causes the plugin to consider the operation failed.

This means that the plugin will not be automatically suggested/linked during the `munin-node-configure` step. And if manually enabled, it will exit immediately after the connection is initialized - so the `value` metric will not include the transmit time for downloading any of the actual data at the configured URL.

### Solution
Conveniently, wget offers an option to disable certificate validation - [`--no-check-certificate`](https://www.gnu.org/software/wget/manual/wget.html#index-SSL-certificate_002c-check). When I enable this option then the http_loadtime plugin works fine with self-signed certificates.

In my case I was able to work around the problem by trusting the certificate in the operating system. You could also potentially work around this problem by setting the option in a wget config file for the root user. But those are not universal solutions. It would be difficult to use certificate trust to work around this problem with certificates that get regularly regenerated, have short lifetimes, or are outside of the control of the person configuring the plugin (e.g. remote). And a root wget config is kind of a hack solution. Which would silently disable an important security feature in other situations - probably long after you've forgotten about the hack workaround.

### Considering certificate validity
I don't think that the validity of the certificate is relevant for a performance monitor plugin like http_loadtime. It is quite literally sending the received data to `/dev/null` - so the security considerations are essentially non-existent. A user enabling the plugin simply wants to know the HTTP load time for the target URL(s). The result of the TLS handshake is irrelevant for that metric. And now that HTTPS-by-default has basically become the standard, the use of self-signed certificates has become quite common - particularly for LAN/intranet services.