### PR TITLE
fix Issue #1641 'Munin-node fails to start when 'host *' in config

### DIFF
--- a/doc/reference/munin-node.conf.rst
+++ b/doc/reference/munin-node.conf.rst
@@ -208,7 +208,7 @@ A pretty normal configuration file:
   # cidr_deny  192.0.2.42/32
 
   # Which address to bind to;
-  host *
+  host 0.0.0.0
   # host 127.0.0.1
 
   # And which port

--- a/etc/munin-node.conf.PL
+++ b/etc/munin-node.conf.PL
@@ -78,7 +78,7 @@ allow ^::1$
 
 # Which address to bind to.
 #host 127.0.0.1
-host *
+host 0.0.0.0
 
 # The TCP port the munin-node listens on.
 port 4949


### PR DESCRIPTION
In the default configuration file /etc/munin/munin-node.conf

"host *" 

does no longer work (seen in debian trixie). Issue #1641 states that.

Replacing "*" by 0.0.0.0 lets the munin node start and accept connections on all interfaces including localhost and so effectively fixes Issue #1641.

I changed this setting in the default node-config and a config documentation file.

Background: see eg.g https://www.baeldung.com/cs/ip-all-zeroes