### PR TITLE
`munin-node.conf`: add comment on how to make default `host *` work in IPv4-only case

### DIFF
--- a/doc/reference/munin-node.conf.rst
+++ b/doc/reference/munin-node.conf.rst
@@ -214,6 +214,10 @@ A pretty normal configuration file:
   # And which port
   port 4949
 
+  # if only ipv4 is working, uncomment this line
+  # ipv 4
+
+
 
 SEE ALSO
 ========

--- a/etc/munin-node.conf.PL
+++ b/etc/munin-node.conf.PL
@@ -83,4 +83,7 @@ host *
 # The TCP port the munin-node listens on.
 port 4949
 
+# if only ipv4 is working, uncomment this line
+# ipv 4
+
 EOF


### PR DESCRIPTION
    host * will default to [::] i.e. IP v6. If IPv6 is not working/switched off, munin-node will not start.

    In the ipv4 case, it helps to dictate ipv4 only operation.
    This makes "host *" work.

    the added lines suggest this and tell the user, when to use it.