### PR TITLE
df: add an example of name for the file

### DIFF
--- a/plugins/node.d.linux/df
+++ b/plugins/node.d.linux/df
@@ -33,7 +33,7 @@ This configuration snipplet is an example with the defaults:
     env.warning 92
     env.critical 98
 
-Put it in a file in /etc/munin/plugin-conf.d/ (like /etc/munin/plugin-conf.d/zz_df) and restart the munin-node.
+Put it in a file in /etc/munin/plugin-conf.d/ (like /etc/munin/plugin-conf.d/zz_df so it is read after the default /etc/munin/plugin-conf.d/munin-node) and restart the munin-node.
 
 You may specify filesystem specific warning and critical levels:
 


### PR DESCRIPTION
I created a file with this config for the `df` plugin:

```
[df*]
env.warning 93
env.critical 98
```

I named it `/etc/munin/plugin-conf.d/df` and the settings were ignored.

Then I renamed it to `/etc/munin/plugin-conf.d/zz_df` and the settings were applied.

It looks like my custom file must be read after `/etc/munin/plugin-conf.d/munin-node`, so I used the `zz_` prefix.

I didn’t change the file `/etc/munin/plugin-conf.d/munin-node` to avoid conflicts later when updating munin. It contains this configuration:

```
(…)
[df*]
env.warning 92
env.critical 98
env.exclude_re ^/run/user ^/var/lib/docker
(…)
```

### Test

```
# ls
df  dhcpd3  munin-node  README  spamstats
# munin-run --debug df
(…)
# Environment warning = 92
(…)
# mv -v df zz_df
renamed 'df' -> 'zz_df'
# munin-run --debug df
(…)
# Environment warning = 93
(…)
```

So yes the order of the files is important.

### Another proof

Files are processed by alphabetical order:

```
# munin-run --debug df
(…)
# Processing plugin configuration from /etc/munin/plugin-conf.d/README
# Processing plugin configuration from /etc/munin/plugin-conf.d/dhcpd3
# Processing plugin configuration from /etc/munin/plugin-conf.d/munin-node
# Processing plugin configuration from /etc/munin/plugin-conf.d/spamstats
# Processing plugin configuration from /etc/munin/plugin-conf.d/zz_df
```