### PR TITLE
plugins/nut_*: emit 'U' if value is not seen in upsc output

### DIFF
--- a/plugins/node.d/nut_misc
+++ b/plugins/node.d/nut_misc
@@ -105,7 +105,7 @@ sub fetch_values {
 	}
 	$status{'battery_runtime'} /= 60;
 	foreach my $label (sort keys %graph) {
-		print "$label.value $status{$label}\n";
+		print "$label.value " . ($status{$label} // 'U') . "\n";
 	}
 }
 

--- a/plugins/node.d/nut_volts
+++ b/plugins/node.d/nut_volts
@@ -65,6 +65,6 @@ sub fetch_values {
 		$status{$label} = $value;
 	}
 	foreach my $label (sort keys %graph) {
-		print "$label.value $status{$label}\n";
+		print "$label.value " . ($status{$label} // 'U') . "\n";
 	}
 }


### PR DESCRIPTION
Not all UPS support all metrics that the plugins look for.

In my case, some CyberPower brand units don't show input_frequency/ups_temperature for nut_misc, and
input_voltage_minimum/input_voltage_maximum for nut_volts.

Emit a value of 'U' for the missing attribute(s); this otherwise caused warnings for each fetch on at least stable-2.0.