### PR TITLE
[plugins/mysql_] document that SELECT grant is needed

### DIFF
--- a/plugins/node.d/mysql_
+++ b/plugins/node.d/mysql_
@@ -77,7 +77,7 @@ Note: requires 'user munin' in the configuration.
 
 The minimum required privileges of the munin database user is:
 
-  GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'munin'@'localhost';
+  GRANT SELECT, PROCESS, REPLICATION CLIENT ON *.* TO 'munin'@'localhost';
 
 
 Warning and critical values can be set via the environment in the usual way.


### PR DESCRIPTION
Otherwise, munin-node fails getting some of the data with the following error.

    2026/02/21-18:14:39 [3094557]   DBI connect('mysql;mysql_read_default_file=/etc/mysql/debian.cnf;mysql_connect_timeout=5','munin',...) failed: Access denied for user 'munin'@'localhost' to database 'mysql' at /etc/munin/plugins/mysql_tmp_tables line 1090.