### PR TITLE
Support TLS certificate chain files

### DIFF
--- a/common/lib/Munin/Common/TLS.pm
+++ b/common/lib/Munin/Common/TLS.pm
@@ -174,11 +174,10 @@ sub _load_certificate {
 
     if ($self->{tls_cert} && -e $self->{tls_cert}) {
         if (defined $self->{tls_cert} and length $self->{tls_cert}) {
-	    if (!Net::SSLeay::CTX_use_certificate_file($self->{tls_context}, 
-                                                       $self->{tls_cert}, 
-                                                       &Net::SSLeay::FILETYPE_PEM)) {
-	        $self->{logger}("[WARNING] Problem occurred when trying to read file with certificate \"$self->{tls_cert}\": $!. Continuing without certificate.");
-	    }
+            if (!Net::SSLeay::CTX_use_certificate_chain_file($self->{tls_context},
+                                                             $self->{tls_cert})) {
+                $self->{logger}("[WARNING] Problem occurred when trying to read file with certificate \"$self->{tls_cert}\": $!. Continuing without certificate.");
+            }
         }
     }
     else {

--- a/master/doc/munin.conf.pod.in
+++ b/master/doc/munin.conf.pod.in
@@ -193,9 +193,10 @@ certificate can be stored in the same file.  Affects: munin-update.
 
 =item B<tls_certificate> <value>
 
-This directive sets the location of the TLS certificate to be used for
-TLS.  Default is @@CONFDIR@@/munin.pem.  The private key and
-certificate can be stored in the same file.  Affects: munin-update.
+This directive sets the location of the TLS certificate and optional
+intermediate CA certificates to be used for TLS.  Default is
+@@CONFDIR@@/munin.pem.  The private key and certificate can be
+stored in the same file.  Affects: munin-update.
 
 =item B<tls_ca_certificate> <value>
 

--- a/node/doc/munin-node.conf.pod
+++ b/node/doc/munin-node.conf.pod
@@ -96,9 +96,10 @@ certificate can be stored in the same file.
 
 =item B<tls_certificate> <value>
 
-This directive sets the location of the TLS certificate to be used for
-TLS.  Default is @@CONFDIR@@/munin-node.pem.  The private key and
-certificate can be stored in the same file.
+This directive sets the location of the TLS certificate and optional
+intermediate CA certificates to be used for TLS.  Default is
+@@CONFDIR@@/munin-node.pem.  The private key and certificate can be
+stored in the same file.
 
 =item B<tls_ca_certificate> <value>
 


### PR DESCRIPTION
Cherry-pick 9cb18f268ef94a26110e93aef2301fc36e7ab615 from [master](https://github.com/munin-monitoring/munin/tree/master):

This aligns Munin TLS setup with other TLS clients and servers:
 * tls_certificate is used for specifying the client or server certificate and optionally intermediate CA certificates (if any)
 * tls_ca_certificate is used only for specifying CA certificates used to verifying peer's certificate (as documented) and not for specifying intermediate CA certificates

This allows separation of intermediate client and server CA certificates.