### PR TITLE
Fix PostgreSQL 17 version checks in `postgres_bgwriter` and `postgres_checkpoints`

### DIFF
--- a/plugins/node.d/postgres_bgwriter.in
+++ b/plugins/node.d/postgres_bgwriter.in
@@ -62,13 +62,13 @@ my $pg = Munin::Plugin::Pgsql->new(
     info       => 'bgwriter buffer statistics',
     vlabel     => 'buffers / second',
     basequery => [
-        "SELECT buffers_checkpoint,buffers_clean,buffers_backend,buffers_alloc FROM pg_stat_bgwriter",
-        [ 17,
-            "SELECT pg_stat_get_checkpointer_buffers_written() as buffers_checkpoint,
-              buffers_clean,
-              pg_stat_get_checkpointer_buffers_written() as buffers_backend,
-              buffers_alloc
-              FROM pg_stat_bgwriter",
+        "SELECT pg_stat_get_checkpointer_buffers_written() as buffers_checkpoint,
+          buffers_clean,
+          pg_stat_get_checkpointer_buffers_written() as buffers_backend,
+          buffers_alloc
+          FROM pg_stat_bgwriter",
+        [ 16,
+            "SELECT buffers_checkpoint,buffers_clean,buffers_backend,buffers_alloc FROM pg_stat_bgwriter",
         ],
     ],
     pivotquery  => 1,

--- a/plugins/node.d/postgres_checkpoints.in
+++ b/plugins/node.d/postgres_checkpoints.in
@@ -62,9 +62,9 @@ my $pg = Munin::Plugin::Pgsql->new(
     info       => 'Number of checkpoints per minute',
     vlabel     => 'Checkpoints / minute',
     basequery => [
-        "SELECT checkpoints_timed,checkpoints_req FROM pg_stat_bgwriter",
-        [ 17,
-            "SELECT num_timed as checkpoints_timed, num_requested as checkpoints_req FROM pg_catalog.pg_stat_checkpointer;",
+        "SELECT num_timed as checkpoints_timed, num_requested as checkpoints_req FROM pg_catalog.pg_stat_checkpointer;",
+        [ 16,
+            "SELECT checkpoints_timed,checkpoints_req FROM pg_stat_bgwriter",
         ],
     ],
     pivotquery => 1,


### PR DESCRIPTION
The changes authored in 804f528c6ddc7610f26f4434dd52997645a07812 and cc9be71f3d0a17835aa46cdc46c28abaaeb93b00 applied the updated
query to Postgres versions <= 17 (up to and including 17), and as a result
this plugin once again breaks with Postgres 18 as well as potentially breaking
any existing installations on lower Postgres versions.  This PR moves the
updated query to the first/default basequery, and the original pre-17 query
is now gated by "<=16".

Tested and confirmed working in my environment.