### PR TITLE
exclude efivarfs from df and df_abs plugins

### DIFF
--- a/plugins/node.d.linux/df
+++ b/plugins/node.d.linux/df
@@ -29,7 +29,7 @@ the disk usage.
 This configuration snipplet is an example with the defaults:
 
   [df]
-    env.exclude none unknown rootfs iso9660 squashfs udf romfs ramfs debugfs cgroup_root devtmpfs
+    env.exclude none unknown rootfs iso9660 squashfs udf romfs ramfs debugfs cgroup_root devtmpfs efivarfs
     env.warning 92
     env.critical 98
 
@@ -108,7 +108,7 @@ $ENV{LC_ALL} = 'C';
 # For these devices use the mount point, the device is useless
 my %usemntpt = ( tmpfs => 1, none => 1, udev => 1, simfs => 1 );
 
-my @exclude = qw(none unknown rootfs iso9660 squashfs udf romfs ramfs debugfs cgroup_root devtmpfs);
+my @exclude = qw(none unknown rootfs iso9660 squashfs udf romfs ramfs debugfs cgroup_root devtmpfs efivarfs);
 my $dfopts  = $ENV{'dfopts'} || "-P -l";
 $dfopts .= ' ';
 my $title = "Disk usage";

--- a/plugins/node.d.linux/df_abs
+++ b/plugins/node.d.linux/df_abs
@@ -24,7 +24,7 @@ network filesystems, set "env.dfopts", and omit the "-l" option.
 =head2 DEFAULT CONFIGURATION
 
  [df_abs]
-  env.exclude     iso9660
+  env.exclude     iso9660 efivarfs
   env.exclude_re  ^/dev/sdc
   env.warning     92
   env.critical    98
@@ -90,7 +90,7 @@ check_for_regex_match() {
 
 total=${total:-on}
 
-dfopts=${dfopts:-"-P -l"}
+dfopts=${dfopts:-"-P -l -x efivarfs"}
 exclude_re=${exclude_re:-}
 exclude=${exclude:-iso9660}
 exclude=$(echo "$exclude" | sed -r -e 's/ +/ -x /g' -e 's/^/-x /')


### PR DESCRIPTION
efivarfs is a pseudo fs to access to EFI variables

Its available space is always 0 leading to a false alarm in munin.